### PR TITLE
add -r argument for stopping at first blr

### DIFF
--- a/diff.py
+++ b/diff.py
@@ -159,6 +159,13 @@ parser.add_argument(
     help="Stop disassembling at the first 'jr ra'. Some functions have multiple return points, so use with care!",
 )
 parser.add_argument(
+    "-r",
+    "--stop-blr",
+    dest="stop_blr",
+    action="store_true",
+    help="Stop disassembling at the first 'blr'. Some functions have multiple return points, so use with care!",
+)
+parser.add_argument(
     "-i",
     "--ignore-large-imms",
     dest="ignore_large_imms",
@@ -1093,6 +1100,8 @@ def process(lines: List[str]) -> List[Line]:
 
         if args.stop_jrra and mnemonic == "jr" and row_parts[1].strip() == "ra":
             stop_after_delay_slot = True
+        if args.stop_blr and mnemonic == "blr":
+            break
         elif stop_after_delay_slot:
             break
 


### PR DESCRIPTION
#196 
as said in the arg description, for shorter functions which include multiple `blr`s this option should be omitted.