### PR TITLE
make the build process "quieter"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ INCLUDES := -Iinclude -Iinclude/dolphin -Iinclude/CodeWarrior -Iinclude/rwsdk
 
 ASFLAGS := -mgekko -I include
 LDFLAGS := -map $(MAP)
-CFLAGS  := -g -Cpp_exceptions off -proc gekko -fp hard -O4,p -msgstyle gcc \
+CFLAGS  := -g -DGAMECUBE -Cpp_exceptions off -proc gekko -fp hard -O4,p -msgstyle gcc \
            -pragma "check_header_flags off" -pragma "force_active on" \
            -str reuse,pool,readonly -char unsigned -use_lmw_stmw on -inline off -gccincludes $(INCLUDES) 
 PREPROCESS := -preprocess -DGAMECUBE -gccincludes $(INCLUDES)

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ LDFLAGS := -map $(MAP)
 CFLAGS  := -g -Cpp_exceptions off -proc gekko -fp hard -O4,p -msgstyle gcc \
            -pragma "check_header_flags off" -pragma "force_active on" \
            -str reuse,pool,readonly -char unsigned -use_lmw_stmw on -inline off -gccincludes $(INCLUDES) 
-PREPROCESS := -preprocess -DGAMECUBE -gccincludes $(INCLUDES) -DGAMECUBE
+PREPROCESS := -preprocess -DGAMECUBE -gccincludes $(INCLUDES)
 PPROCFLAGS := -fsymbol-fixup
 
 # elf2dol needs to know these in order to calculate sbss correctly.


### PR DESCRIPTION
This commit modifies the Makefile in order to allow for a quieter build. It does hide the executed commands but they can be shown by running `make S=`. This also fixes the build on my machine by commenting out a line that apparently does nothing useful. I left it in on the rare chance that we do need it.