### PR TITLE
zNPCTypeTest.cpp 90% complete

### DIFF
--- a/asm/Game/zEntCruiseBubble.s
+++ b/asm/Game/zEntCruiseBubble.s
@@ -10092,6 +10092,7 @@ create__5xVec3Ff:
 /* 80060020 0005CE20  38 21 00 20 */	addi r1, r1, 0x20
 /* 80060024 0005CE24  4E 80 00 20 */	blr 
 
+.global IsHealthy__10zNPCCommonFv
 IsHealthy__10zNPCCommonFv:
 /* 80060028 0005CE28  38 60 00 01 */	li r3, 1
 /* 8006002C 0005CE2C  4E 80 00 20 */	blr 

--- a/asm/Game/zEntPlayer.s
+++ b/asm/Game/zEntPlayer.s
@@ -30982,10 +30982,12 @@ xMat3x3SMul__FP7xMat3x3PC7xMat3x3f:
 /* 80082BC8 0007F9C8  38 21 00 20 */	addi r1, r1, 0x20
 /* 80082BCC 0007F9CC  4E 80 00 20 */	blr 
 
+.global SetCarryState__10zNPCCommonF18en_NPC_CARRY_STATE
 SetCarryState__10zNPCCommonF18en_NPC_CARRY_STATE:
 /* 80082BD0 0007F9D0  38 60 00 00 */	li r3, 0
 /* 80082BD4 0007F9D4  4E 80 00 20 */	blr 
 
+.global CanRope__10zNPCCommonFv
 CanRope__10zNPCCommonFv:
 /* 80082BD8 0007F9D8  80 03 01 C8 */	lwz r0, 0x1c8(r3)
 /* 80082BDC 0007F9DC  54 03 01 CE */	rlwinm r3, r0, 0, 7, 7

--- a/asm/Game/zNPCGoalRobo.s
+++ b/asm/Game/zNPCGoalRobo.s
@@ -21820,6 +21820,7 @@ XYZDstSqToPlayer__10zNPCCommonFP5xVec3:
 /* 800EC874 000E9674  38 21 00 10 */	addi r1, r1, 0x10
 /* 800EC878 000E9678  4E 80 00 20 */	blr 
 
+.global DuploNotice__10zNPCCommonF13en_SM_NOTICESPv
 DuploNotice__10zNPCCommonF13en_SM_NOTICESPv:
 /* 800EC87C 000E967C  4E 80 00 20 */	blr 
 

--- a/asm/Game/zNPCMessenger.s
+++ b/asm/Game/zNPCMessenger.s
@@ -1221,10 +1221,12 @@ lbl_800EE290:
 /* 800EE2B8 000EB0B8  38 21 00 70 */	addi r1, r1, 0x70
 /* 800EE2BC 000EB0BC  4E 80 00 20 */	blr 
 
+.global IsAlive__10zNPCCommonFv
 IsAlive__10zNPCCommonFv:
 /* 800EE2C0 000EB0C0  38 60 00 01 */	li r3, 1
 /* 800EE2C4 000EB0C4  4E 80 00 20 */	blr 
 
+.global Stun__10zNPCCommonFf
 Stun__10zNPCCommonFf:
 /* 800EE2C8 000EB0C8  4E 80 00 20 */	blr 
 

--- a/asm/Game/zNPCTypeBoss.s
+++ b/asm/Game/zNPCTypeBoss.s
@@ -332,6 +332,18 @@ __ct__9zNPCB_SB2Fi:
 lbl_8026CBB8:
 	.incbin "baserom.dol", 0x269B98, 0x390
 
+.section .data
+.balign 8
+.global g_hash_bossanim
+g_hash_bossanim:
+	.incbin "baserom.dol", 0x296248, 0x138
+.global g_strz_bossanim
+g_strz_bossanim:
+	.incbin "baserom.dol", 0x296380, 0x138
+.global __vt__8zNPCBoss
+__vt__8zNPCBoss:
+	.incbin "baserom.dol", 0x2964B8, 0xD8
+
 .section .bss
 lbl_80324468:
 	.skip 0x170
@@ -344,6 +356,7 @@ lbl_803CBF44:
 	.skip 0x4
 
 .section .sdata2
+.balign 8
 lbl_803CED08:
 	.incbin "baserom.dol", 0x2B85A8, 0x4
 /* SPECULATION: link order */

--- a/asm/Game/zNPCTypeCommon.s
+++ b/asm/Game/zNPCTypeCommon.s
@@ -1250,6 +1250,7 @@ lbl_800EFFE4:
 /* 800EFFFC 000ECDFC  38 21 00 20 */	addi r1, r1, 0x20
 /* 800F0000 000ECE00  4E 80 00 20 */	blr 
 
+.global Move__10zNPCCommonFP6xScenefP9xEntFrame
 Move__10zNPCCommonFP6xScenefP9xEntFrame:
 /* 800F0004 000ECE04  94 21 FF D0 */	stwu r1, -0x30(r1)
 /* 800F0008 000ECE08  7C 08 02 A6 */	mflr r0
@@ -3795,6 +3796,7 @@ GetParm__10zNPCCommonF10en_npcparmPP10zMovePoint:
 /* 800F2440 000EF240  38 21 00 10 */	addi r1, r1, 0x10
 /* 800F2444 000EF244  4E 80 00 20 */	blr 
 
+.global GetParm__10zNPCCommonF10en_npcparmPv
 GetParm__10zNPCCommonF10en_npcparmPv:
 /* 800F2448 000EF248  94 21 FF D0 */	stwu r1, -0x30(r1)
 /* 800F244C 000EF24C  7C 08 02 A6 */	mflr r0
@@ -3896,6 +3898,7 @@ lbl_800F25BC:
 /* 800F25C8 000EF3C8  38 21 00 30 */	addi r1, r1, 0x30
 /* 800F25CC 000EF3CC  4E 80 00 20 */	blr 
 
+.global GetParmDefault__10zNPCCommonF10en_npcparmPv
 GetParmDefault__10zNPCCommonF10en_npcparmPv:
 /* 800F25D0 000EF3D0  94 21 FF F0 */	stwu r1, -0x10(r1)
 /* 800F25D4 000EF3D4  7C 08 02 A6 */	mflr r0

