### PR TITLE
Modify diff.py to use TemporaryFile to capture output from make

### DIFF
--- a/diff.py
+++ b/diff.py
@@ -206,6 +206,14 @@ parser.add_argument(
     "Recommended in combination with -m.",
 )
 parser.add_argument(
+    "-t",
+    "--temporary",
+    dest="temp",
+    action="store_true",
+    help="Use a temporary file to store the output from make. "
+    "Requires -w."
+)
+parser.add_argument(
     "-3",
     "--threeway=prev",
     dest="threeway",
@@ -407,12 +415,12 @@ def run_make(target: str) -> None:
     subprocess.check_call(["make"] + makeflags + [target])
 
 
-def run_make_capture_output(target: str, stdout: tempfile.TemporaryFile, stderr: tempfile.TemporaryFile) -> "subprocess.CompletedProcess[bytes]":
+def run_make_capture_output(target: str, stdout: tempfile.TemporaryFile = None, stderr: tempfile.TemporaryFile = None) -> "subprocess.CompletedProcess[bytes]":
     target = target.replace("\\", "/")
     return subprocess.run(
         ["make"] + makeflags + [target],
-        stdout=stdout,
-        stderr=stderr,
+        stdout=stdout or subprocess.PIPE,
+        stderr=stderr or subprocess.PIPE,
     )
 
 
@@ -1726,22 +1734,32 @@ def main() -> None:
                 last_build = time.time()
                 if args.make:
                     display.progress("Building...")
-
-                    # Temp files for stdout and stderr
-                    stdout = tempfile.TemporaryFile()
-                    stderr = tempfile.TemporaryFile()
-                    ret = run_make_capture_output(make_target, stdout, stderr)
-                    if ret.returncode != 0:
-                        stdout.seek(0)
-                        stderr.seek(0)
-                        display.update(
-                            stderr.read().decode()
-                            or stdout.read().decode("utf-8-sig", "replace"),
-                            error=True,
-                        )
-                        continue
-                    stdout.close()
-                    stderr.close()
+                    
+                    if args.temp:
+                        # Temp files for stdout and stderr
+                        stdout = tempfile.TemporaryFile()
+                        stderr = tempfile.TemporaryFile()
+                        ret = run_make_capture_output(make_target, stdout, stderr)
+                        if ret.returncode != 0:
+                            stdout.seek(0)
+                            stderr.seek(0)
+                            display.update(
+                                stderr.read().decode("utf-8-sig", "replace")
+                                or stdout.read().decode("utf-8-sig", "replace"),
+                                error=True,
+                            )
+                            continue
+                        stdout.close()
+                        stderr.close()
+                    else:
+                        ret = run_make_capture_output(make_target)
+                        if ret.returncode != 0:
+                            display.update(
+                                ret.stderr.decode("utf-8-sig", "replace")
+                                or ret.stdout.decode("utf-8-sig", "replace"),
+                                error=True,
+                            )
+                            continue
                 mydump = run_objdump(mycmd)
                 display.update(mydump, error=False)
         except KeyboardInterrupt:


### PR DESCRIPTION
On Linux python's `subprocess.run()` seems to have performance issues when capturing stderr using `subprocess.PIPE`. I've updated the script to use `TemporaryFile`s instead and this achieves performance very similar to that under Windows.

I wanted to use `StringIO` first to avoid I/O overhead but `subprocess.run()` requires that the File Object given to it implements `fileno()`. Due to this there may be a small performance hit under Windows, though likely not very noticeable.