### PR TITLE
iAnim.cpp 90% complete

### DIFF
--- a/asm/Core/p2/iAnim.s
+++ b/asm/Core/p2/iAnim.s
@@ -5,44 +5,6 @@
 .section .text  # 0x800BE470 - 0x800BF1C0
 
 
-.global iAnimInit__Fv
-iAnimInit__Fv:
-/* 800BE9F4 000BB7F4  4E 80 00 20 */	blr 
-
-.global iAnimEval__FPvfUiP5xVec3P5xQuat
-iAnimEval__FPvfUiP5xVec3P5xQuat:
-/* 800BE9F8 000BB7F8  94 21 FF F0 */	stwu r1, -0x10(r1)
-/* 800BE9FC 000BB7FC  7C 08 02 A6 */	mflr r0
-/* 800BEA00 000BB800  90 01 00 14 */	stw r0, 0x14(r1)
-/* 800BEA04 000BB804  48 00 07 BD */	bl iAnimEvalSKB__FP14iAnimSKBHeaderfUiP5xVec3P5xQuat
-/* 800BEA08 000BB808  80 01 00 14 */	lwz r0, 0x14(r1)
-/* 800BEA0C 000BB80C  7C 08 03 A6 */	mtlr r0
-/* 800BEA10 000BB810  38 21 00 10 */	addi r1, r1, 0x10
-/* 800BEA14 000BB814  4E 80 00 20 */	blr 
-
-.global iAnimDuration__FPv
-iAnimDuration__FPv:
-/* 800BEA18 000BB818  94 21 FF F0 */	stwu r1, -0x10(r1)
-/* 800BEA1C 000BB81C  7C 08 02 A6 */	mflr r0
-/* 800BEA20 000BB820  90 01 00 14 */	stw r0, 0x14(r1)
-/* 800BEA24 000BB824  48 00 0D 8D */	bl iAnimDurationSKB__FP14iAnimSKBHeader
-/* 800BEA28 000BB828  80 01 00 14 */	lwz r0, 0x14(r1)
-/* 800BEA2C 000BB82C  7C 08 03 A6 */	mtlr r0
-/* 800BEA30 000BB830  38 21 00 10 */	addi r1, r1, 0x10
-/* 800BEA34 000BB834  4E 80 00 20 */	blr 
-
-.global iAnimBoneCount__FPv
-iAnimBoneCount__FPv:
-/* 800BEA38 000BB838  80 83 00 00 */	lwz r4, 0(r3)
-/* 800BEA3C 000BB83C  3C 04 CE BE */	addis r0, r4, 0xcebe
-/* 800BEA40 000BB840  28 00 4B 53 */	cmplwi r0, 0x4b53
-/* 800BEA44 000BB844  40 82 00 0C */	bne lbl_800BEA50
-/* 800BEA48 000BB848  A0 63 00 08 */	lhz r3, 8(r3)
-/* 800BEA4C 000BB84C  4E 80 00 20 */	blr 
-lbl_800BEA50:
-/* 800BEA50 000BB850  38 60 00 00 */	li r3, 0
-/* 800BEA54 000BB854  4E 80 00 20 */	blr 
-
 .global iAnimBlend__FffPUsPfUiP5xVec3P5xQuatP5xVec3P5xQuatP5xVec3P5xQuat
 iAnimBlend__FffPUsPfUiP5xVec3P5xQuatP5xVec3P5xQuatP5xVec3P5xQuat:
 /* 800BEA58 000BB858  94 21 FF 20 */	stwu r1, -0xe0(r1)

--- a/include/rwsdk/rtslerp.h
+++ b/include/rwsdk/rtslerp.h
@@ -12,6 +12,49 @@ struct RtQuatSlerpCache
     RwBool nearlyZeroOm;
 };
 