--- a/asm/Game/zNPCTypeSubBoss.s
+++ b/asm/Game/zNPCTypeSubBoss.s
@@ -218,8 +218,21 @@ PhysicsFlags__11zNPCSubBossCFv:
 .endif
 
 .section .rodata
+.balign 8
 lbl_8026CAA8:
 	.incbin "baserom.dol", 0x269A88, 0x110
+
+.section .data
+.balign 8
+.global g_hash_subbanim
+g_hash_subbanim:
+	.incbin "baserom.dol", 0x2960C0, 0x5C
+.global g_strz_subbanim
+g_strz_subbanim:
+	.incbin "baserom.dol", 0x29611C, 0x5C
+.global __vt__11zNPCSubBoss
+__vt__11zNPCSubBoss:
+	.incbin "baserom.dol", 0x296178, 0xD0
 
 .section .bss
 lbl_803242F8:

--- a/asm/Game/zNPCTypeTest.s
+++ b/asm/Game/zNPCTypeTest.s
@@ -4,93 +4,13 @@
 
 .section .text  # 0x80135ACC - 0x80135EA0
 
-.global ZNPC_Test_Startup__Fv
-ZNPC_Test_Startup__Fv:
-/* 80135ACC 001328CC  94 21 FF E0 */	stwu r1, -0x20(r1)
-/* 80135AD0 001328D0  7C 08 02 A6 */	mflr r0
-/* 80135AD4 001328D4  3C 80 80 2A */	lis r4, g_strz_testanim@ha
-/* 80135AD8 001328D8  3C 60 80 2A */	lis r3, g_hash_testanim@ha
-/* 80135ADC 001328DC  90 01 00 24 */	stw r0, 0x24(r1)
-/* 80135AE0 001328E0  93 E1 00 1C */	stw r31, 0x1c(r1)
-/* 80135AE4 001328E4  3B E4 8F E4 */	addi r31, r4, g_strz_testanim@l
-/* 80135AE8 001328E8  93 C1 00 18 */	stw r30, 0x18(r1)
-/* 80135AEC 001328EC  3B C3 8F B8 */	addi r30, r3, g_hash_testanim@l
-/* 80135AF0 001328F0  93 A1 00 14 */	stw r29, 0x14(r1)
-/* 80135AF4 001328F4  3B A0 00 00 */	li r29, 0
-lbl_80135AF8:
-/* 80135AF8 001328F8  80 7F 00 00 */	lwz r3, 0(r31)
-/* 80135AFC 001328FC  4B F1 67 19 */	bl xStrHash__FPCc
-/* 80135B00 00132900  3B BD 00 01 */	addi r29, r29, 1
-/* 80135B04 00132904  90 7E 00 00 */	stw r3, 0(r30)
-/* 80135B08 00132908  2C 1D 00 0B */	cmpwi r29, 0xb
-/* 80135B0C 0013290C  3B FF 00 04 */	addi r31, r31, 4
-/* 80135B10 00132910  3B DE 00 04 */	addi r30, r30, 4
-/* 80135B14 00132914  41 80 FF E4 */	blt lbl_80135AF8
-/* 80135B18 00132918  80 01 00 24 */	lwz r0, 0x24(r1)
-/* 80135B1C 0013291C  83 E1 00 1C */	lwz r31, 0x1c(r1)
-/* 80135B20 00132920  83 C1 00 18 */	lwz r30, 0x18(r1)
-/* 80135B24 00132924  83 A1 00 14 */	lwz r29, 0x14(r1)
-/* 80135B28 00132928  7C 08 03 A6 */	mtlr r0
-/* 80135B2C 0013292C  38 21 00 20 */	addi r1, r1, 0x20
-/* 80135B30 00132930  4E 80 00 20 */	blr 
-
-.global ZNPC_Test_Shutdown__Fv
-ZNPC_Test_Shutdown__Fv:
-/* 80135B34 00132934  4E 80 00 20 */	blr 
-
-ZNPC_Create_Test__FiP10RyzMemGrowPv:
-/* 80135B38 00132938  94 21 FF F0 */	stwu r1, -0x10(r1)
-/* 80135B3C 0013293C  7C 08 02 A6 */	mflr r0
-/* 80135B40 00132940  3C A0 4E 54 */	lis r5, 0x4E545334@ha
-/* 80135B44 00132944  90 01 00 14 */	stw r0, 0x14(r1)
-/* 80135B48 00132948  38 05 53 34 */	addi r0, r5, 0x4E545334@l
-/* 80135B4C 0013294C  7C 85 23 78 */	mr r5, r4
-/* 80135B50 00132950  93 E1 00 0C */	stw r31, 0xc(r1)
-/* 80135B54 00132954  7C 7F 1B 78 */	mr r31, r3
-/* 80135B58 00132958  7C 1F 00 00 */	cmpw r31, r0
-/* 80135B5C 0013295C  38 60 00 00 */	li r3, 0
-/* 80135B60 00132960  41 82 00 08 */	beq lbl_80135B68
-/* 80135B64 00132964  48 00 00 28 */	b lbl_80135B8C
-lbl_80135B68:
-/* 80135B68 00132968  7F E4 FB 78 */	mr r4, r31
-/* 80135B6C 0013296C  38 60 02 AC */	li r3, 0x2ac
-/* 80135B70 00132970  4B FD 95 E1 */	bl __nw__10RyzMemDataFUliP10RyzMemGrow
-/* 80135B74 00132974  7C 60 1B 79 */	or. r0, r3, r3
-/* 80135B78 00132978  41 82 00 10 */	beq lbl_80135B88
-/* 80135B7C 0013297C  7F E4 FB 78 */	mr r4, r31
-/* 80135B80 00132980  48 00 01 A1 */	bl __ct__8zNPCTestFi
-/* 80135B84 00132984  7C 60 1B 78 */	mr r0, r3
-lbl_80135B88:
-/* 80135B88 00132988  7C 03 03 78 */	mr r3, r0
-lbl_80135B8C:
-/* 80135B8C 0013298C  28 03 00 00 */	cmplwi r3, 0
-/* 80135B90 00132990  41 82 00 08 */	beq lbl_80135B98
-/* 80135B94 00132994  38 63 00 D0 */	addi r3, r3, 0xd0
-lbl_80135B98:
-/* 80135B98 00132998  80 01 00 14 */	lwz r0, 0x14(r1)
-/* 80135B9C 0013299C  83 E1 00 0C */	lwz r31, 0xc(r1)
-/* 80135BA0 001329A0  7C 08 03 A6 */	mtlr r0
-/* 80135BA4 001329A4  38 21 00 10 */	addi r1, r1, 0x10
-/* 80135BA8 001329A8  4E 80 00 20 */	blr 
-
-ZNPC_Destroy_Test__FP12xFactoryInst:
-/* 80135BAC 001329AC  94 21 FF F0 */	stwu r1, -0x10(r1)
-/* 80135BB0 001329B0  7C 08 02 A6 */	mflr r0
-/* 80135BB4 001329B4  38 80 00 01 */	li r4, 1
-/* 80135BB8 001329B8  90 01 00 14 */	stw r0, 0x14(r1)
-/* 80135BBC 001329BC  4B FA 33 E9 */	bl __dt__12xFactoryInstFv
-/* 80135BC0 001329C0  80 01 00 14 */	lwz r0, 0x14(r1)
-/* 80135BC4 001329C4  7C 08 03 A6 */	mtlr r0
-/* 80135BC8 001329C8  38 21 00 10 */	addi r1, r1, 0x10
-/* 80135BCC 001329CC  4E 80 00 20 */	blr 
-
 ZNPC_AnimTable_Test__Fv:
 /* 80135BD0 001329D0  94 21 FF D0 */	stwu r1, -0x30(r1)
 /* 80135BD4 001329D4  7C 08 02 A6 */	mflr r0
