### PR TITLE
Change preprocessor to output .cpp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ __pycache__
 *.pyc
 tools/mwcc_compiler/*.*
 tools/elf2dol
+obj/*
 *.asm
 *.exe
 *.dol

--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ $(OBJ_DIR)/%.o: %.c
 
 $(OBJ_DIR)/%.o: %.cpp
 	@echo " CXX     "$<
-	$S$(CC) $(PREPROCESS) -o $(OBJ_DIR)/$*.cp $< 1>&2
-	$S$(GLBLASM) -s $(OBJ_DIR)/$*.cp
-	$S$(CC) $(CFLAGS) -c -o $@ $(OBJ_DIR)/$*.cp 1>&2
+	$S$(CC) $(PREPROCESS) -o $(OBJ_DIR)/$*.cpp $< 1>&2
+	$S$(GLBLASM) -s $(OBJ_DIR)/$*.cpp
+	$S$(CC) $(CFLAGS) -c -o $@ $(OBJ_DIR)/$*.cpp 1>&2
 	$S$(PPROC) $(PPROCFLAGS) $@


### PR DESCRIPTION
This updates the Makefile to make the preprocessor output *.cpp files instead of *.cp files. It originally outputted *.cp files to the same directory as the source files to avoid overwriting the source files, but then it was updated to output to the obj/ folder. Since then, the *.cp extension has no longer been needed and has made dealing with anonymous namespaces difficult. (e.g. calling a function in an anonymous namespace in xEnt.cpp that hasn't been decomped yet will give the user an "undefined symbol" error, because the function symbol will incorrectly have "xEnt_cp" in the name instead of "xEnt_cpp" after preprocessing). Changing the extension to *.cpp will cause no conflicts and all symbols with anonymous namespaces will now be correctly named.

.gitignore has also been updated to ignore all files in the obj/ folder.