+#define RtQuatSlerpMacro(qpResult, qpFrom, qpTo, rT, sCache)                                       \
+    MACRO_START                                                                                    \
+    {                                                                                              \
+        if ((rT) <= ((RwReal)0))                                                                   \
+        {                                                                                          \
+            /* t is before start */                                                                \
+            *(qpResult) = *(qpFrom);                                                               \
+        }                                                                                          \
+        else if (((RwReal)1) <= (rT))                                                              \
+        {                                                                                          \
+            /* t is after end */                                                                   \
+            *(qpResult) = *(qpTo);                                                                 \
+        }                                                                                          \
+        else                                                                                       \
+        {                                                                                          \
+            /* ... so t must be in the interior then */                                            \
+            /* Calc coefficients rSclFrom, rSclTo */                                               \
+            RwReal rSclFrom = ((RwReal)1) - (rT);                                                  \
+            RwReal rSclTo = (rT);                                                                  \
+                                                                                                   \
+            if (!((sCache)->nearlyZeroOm))                                                         \
+            {                                                                                      \
+                /* Standard case: slerp */                                                         \
+                /* SLERPMESSAGE(("Neither nearly ZERO nor nearly PI")); */                         \
+                                                                                                   \
+                rSclFrom *= (sCache)->omega;                                                       \
+                RwSinMinusPiToPiMacro(rSclFrom, rSclFrom);                                         \
+                rSclTo *= (sCache)->omega;                                                         \
+                RwSinMinusPiToPiMacro(rSclTo, rSclTo);                                             \
+            }                                                                                      \
+                                                                                                   \
+            /* Calc final values */                                                                \
+            RwV3dScaleMacro(&(qpResult)->imag, &(sCache)->raFrom.imag, rSclFrom);                  \
+            RwV3dIncrementScaledMacro(&(qpResult)->imag, &(sCache)->raTo.imag, rSclTo);            \
+            (qpResult)->real =                                                                     \
+                ((sCache)->raFrom.real * rSclFrom) + ((sCache)->raTo.real * rSclTo);               \
+        }                                                                                          \
+    }                                                                                              \
+    MACRO_STOP
+
+#define RtQuatSlerp(qpResult, qpFrom, qpTo, rT, sCache)                                            \
+    RtQuatSlerpMacro(qpResult, qpFrom, qpTo, rT, sCache)
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/rwsdk/rwplcore.h
+++ b/include/rwsdk/rwplcore.h
@@ -53,6 +53,56 @@ struct RwInt128
 #define RwUInt16MAXVAL 0xFFFF
 #define RwUInt16MINVAL 0x0000
 
+#include <math.h>
+
+#define _RW_C1 ((float)4.1666667908e-02)
+#define _RW_C2 ((float)-1.3888889225e-03)
+#define _RW_C3 ((float)2.4801587642e-05)
+#define _RW_C4 ((float)-2.7557314297e-07)
+#define _RW_C5 ((float)2.0875723372e-09)
+#define _RW_C6 ((float)-1.1359647598e-11)
+#define _RW_S1 ((float)-1.6666667163e-01)
+#define _RW_S2 ((float)8.3333337680e-03)
+#define _RW_S3 ((float)-1.9841270114e-04)
+#define _RW_S4 ((float)2.7557314297e-06)
+#define _RW_S5 ((float)-2.5050759689e-08)
+#define _RW_S6 ((float)1.5896910177e-10)
+#define _RW_one ((float)1.0000000000e+00)
+#define _RW_pS0 ((float)1.6666667163e-01)
+#define _RW_pS1 ((float)-3.2556581497e-01)
+#define _RW_pS2 ((float)2.0121252537e-01)
+#define _RW_pS3 ((float)-4.0055535734e-02)
+#define _RW_pS4 ((float)7.9153501429e-04)
+#define _RW_pS5 ((float)3.4793309169e-05)
+#define _RW_pi ((float)3.1415925026e+00)
+#define _RW_pi_tol ((float)0.0312500000e+00)
+#define _RW_pio2_hi ((float)1.5707962513e+00)
+#define _RW_pio2_lo ((float)7.5497894159e-08)
+#define _RW_qS1 ((float)-2.4033949375e+00)
+#define _RW_qS2 ((float)2.0209457874e+00)
+#define _RW_qS3 ((float)-6.8828397989e-01)
+#define _RW_qS4 ((float)7.7038154006e-02)
+
+#define RwCosMinusPiToPiMacro(result, x)                                                           \
+    MACRO_START                                                                                    \
+    {                                                                                              \
+        const float z = x * x;                                                                     \
+        const float r =                                                                            \
+            (z *                                                                                   \
+             (_RW_C1 + z * (_RW_C2 + z * (_RW_C3 + z * (_RW_C4 + z * (_RW_C5 + z * _RW_C6))))));   \
+        result = (_RW_one - ((float)0.5 * z - (z * r)));                                           \
+    }                                                                                              \
+    MACRO_STOP
+
+#define RwSinMinusPiToPiMacro(result, x)                                                           \
+    do                                                                                             \
+    {                                                                                              \
+        const float z = x * x;                                                                     \
+        const float v = z * x;                                                                     \
+        const float r = (_RW_S2 + z * (_RW_S3 + z * (_RW_S4 + z * (_RW_S5 + z * _RW_S6))));        \
+        result = x + v * (_RW_S1 + z * r);                                                         \
+    } while (0)
+
 #define rwLIBRARYBASEVERSION 0x31000
 #define rwLIBRARYWARNVERSION 0x33000
 #define rwLIBRARYCURRENTVERSION 0x35000