-/* 80135BD8 001329D8  3C 60 80 27 */	lis r3, lbl_8026CA50@ha
+/* 80135BD8 001329D8  3C 60 80 27 */	lis r3, _stringBase0_84@ha
 /* 80135BDC 001329DC  3C A0 80 2A */	lis r5, g_strz_testanim@ha
 /* 80135BE0 001329E0  90 01 00 34 */	stw r0, 0x34(r1)
-/* 80135BE4 001329E4  38 63 CA 50 */	addi r3, r3, lbl_8026CA50@l
+/* 80135BE4 001329E4  38 63 CA 50 */	addi r3, r3, _stringBase0_84@l
 /* 80135BE8 001329E8  38 80 00 00 */	li r4, 0
 /* 80135BEC 001329EC  BF 41 00 18 */	stmw r26, 0x18(r1)
 /* 80135BF0 001329F0  3B A5 8F E4 */	addi r29, r5, g_strz_testanim@l
@@ -117,8 +37,8 @@ lbl_80135C20:
 /* 80135C40 00132A40  93 E1 00 10 */	stw r31, 0x10(r1)
 /* 80135C44 00132A44  39 40 00 00 */	li r10, 0
 /* 80135C48 00132A48  80 9C 00 00 */	lwz r4, 0(r28)
-/* 80135C4C 00132A4C  C0 22 A3 70 */	lfs f1, lbl_803CECF0-_SDA2_BASE_(r2)
-/* 80135C50 00132A50  C0 42 A3 74 */	lfs f2, lbl_803CECF4-_SDA2_BASE_(r2)
+/* 80135C4C 00132A4C  C0 22 A3 70 */	lfs f1, _830_2-_SDA2_BASE_(r2)
+/* 80135C50 00132A50  C0 42 A3 74 */	lfs f2, _831_2-_SDA2_BASE_(r2)
 /* 80135C54 00132A54  4B ED 11 05 */	bl xAnimTableNewState__FP10xAnimTablePCcUiUifPfPffPUsPvPFP9xAnimPlayP10xAnimState_vPFP10xAnimStateP11xAnimSinglePv_vPFP9xAnimPlayP5xQuatP5xVec3i_v
 /* 80135C58 00132A58  3B 5A 00 01 */	addi r26, r26, 1
 /* 80135C5C 00132A5C  3B 9C 00 04 */	addi r28, r28, 4
@@ -138,11 +58,11 @@ lbl_80135C70:
 /* 80135C90 00132A90  90 01 00 0C */	stw r0, 0xc(r1)
 /* 80135C94 00132A94  39 20 00 00 */	li r9, 0
 /* 80135C98 00132A98  39 40 00 01 */	li r10, 1
-/* 80135C9C 00132A9C  C0 22 A3 74 */	lfs f1, lbl_803CECF4-_SDA2_BASE_(r2)
+/* 80135C9C 00132A9C  C0 22 A3 74 */	lfs f1, _831_2-_SDA2_BASE_(r2)
 /* 80135CA0 00132AA0  80 9C 00 00 */	lwz r4, 0(r28)
 /* 80135CA4 00132AA4  FC 40 08 90 */	fmr f2, f1
 /* 80135CA8 00132AA8  80 BC 00 04 */	lwz r5, 4(r28)
-/* 80135CAC 00132AAC  C0 62 A3 78 */	lfs f3, lbl_803CECF8-_SDA2_BASE_(r2)
+/* 80135CAC 00132AAC  C0 62 A3 78 */	lfs f3, _832_0-_SDA2_BASE_(r2)
 /* 80135CB0 00132AB0  4B ED 17 11 */	bl xAnimTableNewTransition__FP10xAnimTablePCcPCcPFP15xAnimTransitionP11xAnimSinglePv_UiPFP15xAnimTransitionP11xAnimSinglePv_UiUiUiffUsUsfPUs
 lbl_80135CB4:
 /* 80135CB4 00132AB4  2C 1A 00 01 */	cmpwi r26, 1
