### PR TITLE
Add Github Action to update/create live progress website

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -1,0 +1,46 @@
+name: Publish Website
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # by default it only checks out one commit... not what we want. 0 enables all
+          path: bfbbdecomp
+      - uses: actions/checkout@v2
+        with:
+          repository: mattbruv/bfbbdecomp-website
+          path: website
+      
+      - uses: actions/setup-node@v1
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - run: |
+          pip install gitpython
+          npm install -g parcel-bundler
+          cd website
+          mkdir data
+          cd python
+          python progress.py
+          cd ../
+          npm install
+          npm run build-pages
+
+      - name: Deploy
+        uses: JamesIves/github-pages-deploy-action@3.6.2
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages # The branch the action should deploy to.
+          FOLDER: website/dist # The folder the action should deploy.
+          CLEAN: true # Automatically remove deleted files from the deploy branch
+          SINGLE_COMMIT: true


### PR DESCRIPTION
With the addition of this GitHub action file, we now have a fully automated website set up to track our progress. The website code is entirely separate from this project, so nothing related to the website will ever need to be committed to this repo other than this single action file, and only ever a single commit to a new `gh-pages` branch.

Here's how it works:
1. Every push to the `master` branch on the main repository will trigger the action.
2. Github actions runs the steps in the file. It installs dependencies, runs a python script that parses the main repo's commits and populates that information into JS files which are imported by the website.
3. The website code is bundled up into a deployable folder.
4. This new deployable folder is commited to a new blank `gh-pages` branch.

The `gh-pages` branch will only ever have one commit, as any updates will force erase and overwrite existing gh-pages data when the site is re-built.

If you merge this, there is a one time thing you'll have to do. You have to go into the settings for this repository and set the GitHub Pages branch to `gh-pages` and save.

A live example on my fork: 
https://mattbruv.github.io/bfbbdecomp/progress

I think this website will help put the progress into perspective, as well as let people easily understand where we are.

It has a blank FAQ page right now.
I'm terrible at web design, so I'm very slow at making a website, but I will improve it and make it better, and probably include more information and statistics.
I think it'd also be a good place to write tutorials for how to contribute to the decomp and answer technical questions too.

If you want, I can give you permissions for the website repo.

![](https://i.imgur.com/mgs3fnv.png)