@@ -699,6 +749,95 @@ struct rwGameCube2DVertex
 typedef rwGameCube2DVertex RwIm2DVertex;
 typedef RwUInt16 RxVertexIndex;
 typedef RxVertexIndex RwImVertexIndex;
+
+#if (!defined(RwV3dAssignMacro))
+#define RwV3dAssignMacro(_target, _source) (*(_target) = *(_source))
+#endif /* (!defined(RwV3dAssignMacro)) */
+
+#define RwV3dAddMacro(o, a, b)                                                                     \
+    MACRO_START                                                                                    \
+    {                                                                                              \
+        (o)->x = (((a)->x) + ((b)->x));                                                            \
+        (o)->y = (((a)->y) + ((b)->y));                                                            \
+        (o)->z = (((a)->z) + ((b)->z));                                                            \
+    }                                                                                              \
+    MACRO_STOP
+
+#define RwV3dSubMacro(o, a, b)                                                                     \
+    MACRO_START                                                                                    \
+    {                                                                                              \
+        (o)->x = (((a)->x) - ((b)->x));                                                            \
+        (o)->y = (((a)->y) - ((b)->y));                                                            \
+        (o)->z = (((a)->z) - ((b)->z));                                                            \
+    }                                                                                              \
+    MACRO_STOP
+
+#define RwV3dScaleMacro(o, a, s)                                                                   \
+    MACRO_START                                                                                    \
+    {                                                                                              \
+        (o)->x = (((a)->x) * ((s)));                                                               \
+        (o)->y = (((a)->y) * ((s)));                                                               \
+        (o)->z = (((a)->z) * ((s)));                                                               \
+    }                                                                                              \
+    MACRO_STOP
+
+#define RwV3dIncrementScaledMacro(o, a, s)                                                         \
+    MACRO_START                                                                                    \
+    {                                                                                              \
+        (o)->x += (((a)->x) * ((s)));                                                              \
+        (o)->y += (((a)->y) * ((s)));                                                              \
+        (o)->z += (((a)->z) * ((s)));                                                              \
+    }                                                                                              \
+    MACRO_STOP
+
+#define RwV3dNegateMacro(o, a)                                                                     \
+    MACRO_START                                                                                    \
+    {                                                                                              \
+        (o)->x = -(a)->x;                                                                          \
+        (o)->y = -(a)->y;                                                                          \
+        (o)->z = -(a)->z;                                                                          \
+    }                                                                                              \
+    MACRO_STOP
+
+#define RwV3dDotProductMacro(a, b)                                                                 \
+    ((((((((a)->x) * ((b)->x))) + ((((a)->y) * ((b)->y))))) + ((((a)->z) * ((b)->z)))))
+
+#define RwV3dCrossProductMacro(o, a, b)                                                            \
+    MACRO_START                                                                                    \
+    {                                                                                              \
+        (o)->x = (((((a)->y) * ((b)->z))) - ((((a)->z) * ((b)->y))));                              \
+        (o)->y = (((((a)->z) * ((b)->x))) - ((((a)->x) * ((b)->z))));                              \
+        (o)->z = (((((a)->x) * ((b)->y))) - ((((a)->y) * ((b)->x))));                              \
+    }                                                                                              \
+    MACRO_STOP
+
+#define _rwV3dNormalizeMacro(_result, _out, _in)                                                   \
+    MACRO_START                                                                                    \
+    {                                                                                              \
+        RwReal length2 = RwV3dDotProductMacro(_in, _in);                                           \
+        rwInvSqrtMacro(&(_result), length2);                                                       \
+        RwV3dScaleMacro(_out, _in, _result);                                                       \
+    }                                                                                              \
+    MACRO_STOP
+
+#define RwV3dNormalizeMacro(_result, _out, _in)                                                    \
+    MACRO_START                                                                                    \
+    {                                                                                              \
+        RwReal length2 = RwV3dDotProductMacro((_in), (_in));                                       \
+        RwReal recip;                                                                              \
+                                                                                                   \
+        rwSqrtInvSqrtMacro(&(_result), &recip, length2);                                           \
+        RwV3dScaleMacro((_out), (_in), recip);                                                     \
+    }                                                                                              \
+    MACRO_STOP
+
+#define RwV3dLengthMacro(_result, _in)                                                             \
+    MACRO_START                                                                                    \
+    {                                                                                              \
+        (_result) = RwV3dDotProductMacro(_in, _in);                                                \
+        rwSqrtMacro(&(_result), _result);                                                          \
+    }                                                                                              \
+    MACRO_STOP
 
 enum RwRenderState
 {

--- a/src/Core/p2/iAnim.cpp
+++ b/src/Core/p2/iAnim.cpp
@@ -1,21 +1,241 @@
 #include "iAnim.h"
 
-#include <types.h>
+#include "iAnimSKB.h"
+#include "../x/xMath.h"
 
-// func_800BE9F4
-#pragma GLOBAL_ASM("asm/Core/p2/iAnim.s", "iAnimInit__Fv")
+#include <rwcore.h>
+#include <rtslerp.h>
 
-// func_800BE9F8
-#pragma GLOBAL_ASM("asm/Core/p2/iAnim.s", "iAnimEval__FPvfUiP5xVec3P5xQuat")
+void iAnimInit()
+{
+    return;
+}
 
-// func_800BEA18
-#pragma GLOBAL_ASM("asm/Core/p2/iAnim.s", "iAnimDuration__FPv")
+void iAnimEval(void* RawData, float32 time, uint32 flags, xVec3* tran, xQuat* quat)
+{
+    iAnimEvalSKB((iAnimSKBHeader*)RawData, time, flags, tran, quat);
+}
 
-// func_800BEA38
-#pragma GLOBAL_ASM("asm/Core/p2/iAnim.s", "iAnimBoneCount__FPv")
+float32 iAnimDuration(void* RawData)
+{
+    return iAnimDurationSKB((iAnimSKBHeader*)RawData);
+}
 
+uint32 iAnimBoneCount(void* RawData)
+{
+    if (*(uint32*)RawData == '1BKS')
+    {
+        return ((iAnimSKBHeader*)RawData)->BoneCount;
+    }
+
+    return 0;
+}
+
+#ifndef NON_MATCHING
 // func_800BEA58
-#pragma GLOBAL_ASM("asm/Core/p2/iAnim.s", "iAnimBlend__FffPUsPfUiP5xVec3P5xQuatP5xVec3P5xQuatP5xVec3P5xQuat")
+#pragma GLOBAL_ASM("asm/Core/p2/iAnim.s",                                                          \
+                   "iAnimBlend__FffPUsPfUiP5xVec3P5xQuatP5xVec3P5xQuatP5xVec3P5xQuat")
+#else
+void iAnimBlend(float32 BlendFactor, float32 BlendRecip, uint16* BlendTimeOffset,
+                float32* BoneTable, uint32 BoneCount, xVec3* Tran1, xQuat* Quat1, xVec3* Tran2,
+                xQuat* Quat2, xVec3* TranDest, xQuat* QuatDest)
+{
+    // non-matching: incorrect instruction order and regalloc
 
+    uint32 i;
+    uint32 invert = 0;
+    RtQuat* q2;
+    RtQuat ident = { 0.0f, 0.0f, 0.0f, 1.0f };
+    xVec3* t2;
+
+    if (!Quat2)
+    {
+        q2 = &ident;
+        invert = 1;
+        t2 = (xVec3*)&ident.imag;
+    }
+    else
+    {
+        q2 = (RtQuat*)Quat2;
+        t2 = Tran2;
+    }
+
+    if (BlendFactor < 0.0f)
+    {
+        BlendFactor = -BlendFactor;
+        invert ^= 1;
+    }
+
+    if (!BoneTable && !BlendTimeOffset)
+    {
+        float32 lerp = BlendFactor * BlendRecip;
+
+        if (lerp < 0.0f)
+        {
+            lerp = 0.0f;
+        }
+        else if (lerp > 1.0f)
+        {
+            lerp = 1.0f;
+        }
+
+        if (invert)
+        {
+            lerp = 1.0f - lerp;
+        }
+
+        if (Quat1)
+        {
+            // non-matching: 0.0f constant is loaded outside of loop
+
+            for (i = 0; i < BoneCount; i++)
+            {
+                RtQuatSlerpCache qcache;
+
+                RtQuatSetupSlerpCache((RtQuat*)Quat1, q2, &qcache);
+                RtQuatSlerp((RtQuat*)QuatDest, (RtQuat*)Quat1, q2, lerp, &qcache);
+
+                Quat1++;
+
+                if (Quat2)
+                {
+                    q2++;
+                }
+
+                QuatDest++;
+            }
+        }
+
+        if (Tran1)
+        {
+            if (Quat2)
+            {
+                for (i = 0; i < BoneCount; i++, TranDest++, t2++, Tran1++)
+                {
+                    TranDest->x = lerp * (t2->x - Tran1->x) + Tran1->x;
+                    TranDest->y = lerp * (t2->y - Tran1->y) + Tran1->y;
+                    TranDest->z = lerp * (t2->z - Tran1->z) + Tran1->z;
+                }
+            }
+            else
+            {
+                for (i = 0; i < BoneCount; i++, TranDest++, Tran1++)
+                {
+                    TranDest->x = lerp * (t2->x - Tran1->x) + Tran1->x;
+                    TranDest->y = lerp * (t2->y - Tran1->y) + Tran1->y;
+                    TranDest->z = lerp * (t2->z - Tran1->z) + Tran1->z;
+                }
+            }
+        }
+    }
+    else
+    {
+        float32 baselerp;
+
+        if (!BlendTimeOffset)
+        {
+            baselerp = BlendFactor * BlendRecip;
+
+            if (baselerp < 0.0f)
+            {
+                baselerp = 0.0f;
+            }
+            else if (baselerp > 1.0f)
+            {
+                baselerp = 1.0f;
+            }
+
+            if (invert)
+            {
+                baselerp = 1.0f - baselerp;
+            }
+        }
+
+        for (i = 0; i < BoneCount; i++)
+        {
+            float32 lerp;
+
+            if (BlendTimeOffset)
+            {
+                baselerp = -(1 / 1024.0f * BlendTimeOffset[i * 2] - BlendFactor);
+
+                if (BlendTimeOffset[i * 2 + 1] != 0)
+                {
+                    baselerp *= 1 / 1024.0f * BlendTimeOffset[i * 2 + 1];
+
+                    if (baselerp < 0.0f)
+                    {
+                        baselerp = 0.0f;
+                    }
+                    else if (baselerp > 1.0f)
+                    {
+                        baselerp = 1.0f;
+                    }
+                }
+                else
+                {
+                    if (baselerp < 0.0f)
+                    {
+                        baselerp = 0.0f;
+                    }
+                    else
+                    {
+                        baselerp = 1.0f;
+                    }
+                }
+
+                if (invert)
+                {
+                    baselerp = 1.0f - baselerp;
+                }
+            }
+
+            if (BoneTable)
+            {
+                lerp = baselerp * BoneTable[i];
+            }
+            else
+            {
+                lerp = baselerp;
+            }
+
+            if (Quat1)
+            {
+                RtQuatSlerpCache qcache;
+
+                RtQuatSetupSlerpCache((RtQuat*)Quat1, q2, &qcache);
+                RtQuatSlerp((RtQuat*)QuatDest, (RtQuat*)Quat1, q2, lerp, &qcache);
+
+                Quat1++;
+
+                if (Quat2)
+                {
+                    q2++;
+                }
+
+                QuatDest++;
+            }
+
+            if (Tran1)
+            {
+                TranDest->x = lerp * (t2->x - Tran1->x) + Tran1->x;
+                TranDest->y = lerp * (t2->y - Tran1->y) + Tran1->y;
+                TranDest->z = lerp * (t2->z - Tran1->z) + Tran1->z;
+
+                Tran1++;
+
+                if (Quat2)
+                {
+                    t2++;
+                }
+
+                TranDest++;
+            }
+        }
+    }
+}
+#endif
+
+// Called in iAnimBlend()
 // func_800BF19C
 #pragma GLOBAL_ASM("asm/Core/p2/iAnim.s", "__as__6RtQuatFRC6RtQuat")

--- a/src/Core/p2/iAnimSKB.h
+++ b/src/Core/p2/iAnimSKB.h
@@ -1,6 +1,19 @@
 #ifndef IANIMSKB_H
 #define IANIMSKB_H
 
+#include "../x/xMath3.h"
 
+struct iAnimSKBHeader
+{
+    uint32 Magic;
+    uint32 Flags;
+    uint16 BoneCount;
+    uint16 TimeCount;
+    uint32 KeyCount;
+    float32 Scale[3];
+};
+
+void iAnimEvalSKB(iAnimSKBHeader* data, float32 time, uint32 flags, xVec3* tran, xQuat* quat);
+float32 iAnimDurationSKB(iAnimSKBHeader* data);
 
 #endif


### PR DESCRIPTION
* Matching: iAnimInit, iAnimEval, iAnimDuration, iAnimBoneCount
* Non-matching: iAnimBlend
* Not attempted: RtQuat::__as (a.k.a. operator=), which is called from iAnimBlend via the RtQuatSlerp macro. Whenever iAnimBlend is fully matching, RtQuat::__as should be removed from iAnim.cpp so that the compiler can generate it automatically.