@@ -156,11 +76,11 @@ lbl_80135CB4:
 /* 80135CD4 00132AD4  90 01 00 0C */	stw r0, 0xc(r1)
 /* 80135CD8 00132AD8  39 20 00 00 */	li r9, 0
 /* 80135CDC 00132ADC  39 40 00 01 */	li r10, 1
-/* 80135CE0 00132AE0  C0 22 A3 74 */	lfs f1, lbl_803CECF4-_SDA2_BASE_(r2)
+/* 80135CE0 00132AE0  C0 22 A3 74 */	lfs f1, _831_2-_SDA2_BASE_(r2)
 /* 80135CE4 00132AE4  80 9C 00 00 */	lwz r4, 0(r28)
 /* 80135CE8 00132AE8  FC 40 08 90 */	fmr f2, f1
 /* 80135CEC 00132AEC  80 BD 00 04 */	lwz r5, 4(r29)
-/* 80135CF0 00132AF0  C0 62 A3 78 */	lfs f3, lbl_803CECF8-_SDA2_BASE_(r2)
+/* 80135CF0 00132AF0  C0 62 A3 78 */	lfs f3, _832_0-_SDA2_BASE_(r2)
 /* 80135CF4 00132AF4  4B ED 16 CD */	bl xAnimTableNewTransition__FP10xAnimTablePCcPCcPFP15xAnimTransitionP11xAnimSinglePv_UiPFP15xAnimTransitionP11xAnimSinglePv_UiUiUiffUsUsfPUs
 lbl_80135CF8:
 /* 80135CF8 00132AF8  3B 5A 00 01 */	addi r26, r26, 1
@@ -174,133 +94,22 @@ lbl_80135CF8:
 /* 80135D18 00132B18  38 21 00 30 */	addi r1, r1, 0x30
 /* 80135D1C 00132B1C  4E 80 00 20 */	blr 
 
