### PR TITLE
add cache to optimize pragma processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ tools/elf2dol
 *.o
 *.cp
 .vscode
+.pragma

--- a/tools/inlineasm/cache.py
+++ b/tools/inlineasm/cache.py
@@ -1,0 +1,29 @@
+import os
+import json
+from pathlib import Path
+
+from helpers import hashString
+
+cachePath = "./.pragma/"
+
+
+def fileCacheName(path):
+    return hashString(str(path)).hexdigest() + ".json"
+
+
+def getFileCache(path):
+    name = fileCacheName(path)
+    fileCache = {"name": "", "size": 0}
+    if not os.path.exists(Path(cachePath + name)):
+        return fileCache
+    else:
+        return json.loads(open(Path(cachePath + name)).read())
+
+
+def saveFileCache(path, fileCache):
+    name = fileCacheName(path)
+    open(Path(cachePath + name), "w").write(json.dumps(fileCache, indent=4))
+
+
+def createCacheFolder():
+    Path(cachePath).mkdir(parents=True, exist_ok=True)

--- a/tools/inlineasm/globalasm.py
+++ b/tools/inlineasm/globalasm.py
@@ -1,7 +1,7 @@
 import argparse
 from pathlib import Path
+from cache import createCacheFolder, getFileCache, saveFileCache
 from helpers import *
-import os
 
 info = """globalasm.py:
 
@@ -11,8 +11,10 @@ Specified by #pragma GLOBAL_ASM(assemblyFilePath, functionName)
 
 parser = argparse.ArgumentParser(description=info)
 parser.add_argument("cpFile", help="The .cp file to process")
-parser.add_argument(
-    "-s", "--scope", help="Set function scope equal to scope in assembly", action="store_true")
+parser.add_argument("-s",
+                    "--scope",
+                    help="Set function scope equal to scope in assembly",
+                    action="store_true")
 
 
 def run():
@@ -21,6 +23,10 @@ def run():
     cpPath = Path(args.cpFile)
     cpText = open(cpPath).read()
     matches = getPragmaMatches(cpText)
+
+    # Create path to cache if not exists
+    createCacheFolder()
+    fileCache = getFileCache(cpPath)
 
     if len(matches) == 0:
         return
@@ -42,21 +48,28 @@ def run():
         if key not in asmFileDictionary:
             fileText = open(asmPath).read()
             funcs = set(getAsmFunctions(fileText))
-            asmFileDictionary[key] = {
-                "text": fileText,
-                "funcs": funcs
-            }
+            asmFileDictionary[key] = {"text": fileText, "funcs": funcs}
 
         # check to see if the requested function exists
         # before we waste time doing anything
         if func + ":" not in asmFileDictionary[key]["funcs"]:
-            error("function: \"" + func + "\" not in " + key)
+            error("function: '" + func + "' not in " + key)
 
     # Now let's loop through each pragma and substitute it
     for match in matches:
 
         replacePragmaText = match[0]
         pragmaArgs = getPragmaArgs(match[1])
+
+        funcHash = emptyHash()
+        funcHash.update(pragmaArgs[0].encode())
+        funcHash.update(pragmaArgs[1].encode())
+        hashKey = funcHash.hexdigest()
+
+        if hashKey in fileCache:
+            cpText = cpText.replace(replacePragmaText, fileCache[hashKey])
+            continue
+
         asmPath = Path(pragmaArgs[0])
         key = str(asmPath)
         asmFileText = asmFileDictionary[key]["text"]
@@ -73,7 +86,16 @@ def run():
         newSource = writeCode(newSource, funcToImport, codeBytes, isGlobal)
         cpText = cpText.replace(replacePragmaText, newSource)
 
+        # update our file cache to avoid re-processing
+        # the same function on every build
+        fileCache[hashKey] = newSource
+
     open(cpPath, "w").write(cpText)
+
+    if fileCache["size"] != len(fileCache):
+        fileCache["size"] = len(fileCache)
+        fileCache["name"] = str(cpPath)
+        saveFileCache(cpPath, fileCache)
 
 
 run()

--- a/tools/inlineasm/helpers.py
+++ b/tools/inlineasm/helpers.py
@@ -1,4 +1,14 @@
 import re
+import hashlib
+
+
+def emptyHash():
+    return hashlib.sha1()
+
+
+def hashString(string):
+    return hashlib.sha1(string.encode())
+
 
 pragmaRegex = r"(#pragma\sGLOBAL_ASM\((.*?)\))"
 
@@ -6,6 +16,7 @@ pragmaRegex = r"(#pragma\sGLOBAL_ASM\((.*?)\))"
 def getPragmaMatches(fileText):
     matches = re.findall(pragmaRegex, fileText, flags=re.DOTALL)
     return matches
+
 
 # Arguments are processed outside of the regex to keep it simple
 # and support any changes we may make in the future


### PR DESCRIPTION
Made it so the pragma script creates a `.pragma` cache folder where it saves the results of the assembly scraping as a key/value pair based on the function being imported for fast lookup.

Making changes to large files now doesn't take any more time than a tiny file. It's practically instant.

Running `time python tools/inlineasm/globalasm.py -s src/Game/zEntPlayer.cp`:

Without cache:
```
0:04.07 elapsed
0:03.76 elapsed
0:03.72 elapsed
0:03.69 elapsed
0:03.71 elapsed
```

With cache:
```
0:00.30 elapsed
0:00.26 elapsed
0:00.27 elapsed
0:00.28 elapsed
0:00.26 elapsed
```

Running `make` on the entire project from scratch takes about 2 minutes, and then cleaning and running `make` again with the pragma cache saves about 16 seconds of build time for me.
