### PR TITLE
Add "nosig" argument to GLOBAL_ASM

### DIFF
--- a/include/types.h
+++ b/include/types.h
@@ -38,6 +38,7 @@ typedef int32 bool32;
 
 #ifndef __MWERKS__
 #define __declspec(x)
+#define asm
 #endif
 
 #endif

--- a/tools/inlineasm/globalasm.py
+++ b/tools/inlineasm/globalasm.py
@@ -82,8 +82,12 @@ def run():
         if args.scope and ".global " + funcToImport not in asmFileText:
             isGlobal = False
 
+        noSig = False
+        if len(pragmaArgs) > 2 and pragmaArgs[2] == "nosig":
+            noSig = True
+
         newSource = ""
-        newSource = writeCode(newSource, funcToImport, codeBytes, isGlobal)
+        newSource = writeCode(newSource, funcToImport, codeBytes, isGlobal, noSig)
         sourceText = sourceText.replace(replacePragmaText, newSource)
 
         # update our file cache to avoid re-processing

--- a/tools/inlineasm/helpers.py
+++ b/tools/inlineasm/helpers.py
@@ -92,10 +92,16 @@ nofralloc
 {data}
 }}"""
 
+funcTemplateNoSig = """nofralloc
+{data}"""
 
-def writeCode(source, funcName, codeBytes, isGlobal):
+
+def writeCode(source, funcName, codeBytes, isGlobal, noSig):
     source += "\n"
-    t = funcTemplate.replace("{name}", funcName)
+    if noSig:
+        t = funcTemplateNoSig
+    else:
+        t = funcTemplate.replace("{name}", funcName)
     bs = list(map(bytesToString, codeBytes))
     t = t.replace("{data}", "\n".join(bs))
     if not isGlobal:


### PR DESCRIPTION
This adds an optional "nosig" argument to #pragma GLOBAL_ASM. It makes the script insert `nofralloc` and `opword` instructions but not write an extern "C" or function signature around them. This lets you put a #pragma GLOBAL_ASM inside of an asm function you make yourself, which is useful if you need control over how the function is defined. I actually do need this in at least one case so far, where a vtable is only generated if a function has a proper C++ signature (`int32 zNPCGoalTikiCount::Enter(float32, void*)` instead of the mangled one (`asm void Enter__17zNPCGoalTikiCountFfPv()`).

Without "nosig":
```c++
extern "C" {
asm void Enter__17zNPCGoalTikiCountFfPv() {
nofralloc
opword 0x9421FFF0
opword 0x7C0802A6
opword 0x90010014
// ...
}}
```

With "nosig":
```c++
nofralloc
opword 0x9421FFF0
opword 0x7C0802A6
opword 0x90010014
// ...
```

This lets you replace this:
```c++
#ifndef NON_MATCHING
#pragma GLOBAL_ASM("asm/Game/zNPCGoalTiki.s", "Enter__17zNPCGoalTikiCountFfPv")
#else
int32 zNPCGoalTikiCount::Enter(float32, void*)
{
    // c++ code goes here
}
#endif
```

with this:
```c++
#ifndef NON_MATCHING
asm int32 zNPCGoalTikiCount::Enter(float32, void*)
{
#pragma GLOBAL_ASM("asm/Game/zNPCGoalTiki.s", "Enter__17zNPCGoalTikiCountFfPv", "nosig")
}
#else
int32 zNPCGoalTikiCount::Enter(float32, void*)
{
    // c++ code goes here
}
#endif
```