-.global __ct__8zNPCTestFi
-__ct__8zNPCTestFi:
-/* 80135D20 00132B20  94 21 FF F0 */	stwu r1, -0x10(r1)
-/* 80135D24 00132B24  7C 08 02 A6 */	mflr r0
-/* 80135D28 00132B28  90 01 00 14 */	stw r0, 0x14(r1)
-/* 80135D2C 00132B2C  93 E1 00 0C */	stw r31, 0xc(r1)
-/* 80135D30 00132B30  7C 7F 1B 78 */	mr r31, r3
-/* 80135D34 00132B34  4B FB E8 C1 */	bl __ct__10zNPCCommonFi
-/* 80135D38 00132B38  3C 80 80 2A */	lis r4, __vt__8zNPCTest@ha
-/* 80135D3C 00132B3C  7F E3 FB 78 */	mr r3, r31
-/* 80135D40 00132B40  38 04 90 10 */	addi r0, r4, __vt__8zNPCTest@l
-/* 80135D44 00132B44  90 1F 01 B8 */	stw r0, 0x1b8(r31)
-/* 80135D48 00132B48  83 E1 00 0C */	lwz r31, 0xc(r1)
-/* 80135D4C 00132B4C  80 01 00 14 */	lwz r0, 0x14(r1)
-/* 80135D50 00132B50  7C 08 03 A6 */	mtlr r0
-/* 80135D54 00132B54  38 21 00 10 */	addi r1, r1, 0x10
-/* 80135D58 00132B58  4E 80 00 20 */	blr 
-
-Reset__8zNPCTestFv:
-/* 80135D5C 00132B5C  94 21 FF F0 */	stwu r1, -0x10(r1)
-/* 80135D60 00132B60  7C 08 02 A6 */	mflr r0
-/* 80135D64 00132B64  90 01 00 14 */	stw r0, 0x14(r1)
-/* 80135D68 00132B68  93 E1 00 0C */	stw r31, 0xc(r1)
-/* 80135D6C 00132B6C  7C 7F 1B 78 */	mr r31, r3
-/* 80135D70 00132B70  4B FB 9B 35 */	bl Reset__10zNPCCommonFv
-/* 80135D74 00132B74  38 00 00 00 */	li r0, 0
-/* 80135D78 00132B78  90 1F 02 A4 */	stw r0, 0x2a4(r31)
-/* 80135D7C 00132B7C  80 01 00 14 */	lwz r0, 0x14(r1)
-/* 80135D80 00132B80  83 E1 00 0C */	lwz r31, 0xc(r1)
-/* 80135D84 00132B84  7C 08 03 A6 */	mtlr r0
-/* 80135D88 00132B88  38 21 00 10 */	addi r1, r1, 0x10
-/* 80135D8C 00132B8C  4E 80 00 20 */	blr 
-
-Process__8zNPCTestFP6xScenef:
-/* 80135D90 00132B90  94 21 FF E0 */	stwu r1, -0x20(r1)
-/* 80135D94 00132B94  7C 08 02 A6 */	mflr r0
-/* 80135D98 00132B98  90 01 00 24 */	stw r0, 0x24(r1)
-/* 80135D9C 00132B9C  DB E1 00 10 */	stfd f31, 0x10(r1)
-/* 80135DA0 00132BA0  F3 E1 00 18 */	psq_st f31, 24(r1), 0, qr0
-/* 80135DA4 00132BA4  93 E1 00 0C */	stw r31, 0xc(r1)
-/* 80135DA8 00132BA8  93 C1 00 08 */	stw r30, 8(r1)
-/* 80135DAC 00132BAC  7C 7E 1B 78 */	mr r30, r3
-/* 80135DB0 00132BB0  FF E0 08 90 */	fmr f31, f1
-/* 80135DB4 00132BB4  C0 03 02 A8 */	lfs f0, 0x2a8(r3)
-/* 80135DB8 00132BB8  7C 9F 23 78 */	mr r31, r4
-/* 80135DBC 00132BBC  C0 22 A3 7C */	lfs f1, lbl_803CECFC-_SDA2_BASE_(r2)
-/* 80135DC0 00132BC0  EC 00 F8 28 */	fsubs f0, f0, f31
-/* 80135DC4 00132BC4  FC 01 00 40 */	fcmpo cr0, f1, f0
-/* 80135DC8 00132BC8  40 81 00 08 */	ble lbl_80135DD0
-/* 80135DCC 00132BCC  48 00 00 08 */	b lbl_80135DD4
-lbl_80135DD0:
-/* 80135DD0 00132BD0  FC 20 00 90 */	fmr f1, f0
-lbl_80135DD4:
-/* 80135DD4 00132BD4  D0 3E 02 A8 */	stfs f1, 0x2a8(r30)
-/* 80135DD8 00132BD8  C0 3E 02 A8 */	lfs f1, 0x2a8(r30)
-/* 80135DDC 00132BDC  C0 02 A3 74 */	lfs f0, lbl_803CECF4-_SDA2_BASE_(r2)
-/* 80135DE0 00132BE0  FC 01 00 40 */	fcmpo cr0, f1, f0
-/* 80135DE4 00132BE4  40 80 00 50 */	bge lbl_80135E34
-/* 80135DE8 00132BE8  C0 02 A3 80 */	lfs f0, lbl_803CED00-_SDA2_BASE_(r2)
-/* 80135DEC 00132BEC  D0 1E 02 A8 */	stfs f0, 0x2a8(r30)
-/* 80135DF0 00132BF0  80 7E 02 A4 */	lwz r3, 0x2a4(r30)
-/* 80135DF4 00132BF4  38 63 00 01 */	addi r3, r3, 1
-/* 80135DF8 00132BF8  90 7E 02 A4 */	stw r3, 0x2a4(r30)
-/* 80135DFC 00132BFC  80 1E 02 A0 */	lwz r0, 0x2a0(r30)
-/* 80135E00 00132C00  7C 03 00 00 */	cmpw r3, r0
-/* 80135E04 00132C04  41 80 00 0C */	blt lbl_80135E10
-/* 80135E08 00132C08  38 00 00 00 */	li r0, 0
-/* 80135E0C 00132C0C  90 1E 02 A4 */	stw r0, 0x2a4(r30)
-lbl_80135E10:
-/* 80135E10 00132C10  80 1E 02 A4 */	lwz r0, 0x2a4(r30)
-/* 80135E14 00132C14  3C 60 80 2A */	lis r3, g_hash_testanim@ha
-/* 80135E18 00132C18  38 83 8F B8 */	addi r4, r3, g_hash_testanim@l
-/* 80135E1C 00132C1C  7F C3 F3 78 */	mr r3, r30
-/* 80135E20 00132C20  54 00 10 3A */	slwi r0, r0, 2
-/* 80135E24 00132C24  38 A0 00 00 */	li r5, 0
-/* 80135E28 00132C28  7C 84 02 14 */	add r4, r4, r0
-/* 80135E2C 00132C2C  80 84 00 04 */	lwz r4, 4(r4)
-/* 80135E30 00132C30  4B FB CF 61 */	bl AnimStart__10zNPCCommonFUii
-lbl_80135E34:
-/* 80135E34 00132C34  FC 20 F8 90 */	fmr f1, f31
-/* 80135E38 00132C38  7F C3 F3 78 */	mr r3, r30
-/* 80135E3C 00132C3C  7F E4 FB 78 */	mr r4, r31
-/* 80135E40 00132C40  4B FB A2 B1 */	bl Process__10zNPCCommonFP6xScenef
-/* 80135E44 00132C44  E3 E1 00 18 */	psq_l f31, 24(r1), 0, qr0
-/* 80135E48 00132C48  80 01 00 24 */	lwz r0, 0x24(r1)
-/* 80135E4C 00132C4C  CB E1 00 10 */	lfd f31, 0x10(r1)
-/* 80135E50 00132C50  83 E1 00 0C */	lwz r31, 0xc(r1)
-/* 80135E54 00132C54  83 C1 00 08 */	lwz r30, 8(r1)
-/* 80135E58 00132C58  7C 08 03 A6 */	mtlr r0
-/* 80135E5C 00132C5C  38 21 00 20 */	addi r1, r1, 0x20
-/* 80135E60 00132C60  4E 80 00 20 */	blr 
-
-SelfSetup__8zNPCTestFv:
-/* 80135E64 00132C64  38 00 00 00 */	li r0, 0
-/* 80135E68 00132C68  90 03 02 A4 */	stw r0, 0x2a4(r3)
-/* 80135E6C 00132C6C  80 83 01 D8 */	lwz r4, 0x1d8(r3)
-/* 80135E70 00132C70  80 04 03 A4 */	lwz r0, 0x3a4(r4)
-/* 80135E74 00132C74  90 03 02 A0 */	stw r0, 0x2a0(r3)
-/* 80135E78 00132C78  C0 02 A3 80 */	lfs f0, lbl_803CED00-_SDA2_BASE_(r2)
-/* 80135E7C 00132C7C  D0 03 02 A8 */	stfs f0, 0x2a8(r3)
-/* 80135E80 00132C80  4E 80 00 20 */	blr 
-
-AnimPick__8zNPCTestFi16en_NPC_GOAL_SPOTP5xGoal:
-/* 80135E84 00132C84  80 03 02 A4 */	lwz r0, 0x2a4(r3)
-/* 80135E88 00132C88  3C 60 80 2A */	lis r3, g_hash_testanim@ha
-/* 80135E8C 00132C8C  38 63 8F B8 */	addi r3, r3, g_hash_testanim@l
-/* 80135E90 00132C90  54 00 10 3A */	slwi r0, r0, 2
-/* 80135E94 00132C94  7C 63 02 14 */	add r3, r3, r0
-/* 80135E98 00132C98  80 63 00 04 */	lwz r3, 4(r3)
-/* 80135E9C 00132C9C  4E 80 00 20 */	blr 
-
 .endif
-
-.section .rodata
-.balign 8
-lbl_8026CA50:
-	.incbin "baserom.dol", 0x269A30, 0x58
 
 .section .sdata2
 .balign 8
-lbl_803CECF0:
+.global _830_2
+_830_2:
 	.incbin "baserom.dol", 0x2B8590, 0x4
-lbl_803CECF4:
+.global _831_2
+_831_2:
 	.incbin "baserom.dol", 0x2B8594, 0x4
