### PR TITLE
Build improvements and readme updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+# Ignore
 __pycache__
 *.pyc
 tools/mwcc_compiler/*.*
@@ -21,3 +22,6 @@ obj/*
 .vscode
 .pragma
 inspect.s
+
+# Allow
+!tools/mwcc_compiler/README.md

--- a/README.md
+++ b/README.md
@@ -21,28 +21,24 @@ Thanks to [@mattbruv](https://github.com/mattbruv) for setting this up!
 
 ## Building
 
-### Required tools
+### Requirements
 
 * [devkitPro](https://devkitpro.org/wiki/Getting_Started)
+    * During installation, only the 'GameCube Development' component is required.
 * Python3 (`pacman -S msys/python3`)
 * gcc (`pacman -S gcc`)
+* Metrowerks CodeWarrior 2.0 and 2.7 compiler and linker for Embedded PowerPC (`mwcceppc.exe` and `mwldeppc.exe`)
+    * These can be installed with CodeWarrior 2.0 and 2.7 for GameCube. Please obtain access to these tools on your own, or if you are interested in contributing, please join the [BFBB Modding Discord](https://discord.gg/Dvu2UAS) and DM either `Seil#3565` or `mp#8248` for access.
+* A clean DOL of Battle for Bikini Bottom
+    * This is usually named `main.dol` (or something similar) and must be extracted from the GameCube disc for the game. See [this guide](https://battlepedia.org/Setting_up_Dolphin_for_modding) for instructions.
 
 ### Instructions
 
-1. Obtain a clean DOL of BFBB and place it in the base working directory and name it `baserom.dol`.
-2. Obtain a copy of the MWCC (Build 92) PowerPC and place it in tools/mwcc_compiler/2.0/ folder in tools/.
-3. Obtain a copy of the MWCC (Build 108) PowerPC and place it in tools/mwcc_compiler/2.7/ folder in tools/.
-* (NOTE: These compilers' executables [mwcceppc.exe mwasmeppc.exe and mwldeppc.exe] can be installed with Codewarrior 2.0 for Gamecube and Codewarrior 2.7 for Gamecube, but no license or crack is provided with this project. Please obtain access to the compiler on your own.) If you are in the Gamecube/Wii Decompilation discord (not public at this time, but if you are interested and have the skillset to contribute, please DM Revo#7090 on Discord for access), download GC_COMPILERS.zip and extract it to tools/mwcc_compiler/.
-4. Run the `make` command
-
-### Notes
-
-The following environment variables must be set in order to prevent some common errors and warnings during the compiling and linking process:
-
-* `Path` - A folder containing mwldeppc.exe must be added to this variable (either the 2.0 or 2.7 folder will work)
-* `MWCIncludes` - Can be set to any folder (for example `C:/`)
-* `MWLibraries` - Can be set to any folder (for example `C:/`)
-* `MWLibraryFiles` - Unsure what this should be set to yet.
+1. Copy your clean DOL of Battle for Bikini Bottom to the base working directory and rename it `baserom.dol`.
+2. Create a `2.0` and `2.7` folder in `tools/mwcc_compiler`.
+3. Copy the CW 2.0 `mwcceppc.exe` and `mwldeppc.exe` into the `2.0` folder.
+4. Copy the CW 2.7 `mwcceppc.exe` and `mwldeppc.exe` into the `2.7` folder.
+5. Run the `make` command.
 
 ## Contributions
 

--- a/asmdiff.sh
+++ b/asmdiff.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 OBJDUMP="$DEVKITPPC/bin/powerpc-eabi-objdump -D -bbinary -EB -mpowerpc -M gekko --adjust-vma=0x80003200"
-$OBJDUMP baserom.dol > baserom.dump
-$OBJDUMP main.dol > main.dump
+!(test -f baserom.dump) && $OBJDUMP baserom.dol > baserom.dump
+!(test -f main.dump) && $OBJDUMP main.dol > main.dump
 diff -u --color=always baserom.dump main.dump | head -n 2000

--- a/include/CodeWarrior/size_t.h
+++ b/include/CodeWarrior/size_t.h
@@ -1,8 +1,7 @@
 #ifndef _MSL_SIZE_T_H
 #define _MSL_SIZE_T_H
 
-// prevent Visual Studio Code complaining about __typeof__
-#ifdef _MSC_VER
+#if !defined(__MWERKS__) || __MWERKS__ < 0x2400
 typedef unsigned long size_t;
 #else
 typedef __typeof__(sizeof(0)) size_t;

--- a/src/Core/x/xHud.h
+++ b/src/Core/x/xHud.h
@@ -3,6 +3,7 @@
 
 #include "xBase.h"
 #include "xVec3.h"
+#include "xDynAsset.h"
 
 typedef struct asset;
 typedef struct widget;
@@ -51,6 +52,12 @@ namespace xhud
         ACT_SHOW,
         ACT_HIDE,
         MAX_ACT
+    };
+
+    struct asset : xDynAsset
+    {
+        xVec3 loc;
+        xVec3 size;
     };
 
     struct widget

--- a/src/Core/x/xHudText.h
+++ b/src/Core/x/xHudText.h
@@ -6,10 +6,19 @@
 
 namespace xhud
 {
+    struct text_asset : asset
+    {
+        uint32 text_box;
+        uint32 text;
+    };
+
     struct text_widget : widget
     {
         int8 text[128];
         xtextbox tb;
+
+        text_widget(); // possibly temp, added so zCombo.cpp compiles
+        text_widget(const text_asset&);
 
         void render();
         void update(float32 dt);

--- a/src/Game/zNPCTypeCommon.h
+++ b/src/Game/zNPCTypeCommon.h
@@ -353,6 +353,8 @@ struct zNPCCommon : xNPCBasic
     zNPCLassoInfo* lassdata;
     NPCSndQueue snd_queue[4];
 
+    zNPCCommon(int32);
+
     void AddScripting(xPsyche* psy,
                       int32 (*eval_script)(xGoal*, void*, en_trantype*, float32, void*),
                       int32 (*eval_playanim)(xGoal*, void*, en_trantype*, float32, void*),

--- a/src/Game/zNPCTypeRobot.h
+++ b/src/Game/zNPCTypeRobot.h
@@ -47,6 +47,8 @@ struct zNPCRobot : zNPCCommon
     zNPCLassoInfo raw_lassoinfo;
     xEntDrive raw_drvdata;
 
+    zNPCRobot(int32);
+
     int32 LaunchProjectile(en_npchaz haztyp, float32 spd_proj, float32 dst_minRange,
                            en_mdlvert idx_mvtx, float32 tym_predictMax, float32 hyt_offset);
     void ShowerConfetti(xVec3* pos);

--- a/src/Game/zNPCTypeTiki.h
+++ b/src/Game/zNPCTypeTiki.h
@@ -32,6 +32,8 @@ struct zNPCTiki : zNPCCommon
     void* tikiAnim;
     float32 tikiAnimTime;
 
+    zNPCTiki(int32);
+
     void BUpdate(xVec3* pos);
     void RemoveFromFamily();
     void FindParents(zScene* zsc);

--- a/tools/inlineasm/globalasm.py
+++ b/tools/inlineasm/globalasm.py
@@ -11,6 +11,7 @@ Specified by #pragma GLOBAL_ASM(assemblyFilePath, functionName)
 
 parser = argparse.ArgumentParser(description=info)
 parser.add_argument("file", help="The source file to process")
+parser.add_argument("outfile", help="The file to output to")
 parser.add_argument("-s",
                     "--scope",
                     help="Set function scope equal to scope in assembly",
@@ -22,14 +23,12 @@ def run():
     args = parser.parse_args()
     sourcePath = Path(args.file)
     sourceText = open(sourcePath).read()
+    outPath = Path(args.outfile)
     matches = getPragmaMatches(sourceText)
 
     # Create path to cache if not exists
     createCacheFolder()
     fileCache = getFileCache(sourcePath)
-
-    if len(matches) == 0:
-        return
 
     # in-memory dictionary to optimize the script
     # will hold a bunch of info about each
@@ -91,7 +90,7 @@ def run():
         # the same function on every build
         fileCache[hashKey] = newSource
 
-    open(sourcePath, "w").write(sourceText)
+    open(outPath, "w").write(sourceText)
 
     if fileCache["size"] != len(fileCache):
         fileCache["size"] = len(fileCache)

--- a/tools/mwcc_compiler/README.md
+++ b/tools/mwcc_compiler/README.md
@@ -1,0 +1,5 @@
+# Instructions
+
+1. Create a 2.0 and 2.7 folder
+2. Copy your CW 2.0 mwcceppc.exe and mwldeppc.exe into the 2.0 folder
+3. Copy your CW 2.7 mwcceppc.exe and mwldeppc.exe into the 2.7 folder


### PR DESCRIPTION
This adds the following improvements:
* Added support for all versions of the compiler (1.1 to 2.7).
    * This replaces `-gccincludes`, which was unsupported by older compilers, with `-i-` and `-ir src -ir include`.
    * Minor changes were made to some header files to prevent compile errors on the older compilers. Still OKs on 2.0 (and interestingly, 2.7...)
* Removed the no longer needed preprocessing step.
* Updated the globalasm script to fill the gap of the preprocessor.
    * Takes an output file argument now so it no longer overwrites the input file. This allows the script to read directly from the src/ folder and save to the obj/ folder.
    * The script will now always save the output file even if there are no pragmas to replace, preventing file not found errors.
* Added `-nostdinc` to the compiler and `-nostdlib` to the linker.
    * This makes it so we no longer need to set any of the environment variables 🎉(`Path`, `MWCIncludes`, `MWLibraries`, `MWLibraryFiles`)
* `make clean` will now remove the obj/ folder completely instead of just the .o files.
* Improved the speed of asmdiff.
    * `baserom.dump` will only be generated if it doesn't already exist.
    * `main.dump` will only be generated after compile, so running `./asmdiff.sh` won't re-generate it unnecessarily.
* Updated the readme.
    * Improved the Requirements and Instructions sections.
    * Any contributors who need access to the compilers should now join the BFBB Modding discord and DM either me or @mattbruv.