### PR TITLE
Remove obj directory from source_directories

### DIFF
--- a/diff_settings.py
+++ b/diff_settings.py
@@ -13,6 +13,6 @@ def apply(config, args):
     config['makeflags'] = []
     if args.source:
         config['makeflags'].append('DEBUG=1')
-    config['source_directories'] = ['src', 'libs', 'include', 'obj']
+    config['source_directories'] = ['src', 'libs', 'include']
     config['arch'] = 'ppc'
     config['objdump_executable'] = f"{os.environ['DEVKITPPC']}/bin/powerpc-eabi-objdump"


### PR DESCRIPTION
Removing this directory solves two issues:
The first and most important is it prevents infinitely building the file whenthere's
 an error.

Secondly it fixes the relatively minor issue of calling make twice for every rebuild