-lbl_803CECF8:
+.global _832_0
+_832_0:
 	.incbin "baserom.dol", 0x2B8598, 0x4
-lbl_803CECFC:
+.global _866_5
+_866_5:
 	.incbin "baserom.dol", 0x2B859C, 0x4
-lbl_803CED00:
-	.incbin "baserom.dol", 0x2B85A0, 0x8
+.global _867_6
+_867_6:
+	.incbin "baserom.dol", 0x2B85A0, 0x4

--- a/asm/Game/zTaskBox.s
+++ b/asm/Game/zTaskBox.s
@@ -496,42 +496,6 @@ on_answer__Q28ztaskbox13talk_callbackFQ28ztalkbox11answer_enum:
 .global __vt__Q28ztaskbox13talk_callback
 __vt__Q28ztaskbox13talk_callback:
 	.incbin "baserom.dol", 0x295F80, 0x18
-/* SPECULATION: link order */
-.global g_hash_testanim
-g_hash_testanim:
-	.incbin "baserom.dol", 0x295F98, 0x2C
-/* SPECULATION: link order */
-.global g_strz_testanim
-g_strz_testanim:
-	.incbin "baserom.dol", 0x295FC4, 0x2C
-/* SPECULATION: link order */
-.global __vt__8zNPCTest
-__vt__8zNPCTest:
-	.incbin "baserom.dol", 0x295FF0, 0xD0
-/* SPECULATION: link order */
-.global g_hash_subbanim
-g_hash_subbanim:
-	.incbin "baserom.dol", 0x2960C0, 0x5C
-/* SPECULATION: link order */
-.global g_strz_subbanim
-g_strz_subbanim:
-	.incbin "baserom.dol", 0x29611C, 0x5C
-/* SPECULATION: link order */
-.global __vt__11zNPCSubBoss
-__vt__11zNPCSubBoss:
-	.incbin "baserom.dol", 0x296178, 0xD0
-/* SPECULATION: link order */
-.global g_hash_bossanim
-g_hash_bossanim:
-	.incbin "baserom.dol", 0x296248, 0x138
-/* SPECULATION: link order */
-.global g_strz_bossanim
-g_strz_bossanim:
-	.incbin "baserom.dol", 0x296380, 0x138
-/* SPECULATION: link order */
-.global __vt__8zNPCBoss
-__vt__8zNPCBoss:
-	.incbin "baserom.dol", 0x2964B8, 0xD8
 
 .section .bss
 .balign 8

--- a/include/CodeWarrior/exception
+++ b/include/CodeWarrior/exception
@@ -1,0 +1,6 @@
+#ifndef _EXCEPTION
+#define _EXCEPTION
+
+#include <exception.h>
+
+#endif

--- a/include/CodeWarrior/exception.h
+++ b/include/CodeWarrior/exception.h
@@ -1,0 +1,27 @@
+#ifndef _EXCEPTION_H
+#define _EXCEPTION_H
+
+namespace std
+{
+    class exception
+    {
+    public:
+        exception() throw();
+        exception(const exception&) throw();
+        exception& operator=(const exception&) throw();
+        virtual ~exception() throw();
+        virtual const char* what() const throw();
+    };
+
+    class bad_exception : public exception
+    {
+    public:
+        bad_exception() throw();
+        bad_exception(const bad_exception&) throw();
+        bad_exception& operator=(const bad_exception&) throw();
+        virtual ~bad_exception() throw();
+        virtual const char* what() const throw();
+    };
+} // namespace std
+
+#endif

--- a/include/CodeWarrior/new
+++ b/include/CodeWarrior/new
@@ -1,0 +1,6 @@
+#ifndef _NEW
+#define _NEW
+
+#include <new.h>
+
+#endif

--- a/include/CodeWarrior/new.h
+++ b/include/CodeWarrior/new.h
@@ -1,0 +1,40 @@
+#ifndef _NEW_H
+#define _NEW_H
+
+#include <size_t.h>
+#include <exception.h>
+
+namespace std
+{
+    class bad_alloc : public exception
+    {
+    public:
+        bad_alloc() throw();
+        bad_alloc(const bad_alloc&) throw();
+        bad_alloc& operator=(const bad_alloc&) throw();
+        virtual ~bad_alloc() throw();
+        virtual const char* what() const throw();
+    };
+
+    struct nothrow_t
+    {
+    };
+} // namespace std
+
+void* operator new(size_t size) throw(std::bad_alloc);
+void* operator new(size_t size, const std::nothrow_t&) throw();
+void* operator new(size_t, void* ptr) throw();
+
+void operator delete(void* ptr) throw();
+void operator delete(void* ptr, const std::nothrow_t&) throw();
+void operator delete(void*, void*) throw();
+
+void* operator new[](size_t size) throw(std::bad_alloc);
+void* operator new[](size_t size, const std::nothrow_t&) throw();
+void* operator new[](size_t, void* ptr) throw();
+
+void operator delete[](void* ptr) throw();
+void operator delete[](void* ptr, const std::nothrow_t&) throw();
+void operator delete[](void*, void*) throw();
+
+#endif

--- a/include/CodeWarrior/size_t.h
+++ b/include/CodeWarrior/size_t.h
@@ -1,7 +1,9 @@
 #ifndef _MSL_SIZE_T_H
 #define _MSL_SIZE_T_H
 
-#if !defined(__MWERKS__) || __MWERKS__ < 0x2400
+#ifdef _MSC_VER
+typedef size_t; // hack to make VS Code not complain about size_t in operator new
+#elif !defined(__MWERKS__) || __MWERKS__ < 0x2400
 typedef unsigned long size_t;
 #else
 typedef __typeof__(sizeof(0)) size_t;

