### PR TITLE
Turn off Linker warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ ASMDIFF := ./asmdiff.sh
 INCLUDES := -Iinclude -Iinclude/dolphin -Iinclude/CodeWarrior -Iinclude/rwsdk
 
 ASFLAGS := -mgekko -I include
-LDFLAGS := -map $(MAP)
+LDFLAGS := -map $(MAP) -w off
 CFLAGS  := -g -DGAMECUBE -Cpp_exceptions off -proc gekko -fp hard -fp_contract on -O4,p -msgstyle gcc \
            -pragma "check_header_flags off" -pragma "force_active on" \
            -str reuse,pool,readonly -char unsigned -enum int -use_lmw_stmw on -inline off -gccincludes $(INCLUDES) 


### PR DESCRIPTION
* Gets rid of the "Floating point settings of project file ... does not
  match project settings." warning spam when building the project.
  Unfortunately it doesn't look like there's a way to turn off just that
  individual warning, so turn them all off.