### PR TITLE
Fix diff tool breaking on windows

### DIFF
--- a/diff.py
+++ b/diff.py
@@ -395,10 +395,12 @@ def eval_line_num(expr: str) -> int:
 
 
 def run_make(target: str) -> None:
+    target = target.replace("\\", "/")
     subprocess.check_call(["make"] + makeflags + [target])
 
 
 def run_make_capture_output(target: str) -> "subprocess.CompletedProcess[bytes]":
+    target = target.replace("\\", "/")
     return subprocess.run(
         ["make"] + makeflags + [target],
         stderr=subprocess.PIPE,


### PR DESCRIPTION
After I make sure my `DEVKITPPC` environment variable is set with the correct windows path, All I had to do was include the fix in this commit and now the diff script works/updates as it should for me.