--- a/src/Core/x/xAnim.h
+++ b/src/Core/x/xAnim.h
@@ -169,9 +169,15 @@ xAnimTable* xAnimTableNew(const char* name, xAnimTable** linkedList, uint32 user
 xAnimState* xAnimTableNewState(xAnimTable* table, const char* name, uint32 flags, uint32 userFlags,
                                float32 speed, float32* boneBlend, float32* timeSnap,
                                float32 fadeRecip, uint16* fadeOffset, void* callbackData,
-                               void (*beforeEnter)(xAnimPlay*, xAnimState*),
-                               void (*stateCallback)(xAnimState*, xAnimSingle*, void*),
-                               void (*beforeAnimMatrices)(xAnimPlay*, xQuat*, xVec3*, int32));
+                               xAnimStateBeforeEnterCallback beforeEnter,
+                               xAnimStateCallback stateCallback,
+                               xAnimStateBeforeAnimMatricesCallback beforeAnimMatrices);
+xAnimTransition* xAnimTableNewTransition(xAnimTable* table, const char* source, const char* dest,
+                                         xAnimTransitionConditionalCallback conditional,
+                                         xAnimTransitionCallback callback, uint32 flags,
+                                         uint32 userFlags, float32 srcTime, float32 destTime,
+                                         uint16 priority, uint16 queuePriority, float32 blendRecip,
+                                         uint16* blendOffset);
 void xAnimDefaultBeforeEnter(xAnimPlay* play, xAnimState* state);
 void xAnimPoolInit(xMemPool* pool, uint32 count, uint32 singles, uint32 blendFlags,
                    uint32 effectMax);

--- a/src/Core/x/xRMemData.h
+++ b/src/Core/x/xRMemData.h
@@ -2,7 +2,8 @@
 #define XRMEMDATA_H
 
 #include "xBase.h"
-#include <size_t.h>
+
+#include <new>
 
 struct RyzMemGrow
 {
@@ -22,7 +23,7 @@ struct RyzMemGrow
 
 struct RyzMemData
 {
-    void* operator new(size_t size, uint32 amt, RyzMemGrow* growCtxt);
+    void* operator new(size_t amt, int32, RyzMemGrow* growCtxt);
     void operator delete(void*);
 };
 

--- a/src/Game/zNPCGoalStd.cpp
+++ b/src/Game/zNPCGoalStd.cpp
@@ -261,13 +261,13 @@
 #pragma GLOBAL_ASM("asm/Game/zNPCGoalStd.s", "RestoreColFlags__9xNPCBasicFv")
 
 // func_800D91D8
-uint8 xNPCBasic::ColChkFlags() const
+uint8 xNPCBasic::PhysicsFlags() const
 {
     return 0;
 }
 
 // func_800D91E0
-uint8 xNPCBasic::ColPenFlags()
+uint8 xNPCBasic::ColPenByFlags() const
 {
     return 0;
 }
@@ -279,13 +279,13 @@ uint8 xNPCBasic::ColChkByFlags() const
 }
 
 // func_800D91F0
-uint8 xNPCBasic::ColPenByFlags() const
+uint8 xNPCBasic::ColPenFlags()
 {
     return 0;
 }
 
 // func_800D91F8
-uint8 xNPCBasic::PhysicsFlags() const
+uint8 xNPCBasic::ColChkFlags() const
 {
     return 0;
 }

--- a/src/Game/zNPCMgr.cpp
+++ b/src/Game/zNPCMgr.cpp
@@ -240,7 +240,7 @@ xFactory* xBehaveMgr::GetFactory()
     return this->goalFactory;
 }
 
-void zNPCCommon::PostSetup()
+void xNPCBasic::PostSetup()
 {
 }
 

--- a/src/Game/zNPCSndTable.h
+++ b/src/Game/zNPCSndTable.h
@@ -5,7 +5,7 @@
 
 enum en_NPC_SOUND
 {
-    NPC_STYP_BOGUS = 0xfffffffe,
+    NPC_STYP_BOGUS = -2,
     NPC_STYP_LISTEND = 0,
     NPC_STYP_ENCOUNTER,
     NPC_STYP_CLANKING,

--- a/src/Game/zNPCSpawner.h
+++ b/src/Game/zNPCSpawner.h
@@ -3,6 +3,20 @@
 
 #include <types.h>
 
+enum en_SM_NOTICES
+{
+    SM_NOTE_NPCDIED,
+    SM_NOTE_NPCSTANDBY,
+    SM_NOTE_NPCALIVE,
+    SM_NOTE_DUPPAUSE,
+    SM_NOTE_DUPRESUME,
+    SM_NOTE_DUPSETDELAY,
+    SM_NOTE_DUPDEAD,
+    SM_NOTE_KILLKIDS,
+    SM_NOTE_NOMORE,
+    SM_NOTE_FORCE = 0x7fffffff
+};
+
 void zNPCSpawner_Startup();
 void zNPCSpawner_Shutdown();
 

--- a/src/Game/zNPCTypeCommon.cpp
+++ b/src/Game/zNPCTypeCommon.cpp
@@ -442,19 +442,19 @@ void zNPCCommon::DuploOwner(zNPCCommon* duper)
     npc_duplodude = duper;
 }
 
-void SpeakBegin()
+void zNPCCommon::SpeakBegin()
 {
 }
 
-void SpeakEnd()
+void zNPCCommon::SpeakEnd()
 {
 }
 
-void SpeakStart()
+void zNPCCommon::SpeakStart()
 {
 }
 
-void SpeakStop()
+void zNPCCommon::SpeakStop()
 {
 }
 

--- a/src/Game/zNPCTypeCommon.h
+++ b/src/Game/zNPCTypeCommon.h
@@ -9,6 +9,7 @@
 #include "../Core/x/xEnt.h"
 
 #include "zNPCSndTable.h"
+#include "zNPCSpawner.h"
 #include "zMovePoint.h"
 #include "zShrapnel.h"
 
@@ -366,7 +367,7 @@ struct zNPCCommon : xNPCBasic
     zNPCLassoInfo* lassdata;
     NPCSndQueue snd_queue[4];
 
-    zNPCCommon(int32);
+    zNPCCommon(int32 myType);
 
     uint32 LassoInit();
     zNPCLassoInfo* GimmeLassInfo();
@@ -378,6 +379,7 @@ struct zNPCCommon : xNPCBasic
     void MvptReset(zMovePoint* nav_goto);
     void ModelScaleSet(float32 x, float32 y, float32 z);
     void ModelScaleSet(const xVec3* vec);
