### PR TITLE
Add "inspect" make target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ tools/elf2dol
 *.cp
 .vscode
 .pragma
+inspect.s

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ ASMDIFF := ./asmdiff.sh
 INCLUDES := -Iinclude -Iinclude/dolphin -Iinclude/CodeWarrior -Iinclude/rwsdk
 
 ASFLAGS := -mgekko -I include
-LDFLAGS := -map $(MAP)
+LDFLAGS := -map $(MAP) -w off
 CFLAGS  := -g -DGAMECUBE -Cpp_exceptions off -proc gekko -fp hard -fp_contract on -O4,p -msgstyle gcc \
            -pragma "check_header_flags off" -pragma "force_active on" \
            -str reuse,pool,readonly -char unsigned -enum int -use_lmw_stmw on -inline off -gccincludes $(INCLUDES) 
@@ -114,6 +114,9 @@ clean:
 
 tools:
 	$(MAKE) -C tools
+
+inspect:
+	$(CC) $(CFLAGS) -o inspect.s -S $(INSPECT)
 
 $(ELF): $(O_FILES) $(LDSCRIPT)
 	@echo " LINK    "$@


### PR DESCRIPTION
* Add an "inspect" make target which builds a file specified with the
  INSPECT make variable to inspect.s in the root directory to experiment
  with a function being reverse engineered.

* Also turn off warnings on the linker so that you don't get warning
  spam when running the make command.