### PR TITLE
Set max compiler/linker errors to 1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,14 @@ clean:
 tools:
 	$(MAKE) -C tools
 
+inspect:
+ifeq ($(WINDOWS),1)
+	$(CC) $(CFLAGS) -o inspect.s -S $(subst \,/,$(subst C:\,/c/,$(INSPECT)))
+else
+	$(CC) $(CFLAGS) -o inspect.s -S $(INSPECT)
+endif
+	python3 tools/inspect_postprocess.py inspect.s
+
 $(ELF): $(O_FILES) $(LDSCRIPT)
 	@echo " LINK    "$@
 	$S$(LD) $(LDFLAGS) -o $@ -lcf $(LDSCRIPT) $(O_FILES) 1>&2

--- a/Makefile
+++ b/Makefile
@@ -74,8 +74,8 @@ ASMDIFF := ./asmdiff.sh
 INCLUDES := -Iinclude -Iinclude/dolphin -Iinclude/CodeWarrior -Iinclude/rwsdk
 
 ASFLAGS := -mgekko -I include
-LDFLAGS := -map $(MAP) -w off
-CFLAGS  := -g -DGAMECUBE -Cpp_exceptions off -proc gekko -fp hard -fp_contract on -O4,p -msgstyle gcc \
+LDFLAGS := -map $(MAP) -w off -maxerrors 1
+CFLAGS  := -g -DGAMECUBE -Cpp_exceptions off -proc gekko -fp hard -fp_contract on -O4,p -msgstyle gcc -maxerrors 1 \
            -pragma "check_header_flags off" -RTTI off -pragma "force_active on" \
            -str reuse,pool,readonly -char unsigned -enum int -use_lmw_stmw on -inline off -gccincludes $(INCLUDES) 
 PREPROCESS := -preprocess -DGAMECUBE -gccincludes $(INCLUDES)
@@ -115,14 +115,6 @@ clean:
 
 tools:
 	$(MAKE) -C tools
-
-inspect:
-ifeq ($(WINDOWS),1)
-	$(CC) $(CFLAGS) -o inspect.s -S $(subst \,/,$(subst C:\,/c/,$(INSPECT)))
-else
-	$(CC) $(CFLAGS) -o inspect.s -S $(INSPECT)
-endif
-	python3 tools/inspect_postprocess.py inspect.s
 
 $(ELF): $(O_FILES) $(LDSCRIPT)
 	@echo " LINK    "$@


### PR DESCRIPTION
This adds `-maxerrors 1` to the compiler and linker flags, which mainly takes care of the compiler's seemingly infinite wall of unhelpful errors by condensing it down to one error. No more running `make` in Command Prompt just to be able to scroll up to the first error lol

Before:
```
obj\src\Core\x\xCollide.cpp:2405: declaration syntax error
obj\src\Core\x\xCollide.cpp:2419: declaration syntax error
obj\src\Core\x\xCollide.cpp:2429: '}' expected
obj\src\Core\x\xCollide.cpp:2430: declaration syntax error
obj\src\Core\x\xCollide.cpp:2431: declaration syntax error
obj\src\Core\x\xCollide.cpp:2432: declaration syntax error
obj\src\Core\x\xCollide.cpp:2433: declaration syntax error
obj\src\Core\x\xCollide.cpp:2434: declaration syntax error
obj\src\Core\x\xCollide.cpp:2435: declaration syntax error
obj\src\Core\x\xCollide.cpp:2436: declaration syntax error
obj\src\Core\x\xCollide.cpp:2437: declaration syntax error
obj\src\Core\x\xCollide.cpp:2438: declaration syntax error
obj\src\Core\x\xCollide.cpp:2439: declaration syntax error
obj\src\Core\x\xCollide.cpp:2440: declaration syntax error
obj\src\Core\x\xCollide.cpp:2441: declaration syntax error
obj\src\Core\x\xCollide.cpp:2442: declaration syntax error

...
```

After:
```
obj\src\Core\x\xCollide.cpp:2405: declaration syntax error
Too many errors printed, aborting program

User break, cancelled...
make: *** [Makefile:138: obj/src/Core/x/xCollide.o] Error 2
```

Fixes #34