+    int32 AnimStart(uint32 animID, int32 forceRestart);
     void GiveReward();
     int32 LassoUseGuides(int32 idx_grabmdl, int32 idx_holdmdl);
     int32 GetVertPos(en_mdlvert vid, xVec3* pos);
@@ -397,17 +399,22 @@ struct zNPCCommon : xNPCBasic
 
     // vTable (xNPCBasic)
 
-    void Init(xEntAsset* asset);
-    void Reset();
-    void Process(xScene* xscn, float32 dt);
-    void NewTime(xScene* xscn, float32 dt);
-    void Destroy();
+    virtual void Init(xEntAsset* asset);
+    virtual void Reset();
+    virtual void Setup();
+    virtual void Process(xScene* xscn, float32 dt);
+    virtual void BUpdate(xVec3* pos);
+    virtual void NewTime(xScene* xscn, float32 dt);
+    virtual void Move(xScene* xscn, float32 dt, xEntFrame*);
+    virtual int32 SysEvent(xBase* from, xBase* to, uint32 toEvent, const float32* toParam,
+                           xBase* toParamWidget, int32* handled);
+    virtual void CollideReview();
+    virtual void Destroy();
 
     // vTable (zNPCCommon)
     virtual int32 NPCMessage(NPCMsg* mail);
     virtual void RenderExtra();
     virtual void RenderExtraPostParticles();
-    virtual void PostSetup();
     virtual void ParseINI();
     virtual void ParseLinks();
     virtual void ParseProps();
@@ -415,25 +422,29 @@ struct zNPCCommon : xNPCBasic
     virtual void SelfDestroy();
     virtual int32 IsHealthy();
     virtual int32 IsAlive();
-    virtual void Damage(en_NPC_DAMAGE_TYPE damtype, xBase* who, xVec3* vec_hit);
-    virtual int32 Respawn(xVec3* pos, zMovePoint* mvptFirst, zMovePoint* mvptSpawnRef);
+    virtual void Damage(en_NPC_DAMAGE_TYPE damtype, xBase* who, const xVec3* vec_hit);
+    virtual int32 Respawn(const xVec3* pos, zMovePoint* mvptFirst, zMovePoint* mvptSpawnRef);
     virtual void DuploOwner(zNPCCommon* duper);
-    virtual void DuploNotice();
+    virtual void DuploNotice(en_SM_NOTICES, void*);
     virtual int32 CanRope();
     virtual void LassoNotify(en_LASSO_EVENT event);
-    virtual int32 SetCarryState();
+    virtual int32 SetCarryState(en_NPC_CARRY_STATE);
     virtual void Stun(float32 stuntime);
     virtual void SpeakBegin();
     virtual void SpeakEnd();
     virtual void SpeakStart();
     virtual void SpeakStop();
     virtual uint32 AnimPick(int32 animID, en_NPC_GOAL_SPOT gspot, xGoal* goal);
-    virtual void GetParm(en_npcparm pid, zMovePoint** val);
+    virtual void GetParm(en_npcparm pid, void* val);
     virtual void GetParmDefault(en_npcparm pid, void* val);
     virtual float32 GenShadCacheRad();
     virtual xEntDrive* PRIV_GetDriverData();
     virtual zNPCLassoInfo* PRIV_GetLassoData();
     virtual int32 LassoSetup();
+
+protected:
+    // This prevents implicit destructors from being generated in subclasses of zNPCCommon
+    ~zNPCCommon();
 };
 
 struct NPCSysEvent

--- a/src/Game/zNPCTypeTest.h
+++ b/src/Game/zNPCTypeTest.h
@@ -19,5 +19,8 @@ struct zNPCTest : zNPCCommon
 
 void ZNPC_Test_Startup();
 void ZNPC_Test_Shutdown();
+xFactoryInst* ZNPC_Create_Test(int32 who, RyzMemGrow* grow, void*);
+void ZNPC_Destroy_Test(xFactoryInst* inst);
+xAnimTable* ZNPC_AnimTable_Test();
 
 #endif

--- a/src/Game/zNPCTypeTest.h
+++ b/src/Game/zNPCTypeTest.h
@@ -1,6 +1,22 @@
 #ifndef ZNPCTYPETEST_H
 #define ZNPCTYPETEST_H
 
+#include "zNPCTypeCommon.h"
+
+struct zNPCTest : zNPCCommon
+{
+    int32 numAnimations;
+    int32 currentState;
+    float32 transitionTimer;
+
+    zNPCTest(int32 myType);
+
+    virtual void Reset();
+    virtual void Process(xScene* xscn, float32 dt);
+    virtual void SelfSetup();
+    virtual uint32 AnimPick(int32, en_NPC_GOAL_SPOT, xGoal*);
+};
+
 void ZNPC_Test_Startup();
 void ZNPC_Test_Shutdown();
 


### PR DESCRIPTION
Everything is matching except for `ZNPC_AnimTable_Test` due to float scheduling issues. I fixed some issues with zNPCCommon, mostly involving its vtable, which allowed me to decomp zNPCTest's constructor and functions correctly (this should also help with other zNPCCommon-derived types) and added `<new>` and `<exception>` headers to properly support overloading `operator new` which is required by RyzMemData.

zNPCTest seems like it's a decent reference point/template for how the rest of the NPC types work. It's relatively simple and only overrides a few zNPCCommon functions but it still demonstrates some cool things.

`ZNPC_Create_Test` in zNPCTypeTest.cpp contains a good example of how `new` is used to instantiate an NPC:

```c++
new (who, grow) zNPCTest(who);
```

We need to include 2 extra arguments in parentheses before calling zNPCTest's constructor. These 2 arguments are passed to `RyzMemData::operator new`, which takes 3 arguments:

```c++
void* operator new(size_t amt, int32, RyzMemGrow* growCtxt);
```

The first argument, `amt`, is implicitly passed from the `new` keyword; it's the size of the struct/class being created. The `int32` and `growCtxt` arguments map directly to the arguments we put in the parentheses (`(who, grow)`).