### PR TITLE
Cruise bubble state type virtuals

### DIFF
--- a/asm/Game/zEntCruiseBubble.s
+++ b/asm/Game/zEntCruiseBubble.s
@@ -6746,7 +6746,10 @@ lbl_8005EEB8:
 /* 8005EED0 0005BCD0  4E 80 00 20 */	blr 
 
 /* refresh_missle_alpha__Q313cruise_bubble30@unnamed@zEntCruiseBubble_cpp@18state_camera_seizeFf */
-refresh_missle_alpha__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18state_camera_seizeFf:
+/* changed from ... */
+/* refresh_missle_alpha__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18state_camera_seizeFf: */
+/* ... so linker can find it */
+refresh_missle_alpha__Q213cruise_bubble18state_camera_seizeFf:
 /* 8005EED4 0005BCD4  94 21 FF F0 */	stwu r1, -0x10(r1)
 /* 8005EED8 0005BCD8  7C 08 02 A6 */	mflr r0
 /* 8005EEDC 0005BCDC  90 01 00 14 */	stw r0, 0x14(r1)
@@ -6790,7 +6793,10 @@ lbl_8005EF5C:
 /* 8005EF68 0005BD68  4E 80 00 20 */	blr 
 
 /* update_turn__Q313cruise_bubble30@unnamed@zEntCruiseBubble_cpp@18state_camera_seizeFf */
-update_turn__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18state_camera_seizeFf:
+/* changed from ... */
+/* update_turn__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18state_camera_seizeFf: */
+/* ... so linker can find it */
+update_turn__Q213cruise_bubble18state_camera_seizeFf:
 /* 8005EF6C 0005BD6C  94 21 FF B0 */	stwu r1, -0x50(r1)
 /* 8005EF70 0005BD70  7C 08 02 A6 */	mflr r0
 /* 8005EF74 0005BD74  90 01 00 54 */	stw r0, 0x54(r1)
@@ -6854,7 +6860,10 @@ lbl_8005F03C:
 /* 8005F054 0005BE54  4E 80 00 20 */	blr 
 
 /* update_move__Q313cruise_bubble30@unnamed@zEntCruiseBubble_cpp@18state_camera_seizeFf */
-update_move__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18state_camera_seizeFf:
+/* changed from ... */
+/* update_move__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18state_camera_seizeFf: */
+/* ... so linker can find it */
+update_move__Q213cruise_bubble18state_camera_seizeFf:
 /* 8005F058 0005BE58  94 21 FF A0 */	stwu r1, -0x60(r1)
 /* 8005F05C 0005BE5C  7C 08 02 A6 */	mflr r0
 /* 8005F060 0005BE60  90 01 00 64 */	stw r0, 0x64(r1)

--- a/asm/Game/zEntCruiseBubble.s
+++ b/asm/Game/zEntCruiseBubble.s
@@ -7202,7 +7202,10 @@ lbl_8005F4E4:
 /* 8005F4F4 0005C2F4  4E 80 00 20 */	blr 
 
 /* move__Q313cruise_bubble30@unnamed@zEntCruiseBubble_cpp@19state_camera_surveyFv */
-move__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_19state_camera_surveyFv:
+/* changed from ... */
+/* move__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_19state_camera_surveyFv: */
+/* ... so linker can find it */
+move__Q213cruise_bubble19state_camera_surveyFv:
 /* 8005F4F8 0005C2F8  94 21 FF A0 */	stwu r1, -0x60(r1)
 /* 8005F4FC 0005C2FC  7C 08 02 A6 */	mflr r0
 /* 8005F500 0005C300  90 01 00 64 */	stw r0, 0x64(r1)
@@ -7266,7 +7269,10 @@ move__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_19st
 /* 8005F5E8 0005C3E8  4E 80 00 20 */	blr 
 
 /* eval_missle_path__Q313cruise_bubble30@unnamed@zEntCruiseBubble_cpp@19state_camera_surveyCFfR5xVec3Rf */
-eval_missle_path__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_19state_camera_surveyCFfR5xVec3Rf:
+/* changed from ... */
+/* eval_missle_path__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_19state_camera_surveyCFfR5xVec3Rf: */
+/* ... so linker can find it */
+eval_missle_path__Q213cruise_bubble19state_camera_surveyCFfR5xVec3Rf:
 /* 8005F5EC 0005C3EC  94 21 FF D0 */	stwu r1, -0x30(r1)
 /* 8005F5F0 0005C3F0  7C 08 02 A6 */	mflr r0
 /* 8005F5F4 0005C3F4  90 01 00 34 */	stw r0, 0x34(r1)
@@ -7347,14 +7353,20 @@ lbl_8005F6F8:
 /* 8005F710 0005C510  4E 80 00 20 */	blr 
 
 /* lerp__Q313cruise_bubble30@unnamed@zEntCruiseBubble_cpp@19state_camera_surveyCFRffff */
-lerp__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_19state_camera_surveyCFRffff:
+/* changed from ... */
+/* lerp__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_19state_camera_surveyCFRffff: */
+/* ... so linker can find it */
+lerp__Q213cruise_bubble19state_camera_surveyCFRffff:
 /* 8005F714 0005C514  EC 03 10 28 */	fsubs f0, f3, f2
 /* 8005F718 0005C518  EC 01 10 3A */	fmadds f0, f1, f0, f2
 /* 8005F71C 0005C51C  D0 04 00 00 */	stfs f0, 0(r4)
 /* 8005F720 0005C520  4E 80 00 20 */	blr 
 
 /* lerp__Q313cruise_bubble30@unnamed@zEntCruiseBubble_cpp@19state_camera_surveyCFR5xVec3fRC5xVec3RC5xVec3 */
-lerp__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_19state_camera_surveyCFR5xVec3fRC5xVec3RC5xVec3:
+/* changed from ... */
+/* lerp__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_19state_camera_surveyCFR5xVec3fRC5xVec3RC5xVec3: */
+/* ... so linker can find it */
+lerp__Q213cruise_bubble19state_camera_surveyCFR5xVec3fRC5xVec3RC5xVec3:
 /* 8005F724 0005C524  94 21 FF D0 */	stwu r1, -0x30(r1)
 /* 8005F728 0005C528  7C 08 02 A6 */	mflr r0
 /* 8005F72C 0005C52C  90 01 00 34 */	stw r0, 0x34(r1)
@@ -7396,7 +7408,10 @@ lerp__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_19st
 /* 8005F7BC 0005C5BC  4E 80 00 20 */	blr 
 
 /* find_nearest__Q313cruise_bubble30@unnamed@zEntCruiseBubble_cpp@19state_camera_surveyCFf */
-find_nearest__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_19state_camera_surveyCFf:
+/* changed from ... */
+/* find_nearest__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_19state_camera_surveyCFf: */
+/* ... so linker can find it */
+find_nearest__Q213cruise_bubble19state_camera_surveyCFf:
 /* 8005F7C0 0005C5C0  94 21 FF E0 */	stwu r1, -0x20(r1)
 /* 8005F7C4 0005C5C4  7C 08 02 A6 */	mflr r0
 /* 8005F7C8 0005C5C8  90 01 00 24 */	stw r0, 0x24(r1)
@@ -7472,7 +7487,10 @@ lbl_8005F8B4:
 /* 8005F8C0 0005C6C0  4E 80 00 20 */	blr 
 
 /* init_path__Q313cruise_bubble30@unnamed@zEntCruiseBubble_cpp@19state_camera_surveyFv */
-init_path__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_19state_camera_surveyFv:
+/* changed from ... */
+/* init_path__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_19state_camera_surveyFv: */
+/* ... so linker can find it */
+init_path__Q213cruise_bubble19state_camera_surveyFv:
 /* 8005F8C4 0005C6C4  94 21 FF B0 */	stwu r1, -0x50(r1)
 /* 8005F8C8 0005C6C8  7C 08 02 A6 */	mflr r0
 /* 8005F8CC 0005C6CC  90 01 00 54 */	stw r0, 0x54(r1)
@@ -7602,7 +7620,10 @@ lbl_8005FA80:
 /* 8005FA90 0005C890  4E 80 00 20 */	blr 
 
 /* control_jerked__Q313cruise_bubble30@unnamed@zEntCruiseBubble_cpp@19state_camera_surveyCFv */
-control_jerked__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_19state_camera_surveyCFv:
+/* changed from ... */
+/* control_jerked__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_19state_camera_surveyCFv: */
+/* ... so linker can find it */
+control_jerked__Q213cruise_bubble19state_camera_surveyCFv:
 /* 8005FA94 0005C894  94 21 FF C0 */	stwu r1, -0x40(r1)
 /* 8005FA98 0005C898  7C 08 02 A6 */	mflr r0
 /* 8005FA9C 0005C89C  90 01 00 44 */	stw r0, 0x44(r1)

--- a/asm/Game/zEntCruiseBubble.s
+++ b/asm/Game/zEntCruiseBubble.s
@@ -4599,16 +4599,16 @@ start__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16s
 /* 8005CFFC 00059DFC  C0 02 89 B8 */	lfs f0, zEntCruiseBubble_f_0_0-_SDA2_BASE_(r2)
 /* 8005D000 00059E00  D0 1F 00 38 */	stfs f0, 0x38(r31)
 /* 8005D004 00059E04  4B FA E2 61 */	bl __as__5xVec3FRC5xVec3
-/* 8005D008 00059E08  3C 60 80 2E */	lis r3, lbl_802DBE30@ha
-/* 8005D00C 00059E0C  38 63 BE 30 */	addi r3, r3, lbl_802DBE30@l
+/* 8005D008 00059E08  3C 60 80 2E */	lis r3, missle_record__13cruise_bubble@ha
+/* 8005D00C 00059E0C  38 63 BE 30 */	addi r3, r3, missle_record__13cruise_bubble@l
 /* 8005D010 00059E10  48 00 34 55 */	bl reset__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data_esc__4_127_esc__1_Fv
 /* 8005D014 00059E14  C0 3F 00 18 */	lfs f1, 0x18(r31)
 /* 8005D018 00059E18  38 61 00 18 */	addi r3, r1, 0x18
 /* 8005D01C 00059E1C  38 9F 00 2C */	addi r4, r31, 0x2c
 /* 8005D020 00059E20  48 00 00 6D */	bl __ct__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_dataFRC5xVec3f
-/* 8005D024 00059E24  3C A0 80 2E */	lis r5, lbl_802DBE30@ha
+/* 8005D024 00059E24  3C A0 80 2E */	lis r5, missle_record__13cruise_bubble@ha
 /* 8005D028 00059E28  7C 64 1B 78 */	mr r4, r3
-/* 8005D02C 00059E2C  38 65 BE 30 */	addi r3, r5, lbl_802DBE30@l
+/* 8005D02C 00059E2C  38 65 BE 30 */	addi r3, r5, missle_record__13cruise_bubble@l
 /* 8005D030 00059E30  48 00 33 29 */	bl push_front__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data_esc__4_127_esc__1_FRCQ313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data
 /* 8005D034 00059E34  4B FF FC 3D */	bl get_missle_mat__Q213cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_Fv
 /* 8005D038 00059E38  7C 64 1B 78 */	mr r4, r3
@@ -4616,9 +4616,9 @@ start__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16s
 /* 8005D040 00059E40  38 61 00 08 */	addi r3, r1, 8
 /* 8005D044 00059E44  38 84 00 30 */	addi r4, r4, 0x30
 /* 8005D048 00059E48  48 00 00 45 */	bl __ct__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_dataFRC5xVec3f
-/* 8005D04C 00059E4C  3C A0 80 2E */	lis r5, lbl_802DBE30@ha
+/* 8005D04C 00059E4C  3C A0 80 2E */	lis r5, missle_record__13cruise_bubble@ha
 /* 8005D050 00059E50  7C 64 1B 78 */	mr r4, r3
-/* 8005D054 00059E54  38 65 BE 30 */	addi r3, r5, lbl_802DBE30@l
+/* 8005D054 00059E54  38 65 BE 30 */	addi r3, r5, missle_record__13cruise_bubble@l
 /* 8005D058 00059E58  48 00 33 01 */	bl push_front__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data_esc__4_127_esc__1_FRCQ313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data
 /* 8005D05C 00059E5C  4B FF FC 15 */	bl get_missle_mat__Q213cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_Fv
 /* 8005D060 00059E60  C0 22 89 C0 */	lfs f1, zEntCruiseBubble_f_1_0-_SDA2_BASE_(r2)
@@ -4648,7 +4648,7 @@ stop__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16st
 /* 8005D0D8 00059ED8  4B FF A1 AD */	bl stop_sound__Q213cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_FiUi
 /* 8005D0DC 00059EDC  38 60 02 04 */	li r3, 0x204
 /* 8005D0E0 00059EE0  4B FF AB 11 */	bl signal_event__Q213cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_FUi
-/* 8005D0E4 00059EE4  C0 22 89 BC */	lfs f1, lbl_803CD33C-_SDA2_BASE_(r2)
+/* 8005D0E4 00059EE4  C0 22 89 BC */	lfs f1, zEntCruiseBubble_f_1_0e38-_SDA2_BASE_(r2)
 /* 8005D0E8 00059EE8  38 61 00 14 */	addi r3, r1, 0x14
 /* 8005D0EC 00059EEC  4B FB F7 8D */	bl __as__5xVec3Ff
 /* 8005D0F0 00059EF0  C0 22 89 B8 */	lfs f1, zEntCruiseBubble_f_0_0-_SDA2_BASE_(r2)
@@ -4675,7 +4675,7 @@ abort__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16s
 /* 8005D13C 00059F3C  4B FF A1 49 */	bl stop_sound__Q213cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_FiUi
 /* 8005D140 00059F40  38 60 02 04 */	li r3, 0x204
 /* 8005D144 00059F44  4B FF AA AD */	bl signal_event__Q213cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_FUi
-/* 8005D148 00059F48  C0 22 89 BC */	lfs f1, lbl_803CD33C-_SDA2_BASE_(r2)
+/* 8005D148 00059F48  C0 22 89 BC */	lfs f1, zEntCruiseBubble_f_1_0e38-_SDA2_BASE_(r2)
 /* 8005D14C 00059F4C  38 61 00 14 */	addi r3, r1, 0x14
 /* 8005D150 00059F50  4B FB F7 29 */	bl __as__5xVec3Ff
 /* 8005D154 00059F54  C0 22 89 B8 */	lfs f1, zEntCruiseBubble_f_0_0-_SDA2_BASE_(r2)
@@ -4738,13 +4738,13 @@ lbl_8005D224:
 /* 8005D228 0005A028  FC 20 F8 90 */	fmr f1, f31
 /* 8005D22C 0005A02C  7F E3 FB 78 */	mr r3, r31
 /* 8005D230 0005A030  48 00 06 F9 */	bl update_move__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16state_missle_flyFf
-/* 8005D234 0005A034  3C 60 80 2E */	lis r3, lbl_802DBE30@ha
-/* 8005D238 0005A038  38 63 BE 30 */	addi r3, r3, lbl_802DBE30@l
+/* 8005D234 0005A034  3C 60 80 2E */	lis r3, missle_record__13cruise_bubble@ha
+/* 8005D238 0005A038  38 63 BE 30 */	addi r3, r3, missle_record__13cruise_bubble@l
 /* 8005D23C 0005A03C  48 00 32 6D */	bl full__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data_esc__4_127_esc__1_CFv
 /* 8005D240 0005A040  54 60 06 3F */	clrlwi. r0, r3, 0x18
 /* 8005D244 0005A044  41 82 00 10 */	beq lbl_8005D254
-/* 8005D248 0005A048  3C 60 80 2E */	lis r3, lbl_802DBE30@ha
-/* 8005D24C 0005A04C  38 63 BE 30 */	addi r3, r3, lbl_802DBE30@l
+/* 8005D248 0005A048  3C 60 80 2E */	lis r3, missle_record__13cruise_bubble@ha
+/* 8005D24C 0005A04C  38 63 BE 30 */	addi r3, r3, missle_record__13cruise_bubble@l
 /* 8005D250 0005A050  48 00 32 45 */	bl pop_back__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data_esc__4_127_esc__1_Fv
 lbl_8005D254:
 /* 8005D254 0005A054  7F E3 FB 78 */	mr r3, r31
@@ -4762,9 +4762,9 @@ lbl_8005D274:
 /* 8005D280 0005A080  38 61 00 18 */	addi r3, r1, 0x18
 /* 8005D284 0005A084  38 84 00 50 */	addi r4, r4, 0x50
 /* 8005D288 0005A088  4B FF FE 05 */	bl __ct__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_dataFRC5xVec3f
-/* 8005D28C 0005A08C  3C A0 80 2E */	lis r5, lbl_802DBE30@ha
+/* 8005D28C 0005A08C  3C A0 80 2E */	lis r5, missle_record__13cruise_bubble@ha
 /* 8005D290 0005A090  7C 64 1B 78 */	mr r4, r3
-/* 8005D294 0005A094  38 65 BE 30 */	addi r3, r5, lbl_802DBE30@l
+/* 8005D294 0005A094  38 65 BE 30 */	addi r3, r5, missle_record__13cruise_bubble@l
 /* 8005D298 0005A098  48 00 30 C1 */	bl push_front__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data_esc__4_127_esc__1_FRCQ313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data
 /* 8005D29C 0005A09C  38 60 00 06 */	li r3, 6
 /* 8005D2A0 0005A0A0  48 00 00 94 */	b lbl_8005D334
@@ -4775,9 +4775,9 @@ lbl_8005D2A4:
 /* 8005D2B0 0005A0B0  38 61 00 08 */	addi r3, r1, 8
 /* 8005D2B4 0005A0B4  38 84 00 30 */	addi r4, r4, 0x30
 /* 8005D2B8 0005A0B8  4B FF FD D5 */	bl __ct__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_dataFRC5xVec3f
-/* 8005D2BC 0005A0BC  3C A0 80 2E */	lis r5, lbl_802DBE30@ha
+/* 8005D2BC 0005A0BC  3C A0 80 2E */	lis r5, missle_record__13cruise_bubble@ha
 /* 8005D2C0 0005A0C0  7C 64 1B 78 */	mr r4, r3
-/* 8005D2C4 0005A0C4  38 65 BE 30 */	addi r3, r5, lbl_802DBE30@l
+/* 8005D2C4 0005A0C4  38 65 BE 30 */	addi r3, r5, missle_record__13cruise_bubble@l
 /* 8005D2C8 0005A0C8  48 00 30 91 */	bl push_front__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data_esc__4_127_esc__1_FRCQ313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data
 /* 8005D2CC 0005A0CC  4B FF F9 A5 */	bl get_missle_mat__Q213cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_Fv
 /* 8005D2D0 0005A0D0  7C 64 1B 78 */	mr r4, r3
@@ -4847,7 +4847,10 @@ update_engine_sound__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_
 /* 8005D444 0005A244  4E 80 00 20 */	blr 
 
 /* collide_hazards__Q313cruise_bubble30@unnamed@zEntCruiseBubble_cpp@16state_missle_flyFv */
-collide_hazards__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16state_missle_flyFv:
+/* changed from ... */
+/* collide_hazards__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16state_missle_flyFv: */
+/* ... so linker can find it */
+collide_hazards__Q213cruise_bubble16state_missle_flyFv:
 /* 8005D448 0005A248  94 21 FF F0 */	stwu r1, -0x10(r1)
 /* 8005D44C 0005A24C  7C 08 02 A6 */	mflr r0
 /* 8005D450 0005A250  3C 60 80 06 */	lis r3, hazard_check__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16state_missle_flyFR9NPCHazardPv@ha
@@ -4884,7 +4887,10 @@ lbl_8005D4B8:
 /* 8005D4C0 0005A2C0  38 21 00 10 */	addi r1, r1, 0x10
 /* 8005D4C4 0005A2C4  4E 80 00 20 */	blr 
 
-hazard_check__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16state_missle_flyFR9NPCHazardPv:
+/* changed from ... */
+/* hazard_check__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16state_missle_flyFR9NPCHazardPv: */
+/* ... so linker can find it */
+hazard_check__Q213cruise_bubble16state_missle_flyFR9NPCHazardPv:
 /* 8005D4C8 0005A2C8  94 21 FF C0 */	stwu r1, -0x40(r1)
 /* 8005D4CC 0005A2CC  7C 08 02 A6 */	mflr r0
 /* 8005D4D0 0005A2D0  90 01 00 44 */	stw r0, 0x44(r1)
@@ -4930,7 +4936,10 @@ lbl_8005D54C:
 /* 8005D568 0005A368  4E 80 00 20 */	blr 
 
 /* collide__Q313cruise_bubble30@unnamed@zEntCruiseBubble_cpp@16state_missle_flyFv */
-collide__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16state_missle_flyFv:
+/* changed from ... */
+/* collide__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16state_missle_flyFv: */
+/* ... so linker can find it */
+collide__Q213cruise_bubble16state_missle_flyFv:
 /* 8005D56C 0005A36C  94 21 FF 90 */	stwu r1, -0x70(r1)
 /* 8005D570 0005A370  7C 08 02 A6 */	mflr r0
 /* 8005D574 0005A374  90 01 00 74 */	stw r0, 0x74(r1)
@@ -5096,7 +5105,10 @@ lbl_8005D7B8:
 /* 8005D7D0 0005A5D0  4E 80 00 20 */	blr 
 
 /* hit_test__Q313cruise_bubble30@unnamed@zEntCruiseBubble_cpp@16state_missle_flyCFR5xVec3R5xVec3R5xVec3RP4xEnt */
-hit_test__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16state_missle_flyCFR5xVec3R5xVec3R5xVec3RP4xEnt:
+/* changed from ... */
+/* hit_test__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16state_missle_flyCFR5xVec3R5xVec3R5xVec3RP4xEnt: */
+/* ... so linker can find it */
+hit_test__Q213cruise_bubble16state_missle_flyCFR5xVec3R5xVec3R5xVec3RP4xEnt:
 /* 8005D7D4 0005A5D4  94 21 FE 60 */	stwu r1, -0x1a0(r1)
 /* 8005D7D8 0005A5D8  7C 08 02 A6 */	mflr r0
 /* 8005D7DC 0005A5DC  3D 00 80 3C */	lis r8, globals@ha
@@ -5186,7 +5198,10 @@ lbl_8005D914:
 /* 8005D924 0005A724  4E 80 00 20 */	blr 
 
 /* update_move__Q313cruise_bubble30@unnamed@zEntCruiseBubble_cpp@16state_missle_flyFf */
-update_move__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16state_missle_flyFf:
+/* changed from ... */
+/* update_move__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16state_missle_flyFf: */
+/* ... so linker can find it */
+update_move__Q213cruise_bubble16state_missle_flyFf:
 /* 8005D928 0005A728  94 21 FF E0 */	stwu r1, -0x20(r1)
 /* 8005D92C 0005A72C  7C 08 02 A6 */	mflr r0
 /* 8005D930 0005A730  7C 65 1B 78 */	mr r5, r3
@@ -5217,7 +5232,10 @@ update_move__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc_
 /* 8005D994 0005A794  4E 80 00 20 */	blr 
 
 /* update_turn__Q313cruise_bubble30@unnamed@zEntCruiseBubble_cpp@16state_missle_flyFf */
-update_turn__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16state_missle_flyFf:
+/* changed from ... */
+/* update_turn__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16state_missle_flyFf: */
+/* ... so linker can find it */
+update_turn__Q213cruise_bubble16state_missle_flyFf:
 /* 8005D998 0005A798  94 21 FF 60 */	stwu r1, -0xa0(r1)
 /* 8005D99C 0005A79C  7C 08 02 A6 */	mflr r0
 /* 8005D9A0 0005A7A0  90 01 00 A4 */	stw r0, 0xa4(r1)
@@ -5351,7 +5369,10 @@ lbl_8005DB44:
 /* 8005DB94 0005A994  4E 80 00 20 */	blr 
 
 /* calculate_rotation__Q313cruise_bubble30@unnamed@zEntCruiseBubble_cpp@16state_missle_flyCFR5xVec2R5xVec2fRC5xVec2RC5xVec2RC5xVec2RC5xVec2 */
-calculate_rotation__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16state_missle_flyCFR5xVec2R5xVec2fRC5xVec2RC5xVec2RC5xVec2RC5xVec2:
+/* changed from ... */
+/* calculate_rotation__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16state_missle_flyCFR5xVec2R5xVec2fRC5xVec2RC5xVec2RC5xVec2RC5xVec2: */
+/* ... so linker can find it */
+calculate_rotation__Q213cruise_bubble16state_missle_flyCFR5xVec2R5xVec2fRC5xVec2RC5xVec2RC5xVec2RC5xVec2:
 /* 8005DB98 0005A998  C0 08 00 00 */	lfs f0, 0(r8)
 /* 8005DB9C 0005A99C  C1 69 00 00 */	lfs f11, 0(r9)
 /* 8005DBA0 0005A9A0  C0 A7 00 00 */	lfs f5, 0(r7)
@@ -7196,23 +7217,23 @@ eval_missle_path__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp
 /* 8005F620 0005C420  3B 9C 00 01 */	addi r28, r28, 1
 /* 8005F624 0005C424  48 00 00 28 */	b lbl_8005F64C
 lbl_8005F628:
-/* 8005F628 0005C428  3C 60 80 2E */	lis r3, lbl_802DBE30@ha
-/* 8005F62C 0005C42C  38 63 BE 30 */	addi r3, r3, lbl_802DBE30@l
+/* 8005F628 0005C428  3C 60 80 2E */	lis r3, missle_record__13cruise_bubble@ha
+/* 8005F62C 0005C42C  38 63 BE 30 */	addi r3, r3, missle_record__13cruise_bubble@l
 /* 8005F630 0005C430  48 00 0E CD */	bl size__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data_esc__4_127_esc__1_CFv
 /* 8005F634 0005C434  7C 1C 18 00 */	cmpw r28, r3
 /* 8005F638 0005C438  41 80 00 14 */	blt lbl_8005F64C
-/* 8005F63C 0005C43C  3C 60 80 2E */	lis r3, lbl_802DBE30@ha
-/* 8005F640 0005C440  38 63 BE 30 */	addi r3, r3, lbl_802DBE30@l
+/* 8005F63C 0005C43C  3C 60 80 2E */	lis r3, missle_record__13cruise_bubble@ha
+/* 8005F640 0005C440  38 63 BE 30 */	addi r3, r3, missle_record__13cruise_bubble@l
 /* 8005F644 0005C444  48 00 0E B9 */	bl size__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data_esc__4_127_esc__1_CFv
 /* 8005F648 0005C448  3B 83 FF FF */	addi r28, r3, -1
 lbl_8005F64C:
-/* 8005F64C 0005C44C  3C 60 80 2E */	lis r3, lbl_802DBE30@ha
+/* 8005F64C 0005C44C  3C 60 80 2E */	lis r3, missle_record__13cruise_bubble@ha
 /* 8005F650 0005C450  38 9C FF FF */	addi r4, r28, -1
-/* 8005F654 0005C454  38 63 BE 30 */	addi r3, r3, lbl_802DBE30@l
+/* 8005F654 0005C454  38 63 BE 30 */	addi r3, r3, missle_record__13cruise_bubble@l
 /* 8005F658 0005C458  48 00 0E BD */	bl __vc__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data_esc__4_127_esc__1_Fi
-/* 8005F65C 0005C45C  3C 80 80 2E */	lis r4, lbl_802DBE30@ha
+/* 8005F65C 0005C45C  3C 80 80 2E */	lis r4, missle_record__13cruise_bubble@ha
 /* 8005F660 0005C460  7C 7B 1B 78 */	mr r27, r3
-/* 8005F664 0005C464  38 04 BE 30 */	addi r0, r4, lbl_802DBE30@l
+/* 8005F664 0005C464  38 04 BE 30 */	addi r0, r4, missle_record__13cruise_bubble@l
 /* 8005F668 0005C468  7F 84 E3 78 */	mr r4, r28
 /* 8005F66C 0005C46C  7C 03 03 78 */	mr r3, r0
 /* 8005F670 0005C470  48 00 0E A5 */	bl __vc__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data_esc__4_127_esc__1_Fi
@@ -7317,9 +7338,9 @@ find_nearest__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc
 /* 8005F7D0 0005C5D0  F3 E1 00 18 */	psq_st f31, 24(r1), 0, qr0
 /* 8005F7D4 0005C5D4  93 E1 00 0C */	stw r31, 0xc(r1)
 /* 8005F7D8 0005C5D8  93 C1 00 08 */	stw r30, 8(r1)
-/* 8005F7DC 0005C5DC  3C 80 80 2E */	lis r4, lbl_802DBE30@ha
+/* 8005F7DC 0005C5DC  3C 80 80 2E */	lis r4, missle_record__13cruise_bubble@ha
 /* 8005F7E0 0005C5E0  FF E0 08 90 */	fmr f31, f1
-/* 8005F7E4 0005C5E4  38 04 BE 30 */	addi r0, r4, lbl_802DBE30@l
+/* 8005F7E4 0005C5E4  38 04 BE 30 */	addi r0, r4, missle_record__13cruise_bubble@l
 /* 8005F7E8 0005C5E8  7C 7E 1B 78 */	mr r30, r3
 /* 8005F7EC 0005C5EC  7C 03 03 78 */	mr r3, r0
 /* 8005F7F0 0005C5F0  3B E0 00 00 */	li r31, 0
@@ -7393,15 +7414,15 @@ init_path__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2
 /* 8005F8D4 0005C6D4  F3 E1 00 48 */	psq_st f31, 72(r1), 0, qr0
 /* 8005F8D8 0005C6D8  93 E1 00 3C */	stw r31, 0x3c(r1)
 /* 8005F8DC 0005C6DC  93 C1 00 38 */	stw r30, 0x38(r1)
-/* 8005F8E0 0005C6E0  3C 80 80 2E */	lis r4, lbl_802DBE30@ha
+/* 8005F8E0 0005C6E0  3C 80 80 2E */	lis r4, missle_record__13cruise_bubble@ha
 /* 8005F8E4 0005C6E4  C3 E2 89 B8 */	lfs f31, zEntCruiseBubble_f_0_0-_SDA2_BASE_(r2)
-/* 8005F8E8 0005C6E8  38 04 BE 30 */	addi r0, r4, lbl_802DBE30@l
+/* 8005F8E8 0005C6E8  38 04 BE 30 */	addi r0, r4, missle_record__13cruise_bubble@l
 /* 8005F8EC 0005C6EC  7C 7E 1B 78 */	mr r30, r3
 /* 8005F8F0 0005C6F0  7C 03 03 78 */	mr r3, r0
 /* 8005F8F4 0005C6F4  48 00 0B 19 */	bl begin__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data_esc__4_127_esc__1_CFv
-/* 8005F8F8 0005C6F8  3C A0 80 2E */	lis r5, lbl_802DBE30@ha
+/* 8005F8F8 0005C6F8  3C A0 80 2E */	lis r5, missle_record__13cruise_bubble@ha
 /* 8005F8FC 0005C6FC  90 81 00 14 */	stw r4, 0x14(r1)
-/* 8005F900 0005C700  38 05 BE 30 */	addi r0, r5, lbl_802DBE30@l
+/* 8005F900 0005C700  38 05 BE 30 */	addi r0, r5, missle_record__13cruise_bubble@l
 /* 8005F904 0005C704  90 61 00 10 */	stw r3, 0x10(r1)
 /* 8005F908 0005C708  7C 03 03 78 */	mr r3, r0
 /* 8005F90C 0005C70C  48 00 0C D1 */	bl end__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data_esc__4_127_esc__1_CFv
@@ -7772,9 +7793,9 @@ lbl_8005FE08:
 __sinit_zEntCruiseBubble_cpp:
 /* 8005FE1C 0005CC1C  94 21 FF F0 */	stwu r1, -0x10(r1)
 /* 8005FE20 0005CC20  7C 08 02 A6 */	mflr r0
-/* 8005FE24 0005CC24  3C 60 80 2E */	lis r3, lbl_802DBE30@ha
+/* 8005FE24 0005CC24  3C 60 80 2E */	lis r3, missle_record__13cruise_bubble@ha
 /* 8005FE28 0005CC28  90 01 00 14 */	stw r0, 0x14(r1)
-/* 8005FE2C 0005CC2C  38 63 BE 30 */	addi r3, r3, lbl_802DBE30@l
+/* 8005FE2C 0005CC2C  38 63 BE 30 */	addi r3, r3, missle_record__13cruise_bubble@l
 /* 8005FE30 0005CC30  48 00 00 15 */	bl __ct__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data_esc__4_127_esc__1_Fv
 /* 8005FE34 0005CC34  80 01 00 14 */	lwz r0, 0x14(r1)
 /* 8005FE38 0005CC38  7C 08 03 A6 */	mtlr r0
@@ -7782,8 +7803,11 @@ __sinit_zEntCruiseBubble_cpp:
 /* 8005FE40 0005CC40  4E 80 00 20 */	blr 
 
 /* __ct__86fixed_queue<Q313cruise_bubble30@unnamed@zEntCruiseBubble_cpp@18missle_record_data,127>Fv */
-.global __ct__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data_esc__4_127_esc__1_Fv
-__ct__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data_esc__4_127_esc__1_Fv:
+.global __ct__54fixed_queue_esc__0_Q213cruise_bubble18missle_record_data_esc__4_127_esc__1_Fv:
+/* changed from ... */
+/* __ct__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data_esc__4_127_esc__1_Fv: */
+/* ... so linker can find it */
+__ct__54fixed_queue_esc__0_Q213cruise_bubble18missle_record_data_esc__4_127_esc__1_Fv:
 /* 8005FE44 0005CC44  94 21 FF F0 */	stwu r1, -0x10(r1)
 /* 8005FE48 0005CC48  7C 08 02 A6 */	mflr r0
 /* 8005FE4C 0005CC4C  3C 80 80 06 */	lis r4, __ct__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_dataFv@ha
@@ -8148,8 +8172,11 @@ lbl_80060320:
 /* 80060354 0005D154  4E 80 00 20 */	blr 
 
 /* push_front__86fixed_queue<Q313cruise_bubble30@unnamed@zEntCruiseBubble_cpp@18missle_record_data,127>FRCQ313cruise_bubble30@unnamed@zEntCruiseBubble_cpp@18missle_record_data */
-.global push_front__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data_esc__4_127_esc__1_FRCQ313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data
-push_front__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data_esc__4_127_esc__1_FRCQ313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data:
+.global push_front__54fixed_queue_esc__0_Q213cruise_bubble18missle_record_data_esc__4_127_esc__1_FRCQ213cruise_bubble18missle_record_data:
+/* changed from ... */
+/* push_front__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data_esc__4_127_esc__1_FRCQ313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data: */
+/* ... so linker can find it */
+push_front__54fixed_queue_esc__0_Q213cruise_bubble18missle_record_data_esc__4_127_esc__1_FRCQ213cruise_bubble18missle_record_data:
 /* 80060358 0005D158  94 21 FF F0 */	stwu r1, -0x10(r1)
 /* 8006035C 0005D15C  7C 08 02 A6 */	mflr r0
 /* 80060360 0005D160  90 01 00 14 */	stw r0, 0x14(r1)
@@ -8182,8 +8209,11 @@ __as__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18mi
 /* 800603C0 0005D1C0  4E 80 00 20 */	blr 
 
 /* front__86fixed_queue<Q313cruise_bubble30@unnamed@zEntCruiseBubble_cpp@18missle_record_data,127>Fv */
-.global front__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data_esc__4_127_esc__1_Fv
-front__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data_esc__4_127_esc__1_Fv:
+.global front__54fixed_queue_esc__0_Q213cruise_bubble18missle_record_data_esc__4_127_esc__1_Fv:
+/* changed from ... */
+/* front__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data_esc__4_127_esc__1_Fv: */
+/* ... so linker can find it */
+front__54fixed_queue_esc__0_Q213cruise_bubble18missle_record_data_esc__4_127_esc__1_Fv:
 /* 800603C4 0005D1C4  94 21 FF F0 */	stwu r1, -0x10(r1)
 /* 800603C8 0005D1C8  7C 08 02 A6 */	mflr r0
 /* 800603CC 0005D1CC  90 01 00 14 */	stw r0, 0x14(r1)
@@ -8208,8 +8238,11 @@ __ml__Q286fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruis
 /* 80060408 0005D208  4E 80 00 20 */	blr 
 
 /* begin__86fixed_queue<Q313cruise_bubble30@unnamed@zEntCruiseBubble_cpp@18missle_record_data,127>CFv */
-.global begin__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data_esc__4_127_esc__1_CFv
-begin__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data_esc__4_127_esc__1_CFv:
+.global begin__54fixed_queue_esc__0_Q213cruise_bubble18missle_record_data_esc__4_127_esc__1_CFv:
+/* changed from ... */
+/* begin__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data_esc__4_127_esc__1_CFv: */
+/* ... so linker can find it */
+begin__54fixed_queue_esc__0_Q213cruise_bubble18missle_record_data_esc__4_127_esc__1_CFv:
 /* 8006040C 0005D20C  94 21 FF F0 */	stwu r1, -0x10(r1)
 /* 80060410 0005D210  7C 08 02 A6 */	mflr r0
 /* 80060414 0005D214  80 83 00 00 */	lwz r4, 0(r3)
@@ -8221,8 +8254,11 @@ begin__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruise
 /* 8006042C 0005D22C  4E 80 00 20 */	blr 
 
 /* create_iterator__86fixed_queue<Q313cruise_bubble30@unnamed@zEntCruiseBubble_cpp@18missle_record_data,127>CFUl */
-.global create_iterator__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data_esc__4_127_esc__1_CFUl
-create_iterator__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data_esc__4_127_esc__1_CFUl:
+.global create_iterator__54fixed_queue_esc__0_Q213cruise_bubble18missle_record_data_esc__4_127_esc__1_CFUl:
+/* changed from ... */
+/* create_iterator__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data_esc__4_127_esc__1_CFUl: */
+/* ... so linker can find it */
+create_iterator__54fixed_queue_esc__0_Q213cruise_bubble18missle_record_data_esc__4_127_esc__1_CFUl:
 /* 80060430 0005D230  94 21 FF F0 */	stwu r1, -0x10(r1)
 /* 80060434 0005D234  7C 60 1B 78 */	mr r0, r3
 /* 80060438 0005D238  7C 83 23 78 */	mr r3, r4
@@ -8233,8 +8269,11 @@ create_iterator__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_
 /* 8006044C 0005D24C  4E 80 00 20 */	blr 
 
 /* push_front__86fixed_queue<Q313cruise_bubble30@unnamed@zEntCruiseBubble_cpp@18missle_record_data,127>Fv */
-.global push_front__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data_esc__4_127_esc__1_Fv
-push_front__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data_esc__4_127_esc__1_Fv:
+.global push_front__54fixed_queue_esc__0_Q213cruise_bubble18missle_record_data_esc__4_127_esc__1_Fv:
+/* changed from ... */
+/* push_front__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data_esc__4_127_esc__1_Fv: */
+/* ... so linker can find it */
+push_front__54fixed_queue_esc__0_Q213cruise_bubble18missle_record_data_esc__4_127_esc__1_Fv:
 /* 80060450 0005D250  80 83 00 00 */	lwz r4, 0(r3)
 /* 80060454 0005D254  38 04 00 7F */	addi r0, r4, 0x7f
 /* 80060458 0005D258  54 00 06 7E */	clrlwi r0, r0, 0x19
@@ -8242,8 +8281,11 @@ push_front__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntC
 /* 80060460 0005D260  4E 80 00 20 */	blr 
 
 /* reset__86fixed_queue<Q313cruise_bubble30@unnamed@zEntCruiseBubble_cpp@18missle_record_data,127>Fv */
-.global reset__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data_esc__4_127_esc__1_Fv
-reset__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data_esc__4_127_esc__1_Fv:
+.global reset__54fixed_queue_esc__0_Q213cruise_bubble18missle_record_data_esc__4_127_esc__1_Fv:
+/* changed from ... */
+/* reset__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data_esc__4_127_esc__1_Fv: */
+/* ... so linker can find it */
+reset__54fixed_queue_esc__0_Q213cruise_bubble18missle_record_data_esc__4_127_esc__1_Fv:
 /* 80060464 0005D264  94 21 FF F0 */	stwu r1, -0x10(r1)
 /* 80060468 0005D268  7C 08 02 A6 */	mflr r0
 /* 8006046C 0005D26C  90 01 00 14 */	stw r0, 0x14(r1)
@@ -8254,16 +8296,22 @@ reset__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruise
 /* 80060480 0005D280  4E 80 00 20 */	blr 
 
 /* clear__86fixed_queue<Q313cruise_bubble30@unnamed@zEntCruiseBubble_cpp@18missle_record_data,127>Fv */
-.global clear__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data_esc__4_127_esc__1_Fv
-clear__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data_esc__4_127_esc__1_Fv:
+.global clear__54fixed_queue_esc__0_Q213cruise_bubble18missle_record_data_esc__4_127_esc__1_Fv:
+/* changed from ... */
+/* clear__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data_esc__4_127_esc__1_Fv: */
+/* ... so linker can find it */
+clear__54fixed_queue_esc__0_Q213cruise_bubble18missle_record_data_esc__4_127_esc__1_Fv:
 /* 80060484 0005D284  38 00 00 00 */	li r0, 0
 /* 80060488 0005D288  90 03 00 04 */	stw r0, 4(r3)
 /* 8006048C 0005D28C  90 03 00 00 */	stw r0, 0(r3)
 /* 80060490 0005D290  4E 80 00 20 */	blr 
 
 /* pop_back__86fixed_queue<Q313cruise_bubble30@unnamed@zEntCruiseBubble_cpp@18missle_record_data,127>Fv */
-.global pop_back__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data_esc__4_127_esc__1_Fv
-pop_back__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data_esc__4_127_esc__1_Fv:
+.global pop_back__54fixed_queue_esc__0_Q213cruise_bubble18missle_record_data_esc__4_127_esc__1_Fv:
+/* changed from ... */
+/* pop_back__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data_esc__4_127_esc__1_Fv: */
+/* ... so linker can find it */
+pop_back__54fixed_queue_esc__0_Q213cruise_bubble18missle_record_data_esc__4_127_esc__1_Fv:
 /* 80060494 0005D294  80 83 00 04 */	lwz r4, 4(r3)
 /* 80060498 0005D298  38 04 00 7F */	addi r0, r4, 0x7f
 /* 8006049C 0005D29C  54 00 06 7E */	clrlwi r0, r0, 0x19
@@ -8271,8 +8319,11 @@ pop_back__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCru
 /* 800604A4 0005D2A4  4E 80 00 20 */	blr 
 
 /* full__86fixed_queue<Q313cruise_bubble30@unnamed@zEntCruiseBubble_cpp@18missle_record_data,127>CFv */
-.global full__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data_esc__4_127_esc__1_CFv
-full__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data_esc__4_127_esc__1_CFv:
+.global full__54fixed_queue_esc__0_Q213cruise_bubble18missle_record_data_esc__4_127_esc__1_CFv:
+/* changed from ... */
+/* full__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data_esc__4_127_esc__1_CFv: */
+/* ... so linker can find it */
+full__54fixed_queue_esc__0_Q213cruise_bubble18missle_record_data_esc__4_127_esc__1_CFv:
 /* 800604A8 0005D2A8  94 21 FF F0 */	stwu r1, -0x10(r1)
 /* 800604AC 0005D2AC  7C 08 02 A6 */	mflr r0
 /* 800604B0 0005D2B0  90 01 00 14 */	stw r0, 0x14(r1)
@@ -8294,14 +8345,20 @@ full__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseB
 /* 800604F0 0005D2F0  4E 80 00 20 */	blr 
 
 /* max_size__86fixed_queue<Q313cruise_bubble30@unnamed@zEntCruiseBubble_cpp@18missle_record_data,127>CFv */
-.global max_size__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data_esc__4_127_esc__1_CFv
-max_size__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data_esc__4_127_esc__1_CFv:
+.global max_size__54fixed_queue_esc__0_Q213cruise_bubble18missle_record_data_esc__4_127_esc__1_CFv:
+/* changed from ... */
+/* max_size__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data_esc__4_127_esc__1_CFv: */
+/* ... so linker can find it */
+max_size__54fixed_queue_esc__0_Q213cruise_bubble18missle_record_data_esc__4_127_esc__1_CFv:
 /* 800604F4 0005D2F4  38 60 00 7F */	li r3, 0x7f
 /* 800604F8 0005D2F8  4E 80 00 20 */	blr 
 
 /* size__86fixed_queue<Q313cruise_bubble30@unnamed@zEntCruiseBubble_cpp@18missle_record_data,127>CFv */
-.global size__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data_esc__4_127_esc__1_CFv
-size__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data_esc__4_127_esc__1_CFv:
+.global size__54fixed_queue_esc__0_Q213cruise_bubble18missle_record_data_esc__4_127_esc__1_CFv:
+/* changed from ... */
+/* size__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data_esc__4_127_esc__1_CFv: */
+/* ... so linker can find it */
+size__54fixed_queue_esc__0_Q213cruise_bubble18missle_record_data_esc__4_127_esc__1_CFv:
 /* 800604FC 0005D2FC  80 83 00 04 */	lwz r4, 4(r3)
 /* 80060500 0005D300  80 63 00 00 */	lwz r3, 0(r3)
 /* 80060504 0005D304  38 04 00 80 */	addi r0, r4, 0x80
@@ -8310,8 +8367,11 @@ size__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseB
 /* 80060510 0005D310  4E 80 00 20 */	blr 
 
 /* __vc__86fixed_queue<Q313cruise_bubble30@unnamed@zEntCruiseBubble_cpp@18missle_record_data,127>Fi */
-.global __vc__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data_esc__4_127_esc__1_Fi
-__vc__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data_esc__4_127_esc__1_Fi:
+.global __vc__54fixed_queue_esc__0_Q213cruise_bubble18missle_record_data_esc__4_127_esc__1_Fi:
+/* changed from ... */
+/* __vc__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data_esc__4_127_esc__1_Fi: */
+/* ... so linker can find it */
+__vc__54fixed_queue_esc__0_Q213cruise_bubble18missle_record_data_esc__4_127_esc__1_Fi:
 /* 80060514 0005D314  94 21 FF F0 */	stwu r1, -0x10(r1)
 /* 80060518 0005D318  7C 08 02 A6 */	mflr r0
 /* 8006051C 0005D31C  90 01 00 14 */	stw r0, 0x14(r1)
@@ -8322,8 +8382,11 @@ __vc__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseB
 /* 80060530 0005D330  4E 80 00 20 */	blr 
 
 /* get_at__86fixed_queue<Q313cruise_bubble30@unnamed@zEntCruiseBubble_cpp@18missle_record_data,127>CFi */
-.global get_at__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data_esc__4_127_esc__1_CFi
-get_at__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data_esc__4_127_esc__1_CFi:
+.global get_at__54fixed_queue_esc__0_Q213cruise_bubble18missle_record_data_esc__4_127_esc__1_CFi:
+/* changed from ... */
+/* get_at__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data_esc__4_127_esc__1_CFi: */
+/* ... so linker can find it */
+get_at__54fixed_queue_esc__0_Q213cruise_bubble18missle_record_data_esc__4_127_esc__1_CFi:
 /* 80060534 0005D334  80 03 00 00 */	lwz r0, 0(r3)
 /* 80060538 0005D338  7C 65 1B 78 */	mr r5, r3
 /* 8006053C 0005D33C  7C 60 22 14 */	add r3, r0, r4
@@ -8384,8 +8447,11 @@ __rf__Q286fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruis
 /* 800605D8 0005D3D8  4E 80 00 20 */	blr 
 
 /* end__86fixed_queue<Q313cruise_bubble30@unnamed@zEntCruiseBubble_cpp@18missle_record_data,127>CFv */
-.global end__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data_esc__4_127_esc__1_CFv
-end__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data_esc__4_127_esc__1_CFv:
+.global end__54fixed_queue_esc__0_Q213cruise_bubble18missle_record_data_esc__4_127_esc__1_CFv:
+/* changed from ... */
+/* end__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data_esc__4_127_esc__1_CFv: */
+/* ... so linker can find it */
+end__54fixed_queue_esc__0_Q213cruise_bubble18missle_record_data_esc__4_127_esc__1_CFv:
 /* 800605DC 0005D3DC  94 21 FF F0 */	stwu r1, -0x10(r1)
 /* 800605E0 0005D3E0  7C 08 02 A6 */	mflr r0
 /* 800605E4 0005D3E4  80 83 00 04 */	lwz r4, 4(r3)
@@ -8815,7 +8881,8 @@ cheat_tweak__13cruise_bubble:
 	.skip 0x1B8
 lbl_802DBDF0:
 	.skip 0x40
-lbl_802DBE30:
+.global missle_record__13cruise_bubble
+missle_record__13cruise_bubble:
 	.skip 0x808
 .global wake_ribbon__13cruise_bubble
 wake_ribbon__13cruise_bubble:
@@ -8876,7 +8943,8 @@ current_tweak__13cruise_bubble:
 .global zEntCruiseBubble_f_0_0
 zEntCruiseBubble_f_0_0:
 	.incbin "baserom.dol", 0x2B6BD8, 0x4
-lbl_803CD33C:
+.global zEntCruiseBubble_f_1_0e38
+zEntCruiseBubble_f_1_0e38:
 	.incbin "baserom.dol", 0x2B6BDC, 0x4
 .global zEntCruiseBubble_f_1_0
 zEntCruiseBubble_f_1_0:

--- a/asm/Game/zEntCruiseBubble.s
+++ b/asm/Game/zEntCruiseBubble.s
@@ -4499,38 +4499,6 @@ start__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_19s
 /* 8005CE24 00059C24  38 21 00 10 */	addi r1, r1, 0x10
 /* 8005CE28 00059C28  4E 80 00 20 */	blr 
 
-/* move__Q313cruise_bubble30@unnamed@zEntCruiseBubble_cpp@19state_missle_appearFv */
-move__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_19state_missle_appearFv:
-/* 8005CE2C 00059C2C  94 21 FF D0 */	stwu r1, -0x30(r1)
-/* 8005CE30 00059C30  7C 08 02 A6 */	mflr r0
-/* 8005CE34 00059C34  90 01 00 34 */	stw r0, 0x34(r1)
-/* 8005CE38 00059C38  93 E1 00 2C */	stw r31, 0x2c(r1)
-/* 8005CE3C 00059C3C  4B FF FE 35 */	bl get_missle_mat__Q213cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_Fv
-/* 8005CE40 00059C40  7C 7F 1B 78 */	mr r31, r3
-/* 8005CE44 00059C44  4B FF FA 91 */	bl get_player_mat__Q213cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_Fv
-/* 8005CE48 00059C48  7C 64 1B 78 */	mr r4, r3
-/* 8005CE4C 00059C4C  7F E3 FB 78 */	mr r3, r31
-/* 8005CE50 00059C50  4B FA E7 1D */	bl __as__7xMat4x3FRC7xMat4x3
-/* 8005CE54 00059C54  7F E3 FB 78 */	mr r3, r31
-/* 8005CE58 00059C58  38 81 00 14 */	addi r4, r1, 0x14
-/* 8005CE5C 00059C5C  4B FD 4F D9 */	bl xMat3x3GetEuler__FPC7xMat3x3P5xVec3
-/* 8005CE60 00059C60  7F E3 FB 78 */	mr r3, r31
-/* 8005CE64 00059C64  38 81 00 14 */	addi r4, r1, 0x14
-/* 8005CE68 00059C68  4B FD 53 3D */	bl xMat3x3Euler__FP7xMat3x3PC5xVec3
-/* 8005CE6C 00059C6C  80 AD 81 80 */	lwz r5, current_tweak__13cruise_bubble-_SDA_BASE_(r13)
-/* 8005CE70 00059C70  7F E4 FB 78 */	mr r4, r31
-/* 8005CE74 00059C74  38 61 00 08 */	addi r3, r1, 8
-/* 8005CE78 00059C78  38 A5 00 30 */	addi r5, r5, 0x30
-/* 8005CE7C 00059C7C  48 00 31 C1 */	bl xMat3x3RMulVec__FP5xVec3PC7xMat3x3PC5xVec3
-/* 8005CE80 00059C80  38 7F 00 30 */	addi r3, r31, 0x30
-/* 8005CE84 00059C84  38 81 00 08 */	addi r4, r1, 8
-/* 8005CE88 00059C88  4B FB 85 BD */	bl __apl__5xVec3FRC5xVec3
-/* 8005CE8C 00059C8C  80 01 00 34 */	lwz r0, 0x34(r1)
-/* 8005CE90 00059C90  83 E1 00 2C */	lwz r31, 0x2c(r1)
-/* 8005CE94 00059C94  7C 08 03 A6 */	mtlr r0
-/* 8005CE98 00059C98  38 21 00 30 */	addi r1, r1, 0x30
-/* 8005CE9C 00059C9C  4E 80 00 20 */	blr 
-
 stop__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_19state_missle_appearFv:
 /* 8005CEA0 00059CA0  94 21 FF F0 */	stwu r1, -0x10(r1)
 /* 8005CEA4 00059CA4  7C 08 02 A6 */	mflr r0

--- a/asm/Game/zEntCruiseBubble.s
+++ b/asm/Game/zEntCruiseBubble.s
@@ -337,10 +337,16 @@ lbl_80057CB8:
 /* 80057CC0 00054AC0  38 21 00 10 */	addi r1, r1, 0x10
 /* 80057CC4 00054AC4  4E 80 00 20 */	blr 
 
-start__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_10state_typeFv:
+/* changed from ... */
+/* start__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_10state_typeFv: */
+/* ... so linker can find it */
+start__Q213cruise_bubble10state_typeFv:
 /* 80057D78 00054B78  4E 80 00 20 */	blr 
 
-stop__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_10state_typeFv:
+/* changed from ... */
+/* stop__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_10state_typeFv: */
+/* ... so linker can find it */
+stop__Q213cruise_bubble10state_typeFv:
 /* 80057D7C 00054B7C  4E 80 00 20 */	blr 
 
 /* changed from ... */

--- a/asm/Game/zEntCruiseBubble.s
+++ b/asm/Game/zEntCruiseBubble.s
@@ -5468,7 +5468,10 @@ lbl_8005DCC4:
 /* 8005DCF4 0005AAF4  4E 80 00 20 */	blr 
 
 /* start_effects__Q313cruise_bubble30@unnamed@zEntCruiseBubble_cpp@20state_missle_explodeFv */
-start_effects__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_20state_missle_explodeFv:
+/* changed from ... */
+/* start_effects__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_20state_missle_explodeFv: */
+/* ... so linker can find it */
+start_effects__Q213cruise_bubble20state_missle_explodeFv:
 /* 8005DCF8 0005AAF8  94 21 FF D0 */	stwu r1, -0x30(r1)
 /* 8005DCFC 0005AAFC  7C 08 02 A6 */	mflr r0
 /* 8005DD00 0005AB00  90 01 00 34 */	stw r0, 0x34(r1)
@@ -5549,7 +5552,10 @@ lbl_8005DE0C:
 /* 8005DE18 0005AC18  38 21 00 30 */	addi r1, r1, 0x30
 /* 8005DE1C 0005AC1C  4E 80 00 20 */	blr 
 
-cb_droplet__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_20state_missle_explodeFP5zFragP10zFragAsset:
+/* changed from ... */
+/* cb_droplet__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_20state_missle_explodeFP5zFragP10zFragAsset: */
+/* ... so linker can find it */
+cb_droplet__Q213cruise_bubble20state_missle_explodeFP5zFragP10zFragAsset:
 /* 8005DE20 0005AC20  94 21 FF 90 */	stwu r1, -0x70(r1)
 /* 8005DE24 0005AC24  7C 08 02 A6 */	mflr r0
 /* 8005DE28 0005AC28  90 01 00 74 */	stw r0, 0x74(r1)
@@ -5655,7 +5661,10 @@ cb_droplet__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__
 /* 8005DFB8 0005ADB8  4E 80 00 20 */	blr 
 
 /* perturb_direction__Q313cruise_bubble30@unnamed@zEntCruiseBubble_cpp@20state_missle_explodeFRC5xVec3ffff */
-perturb_direction__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_20state_missle_explodeFRC5xVec3ffff:
+/* changed from ... */
+/* perturb_direction__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_20state_missle_explodeFRC5xVec3ffff: */
+/* ... so linker can find it */
+perturb_direction__Q213cruise_bubble20state_missle_explodeFRC5xVec3ffff:
 /* 8005DFBC 0005ADBC  94 21 FF 40 */	stwu r1, -0xc0(r1)
 /* 8005DFC0 0005ADC0  7C 08 02 A6 */	mflr r0
 /* 8005DFC4 0005ADC4  90 01 00 C4 */	stw r0, 0xc4(r1)
@@ -5771,7 +5780,10 @@ lbl_8005E0CC:
 /* 8005E174 0005AF74  4E 80 00 20 */	blr 
 
 /* get_next_quadrant__Q313cruise_bubble30@unnamed@zEntCruiseBubble_cpp@20state_missle_explodeFRfRfRfRf */
-get_next_quadrant__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_20state_missle_explodeFRfRfRfRf:
+/* changed from ... */
+/* get_next_quadrant__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_20state_missle_explodeFRfRfRfRf: */
+/* ... so linker can find it */
+get_next_quadrant__Q213cruise_bubble20state_missle_explodeFRfRfRfRf:
 /* 8005E178 0005AF78  3C E0 80 2E */	lis r7, lbl_802DC920@ha
 /* 8005E17C 0005AF7C  94 21 FF E0 */	stwu r1, -0x20(r1)
 /* 8005E180 0005AF80  39 27 C9 20 */	addi r9, r7, lbl_802DC920@l
@@ -5828,7 +5840,10 @@ lbl_8005E1A8:
 /* 8005E244 0005B044  4E 80 00 20 */	blr 
 
 /* reset_quadrants__Q313cruise_bubble30@unnamed@zEntCruiseBubble_cpp@20state_missle_explodeFUif */
-reset_quadrants__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_20state_missle_explodeFUif:
+/* changed from ... */
+/* reset_quadrants__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_20state_missle_explodeFUif: */
+/* ... so linker can find it */
+reset_quadrants__Q213cruise_bubble20state_missle_explodeFUif:
 /* 8005E248 0005B048  94 21 FF C0 */	stwu r1, -0x40(r1)
 /* 8005E24C 0005B04C  7C 08 02 A6 */	mflr r0
 /* 8005E250 0005B050  90 01 00 44 */	stw r0, 0x44(r1)
@@ -5930,7 +5945,10 @@ lbl_8005E38C:
 /* 8005E3B8 0005B1B8  4E 80 00 20 */	blr 
 
 /* apply_damage__Q313cruise_bubble30@unnamed@zEntCruiseBubble_cpp@20state_missle_explodeFf */
-apply_damage__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_20state_missle_explodeFf:
+/* changed from ... */
+/* apply_damage__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_20state_missle_explodeFf: */
+/* ... so linker can find it */
+apply_damage__Q213cruise_bubble20state_missle_explodeFf:
 /* 8005E3BC 0005B1BC  94 21 FF 80 */	stwu r1, -0x80(r1)
 /* 8005E3C0 0005B1C0  7C 08 02 A6 */	mflr r0
 /* 8005E3C4 0005B1C4  3C 80 80 29 */	lis r4, shared__13cruise_bubble@ha
@@ -5990,7 +6008,10 @@ apply_damage__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc
 /* 8005E49C 0005B29C  4E 80 00 20 */	blr 
 
 /* apply_damage_hazards__Q313cruise_bubble30@unnamed@zEntCruiseBubble_cpp@20state_missle_explodeFf */
-apply_damage_hazards__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_20state_missle_explodeFf:
+/* changed from ... */
+/* apply_damage_hazards__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_20state_missle_explodeFf: */
+/* ... so linker can find it */
+apply_damage_hazards__Q213cruise_bubble20state_missle_explodeFf:
 /* 8005E4A0 0005B2A0  94 21 FF F0 */	stwu r1, -0x10(r1)
 /* 8005E4A4 0005B2A4  7C 08 02 A6 */	mflr r0
 /* 8005E4A8 0005B2A8  3C 60 80 06 */	lis r3, hazard_check__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_20state_missle_explodeFR9NPCHazardPv@ha
@@ -6006,7 +6027,10 @@ apply_damage_hazards__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble
 /* 8005E4D0 0005B2D0  38 21 00 10 */	addi r1, r1, 0x10
 /* 8005E4D4 0005B2D4  4E 80 00 20 */	blr 
 
-hazard_check__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_20state_missle_explodeFR9NPCHazardPv:
+/* changed from ... */
+/* hazard_check__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_20state_missle_explodeFR9NPCHazardPv: */
+/* ... so linker can find it */
+hazard_check__Q213cruise_bubble20state_missle_explodeFR9NPCHazardPv:
 /* 8005E4D8 0005B2D8  94 21 FF C0 */	stwu r1, -0x40(r1)
 /* 8005E4DC 0005B2DC  7C 08 02 A6 */	mflr r0
 /* 8005E4E0 0005B2E0  90 01 00 44 */	stw r0, 0x44(r1)

--- a/asm/Game/zEntCruiseBubble.s
+++ b/asm/Game/zEntCruiseBubble.s
@@ -4633,17 +4633,6 @@ start__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16s
 /* 8005D084 00059E84  38 21 00 30 */	addi r1, r1, 0x30
 /* 8005D088 00059E88  4E 80 00 20 */	blr 
 
-/* __ct__Q313cruise_bubble30@unnamed@zEntCruiseBubble_cpp@18missle_record_dataFRC5xVec3f */
-__ct__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_dataFRC5xVec3f:
-/* 8005D08C 00059E8C  80 04 00 00 */	lwz r0, 0(r4)
-/* 8005D090 00059E90  80 A4 00 04 */	lwz r5, 4(r4)
-/* 8005D094 00059E94  90 03 00 00 */	stw r0, 0(r3)
-/* 8005D098 00059E98  80 04 00 08 */	lwz r0, 8(r4)
-/* 8005D09C 00059E9C  90 A3 00 04 */	stw r5, 4(r3)
-/* 8005D0A0 00059EA0  90 03 00 08 */	stw r0, 8(r3)
-/* 8005D0A4 00059EA4  D0 23 00 0C */	stfs f1, 0xc(r3)
-/* 8005D0A8 00059EA8  4E 80 00 20 */	blr 
-
 stop__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16state_missle_flyFv:
 /* 8005D0AC 00059EAC  94 21 FF D0 */	stwu r1, -0x30(r1)
 /* 8005D0B0 00059EB0  7C 08 02 A6 */	mflr r0

--- a/asm/Game/zEntCruiseBubble.s
+++ b/asm/Game/zEntCruiseBubble.s
@@ -5,7 +5,10 @@
 .section .text  # 0x8005720C - 0x800609B4
 
 /* play_sound__Q213cruise_bubble30@unnamed@zEntCruiseBubble_cpp@Fif */
-play_sound__Q213cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_Fif:
+/* changed from ... */
+/* play_sound__Q213cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_Fif: */
+/* ... so linker can find it */
+play_sound__13cruise_bubbleFif:
 /* 80057320 00054120  94 21 FF F0 */	stwu r1, -0x10(r1)
 /* 80057324 00054124  7C 08 02 A6 */	mflr r0
 /* 80057328 00054128  1C 83 00 28 */	mulli r4, r3, 0x28
@@ -72,7 +75,10 @@ lbl_800573E8:
 /* 80057400 00054200  4E 80 00 20 */	blr 
 
 /* play_sound__Q213cruise_bubble30@unnamed@zEntCruiseBubble_cpp@FifPC5xVec3 */
-play_sound__Q213cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_FifPC5xVec3:
+/* changed from ... */
+/* play_sound__Q213cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_FifPC5xVec3: */
+/* ... so linker can find it */
+play_sound__13cruise_bubbleFifPC5xVec3:
 /* 80057404 00054204  94 21 FF F0 */	stwu r1, -0x10(r1)
 /* 80057408 00054208  7C 08 02 A6 */	mflr r0
 /* 8005740C 0005420C  1C A3 00 28 */	mulli r5, r3, 0x28

--- a/asm/Game/zEntCruiseBubble.s
+++ b/asm/Game/zEntCruiseBubble.s
@@ -7010,7 +7010,10 @@ update__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_19
 /* 8005F260 0005C060  4E 80 00 20 */	blr 
 
 /* lock_targets__Q313cruise_bubble30@unnamed@zEntCruiseBubble_cpp@19state_camera_attachFv */
-lock_targets__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_19state_camera_attachFv:
+/* changed from ... */
+/* lock_targets__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_19state_camera_attachFv: */
+/* ... so linker can find it */
+lock_targets__Q213cruise_bubble19state_camera_attachFv:
 /* 8005F264 0005C064  94 21 FF 90 */	stwu r1, -0x70(r1)
 /* 8005F268 0005C068  7C 08 02 A6 */	mflr r0
 /* 8005F26C 0005C06C  90 01 00 74 */	stw r0, 0x74(r1)
@@ -7051,7 +7054,10 @@ lock_targets__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc
 /* 8005F2F8 0005C0F8  4E 80 00 20 */	blr 
 
 /* lock_hazard_targets__Q313cruise_bubble30@unnamed@zEntCruiseBubble_cpp@19state_camera_attachFv */
-lock_hazard_targets__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_19state_camera_attachFv:
+/* changed from ... */
+/* lock_hazard_targets__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_19state_camera_attachFv: */
+/* ... so linker can find it */
+lock_hazard_targets__Q213cruise_bubble19state_camera_attachFv:
 /* 8005F2FC 0005C0FC  94 21 FF F0 */	stwu r1, -0x10(r1)
 /* 8005F300 0005C100  7C 08 02 A6 */	mflr r0
 /* 8005F304 0005C104  3C 60 80 06 */	lis r3, hazard_check__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_19state_camera_attachFR9NPCHazardPv@ha
@@ -7066,7 +7072,10 @@ lock_hazard_targets__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_
 /* 8005F328 0005C128  38 21 00 10 */	addi r1, r1, 0x10
 /* 8005F32C 0005C12C  4E 80 00 20 */	blr 
 
-hazard_check__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_19state_camera_attachFR9NPCHazardPv:
+/* changed from ... */
+/* hazard_check__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_19state_camera_attachFR9NPCHazardPv: */
+/* ... so linker can find it */
+hazard_check__Q213cruise_bubble19state_camera_attachFR9NPCHazardPv:
 /* 8005F330 0005C130  94 21 FF F0 */	stwu r1, -0x10(r1)
 /* 8005F334 0005C134  7C 08 02 A6 */	mflr r0
 /* 8005F338 0005C138  38 63 00 08 */	addi r3, r3, 8
@@ -7079,7 +7088,10 @@ hazard_check__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc
 /* 8005F354 0005C154  4E 80 00 20 */	blr 
 
 /* get_view_bound__Q313cruise_bubble30@unnamed@zEntCruiseBubble_cpp@19state_camera_attachCFR6xBound */
-get_view_bound__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_19state_camera_attachCFR6xBound:
+/* changed from ... */
+/* get_view_bound__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_19state_camera_attachCFR6xBound: */
+/* ... so linker can find it */
+get_view_bound__Q213cruise_bubble19state_camera_attachCFR6xBound:
 /* 8005F358 0005C158  94 21 FF 80 */	stwu r1, -0x80(r1)
 /* 8005F35C 0005C15C  7C 08 02 A6 */	mflr r0
 /* 8005F360 0005C160  90 01 00 84 */	stw r0, 0x84(r1)

--- a/asm/Game/zEntCruiseBubble.s
+++ b/asm/Game/zEntCruiseBubble.s
@@ -6158,13 +6158,13 @@ start__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16s
 /* 8005E69C 0005B49C  D0 1D 00 44 */	stfs f0, 0x44(r29)
 /* 8005E6A0 0005B4A0  D0 1D 00 40 */	stfs f0, 0x40(r29)
 /* 8005E6A4 0005B4A4  4B FD 45 E1 */	bl xQuatFromMat__FP5xQuatPC7xMat3x3
-/* 8005E6A8 0005B4A8  3C 60 80 2E */	lis r3, lbl_802DBDF0@ha
+/* 8005E6A8 0005B4A8  3C 60 80 2E */	lis r3, start_cam_mat__13cruise_bubble@ha
 /* 8005E6AC 0005B4AC  7F E4 FB 78 */	mr r4, r31
-/* 8005E6B0 0005B4B0  38 63 BD F0 */	addi r3, r3, lbl_802DBDF0@l
+/* 8005E6B0 0005B4B0  38 63 BD F0 */	addi r3, r3, start_cam_mat__13cruise_bubble@l
 /* 8005E6B4 0005B4B4  4B FA CE B9 */	bl __as__7xMat4x3FRC7xMat4x3
-/* 8005E6B8 0005B4B8  3C 60 80 2E */	lis r3, lbl_802DBDF0@ha
+/* 8005E6B8 0005B4B8  3C 60 80 2E */	lis r3, start_cam_mat__13cruise_bubble@ha
 /* 8005E6BC 0005B4BC  7F C4 F3 78 */	mr r4, r30
-/* 8005E6C0 0005B4C0  38 63 BD F0 */	addi r3, r3, lbl_802DBDF0@l
+/* 8005E6C0 0005B4C0  38 63 BD F0 */	addi r3, r3, start_cam_mat__13cruise_bubble@l
 /* 8005E6C4 0005B4C4  38 63 00 30 */	addi r3, r3, 0x30
 /* 8005E6C8 0005B4C8  4B FA CB 69 */	bl __ami__5xVec3FRC5xVec3
 /* 8005E6CC 0005B4CC  80 01 00 24 */	lwz r0, 0x24(r1)
@@ -7638,9 +7638,9 @@ start__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_20s
 /* 8005FB68 0005C968  54 60 06 3F */	clrlwi. r0, r3, 0x18
 /* 8005FB6C 0005C96C  40 82 00 68 */	bne lbl_8005FBD4
 /* 8005FB70 0005C970  4B FF 85 99 */	bl get_player_loc__Q213cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_Fv
-/* 8005FB74 0005C974  3C A0 80 2E */	lis r5, lbl_802DBDF0@ha
+/* 8005FB74 0005C974  3C A0 80 2E */	lis r5, start_cam_mat__13cruise_bubble@ha
 /* 8005FB78 0005C978  7C 64 1B 78 */	mr r4, r3
-/* 8005FB7C 0005C97C  38 A5 BD F0 */	addi r5, r5, lbl_802DBDF0@l
+/* 8005FB7C 0005C97C  38 A5 BD F0 */	addi r5, r5, start_cam_mat__13cruise_bubble@l
 /* 8005FB80 0005C980  38 61 00 08 */	addi r3, r1, 8
 /* 8005FB84 0005C984  38 A5 00 30 */	addi r5, r5, 0x30
 /* 8005FB88 0005C988  4B FB 58 59 */	bl __pl__5xVec3CFRC5xVec3
@@ -7656,11 +7656,11 @@ start__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_20s
 /* 8005FBB0 0005C9B0  4B FA DB 69 */	bl xCameraMove__FP7xCameraRC5xVec3
 /* 8005FBB4 0005C9B4  C0 22 89 B8 */	lfs f1, zEntCruiseBubble_f_0_0-_SDA2_BASE_(r2)
 /* 8005FBB8 0005C9B8  3C 60 80 3C */	lis r3, globals@ha
-/* 8005FBBC 0005C9BC  3C 80 80 2E */	lis r4, lbl_802DBDF0@ha
+/* 8005FBBC 0005C9BC  3C 80 80 2E */	lis r4, start_cam_mat__13cruise_bubble@ha
 /* 8005FBC0 0005C9C0  FC 40 08 90 */	fmr f2, f1
 /* 8005FBC4 0005C9C4  38 63 05 58 */	addi r3, r3, globals@l
 /* 8005FBC8 0005C9C8  FC 60 08 90 */	fmr f3, f1
-/* 8005FBCC 0005C9CC  38 84 BD F0 */	addi r4, r4, lbl_802DBDF0@l
+/* 8005FBCC 0005C9CC  38 84 BD F0 */	addi r4, r4, start_cam_mat__13cruise_bubble@l
 /* 8005FBD0 0005C9D0  4B FA DF 45 */	bl xCameraRotate__FP7xCameraRC7xMat3x3fff
 lbl_8005FBD4:
 /* 8005FBD4 0005C9D4  4B FF 7A 29 */	bl camera_taken__Q213cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_Fv
@@ -8921,7 +8921,8 @@ normal_tweak__13cruise_bubble:
 .global cheat_tweak__13cruise_bubble
 cheat_tweak__13cruise_bubble:
 	.skip 0x1B8
-lbl_802DBDF0:
+.global start_cam_mat__13cruise_bubble
+start_cam_mat__13cruise_bubble:
 	.skip 0x40
 .global missle_record__13cruise_bubble
 missle_record__13cruise_bubble:
@@ -8969,6 +8970,7 @@ lbl_803CB566:
 	.skip 0x2
 
 .section .sbss2
+.global lbl_803D0830
 lbl_803D0830:
 	.skip 0x4
 /* SPECULATION: link order */

--- a/asm/Game/zEntCruiseBubble.s
+++ b/asm/Game/zEntCruiseBubble.s
@@ -4167,7 +4167,10 @@ lbl_8005C97C:
 /* 8005C994 00059794  4E 80 00 20 */	blr 
 
 /* update_animation__Q313cruise_bubble30@unnamed@zEntCruiseBubble_cpp@16state_player_aimFf */
-update_animation__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16state_player_aimFf:
+/* changed from ... */
+/* update_animation__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16state_player_aimFf: */
+/* ... so linker can find it */
+update_animation__Q213cruise_bubble16state_player_aimFf:
 /* 8005C998 00059798  94 21 FF F0 */	stwu r1, -0x10(r1)
 /* 8005C99C 0005979C  7C 08 02 A6 */	mflr r0
 /* 8005C9A0 000597A0  90 01 00 14 */	stw r0, 0x14(r1)
@@ -4196,7 +4199,10 @@ update_animation__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp
 /* 8005C9FC 000597FC  4E 80 00 20 */	blr 
 
 /* apply_yaw__Q313cruise_bubble30@unnamed@zEntCruiseBubble_cpp@16state_player_aimFv */
-apply_yaw__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16state_player_aimFv:
+/* changed from ... */
+/* apply_yaw__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16state_player_aimFv: */
+/* ... so linker can find it */
+apply_yaw__Q213cruise_bubble16state_player_aimFv:
 /* 8005CA00 00059800  94 21 FF E0 */	stwu r1, -0x20(r1)
 /* 8005CA04 00059804  7C 08 02 A6 */	mflr r0
 /* 8005CA08 00059808  90 01 00 24 */	stw r0, 0x24(r1)
@@ -4237,7 +4243,10 @@ apply_yaw__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2
 /* 8005CA94 00059894  4E 80 00 20 */	blr 
 
 /* face_camera__Q313cruise_bubble30@unnamed@zEntCruiseBubble_cpp@16state_player_aimFf */
-face_camera__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16state_player_aimFf:
+/* changed from ... */
+/* face_camera__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16state_player_aimFf: */
+/* ... so linker can find it */
+face_camera__Q213cruise_bubble16state_player_aimFf:
 /* 8005CA98 00059898  94 21 FF D0 */	stwu r1, -0x30(r1)
 /* 8005CA9C 0005989C  7C 08 02 A6 */	mflr r0
 /* 8005CAA0 000598A0  90 01 00 34 */	stw r0, 0x34(r1)

--- a/asm/Game/zEntCruiseBubble.s
+++ b/asm/Game/zEntCruiseBubble.s
@@ -4562,10 +4562,6 @@ lbl_8005CF5C:
 /* 8005CF78 00059D78  38 21 00 30 */	addi r1, r1, 0x30
 /* 8005CF7C 00059D7C  4E 80 00 20 */	blr 
 
-/* update_effects__Q313cruise_bubble30@unnamed@zEntCruiseBubble_cpp@19state_missle_appearFf */
-update_effects__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_19state_missle_appearFf:
-/* 8005CF80 00059D80  4E 80 00 20 */	blr 
-
 start__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16state_missle_flyFv:
 /* 8005CF84 00059D84  94 21 FF D0 */	stwu r1, -0x30(r1)
 /* 8005CF88 00059D88  7C 08 02 A6 */	mflr r0

--- a/asm/Game/zEntCruiseBubble.s
+++ b/asm/Game/zEntCruiseBubble.s
@@ -6257,7 +6257,10 @@ lbl_8005E7EC:
 /* 8005E804 0005B604  4E 80 00 20 */	blr 
 
 /* apply_turn__Q313cruise_bubble30@unnamed@zEntCruiseBubble_cpp@16state_camera_aimCFv */
-apply_turn__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16state_camera_aimCFv:
+/* changed from ... */
+/* apply_turn__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16state_camera_aimCFv: */
+/* ... so linker can find it */
+apply_turn__Q213cruise_bubble16state_camera_aimCFv:
 /* 8005E808 0005B608  94 21 FF C0 */	stwu r1, -0x40(r1)
 /* 8005E80C 0005B60C  7C 08 02 A6 */	mflr r0
 /* 8005E810 0005B610  38 63 00 20 */	addi r3, r3, 0x20
@@ -6277,7 +6280,10 @@ apply_turn__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__
 /* 8005E848 0005B648  4E 80 00 20 */	blr 
 
 /* turn__Q313cruise_bubble30@unnamed@zEntCruiseBubble_cpp@16state_camera_aimFf */
-turn__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16state_camera_aimFf:
+/* changed from ... */
+/* turn__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16state_camera_aimFf: */
+/* ... so linker can find it */
+turn__Q213cruise_bubble16state_camera_aimFf:
 /* 8005E84C 0005B64C  94 21 FF 80 */	stwu r1, -0x80(r1)
 /* 8005E850 0005B650  7C 08 02 A6 */	mflr r0
 /* 8005E854 0005B654  90 01 00 84 */	stw r0, 0x84(r1)
@@ -6344,7 +6350,10 @@ lbl_8005E928:
 /* 8005E940 0005B740  4E 80 00 20 */	blr 
 
 /* collide_inward__Q313cruise_bubble30@unnamed@zEntCruiseBubble_cpp@16state_camera_aimFv */
-collide_inward__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16state_camera_aimFv:
+/* changed from ... */
+/* collide_inward__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16state_camera_aimFv: */
+/* ... so linker can find it */
+collide_inward__Q213cruise_bubble16state_camera_aimFv:
 /* 8005E944 0005B744  94 21 FE 70 */	stwu r1, -0x190(r1)
 /* 8005E948 0005B748  7C 08 02 A6 */	mflr r0
 /* 8005E94C 0005B74C  3C 60 80 3C */	lis r3, globals@ha
@@ -6463,7 +6472,10 @@ lbl_8005EAE0:
 /* 8005EAF8 0005B8F8  4E 80 00 20 */	blr 
 
 /* apply_motion__Q313cruise_bubble30@unnamed@zEntCruiseBubble_cpp@16state_camera_aimCFv */
-apply_motion__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16state_camera_aimCFv:
+/* changed from ... */
+/* apply_motion__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16state_camera_aimCFv: */
+/* ... so linker can find it */
+apply_motion__Q213cruise_bubble16state_camera_aimCFv:
 /* 8005EAFC 0005B8FC  94 21 FF E0 */	stwu r1, -0x20(r1)
 /* 8005EB00 0005B900  7C 08 02 A6 */	mflr r0
 /* 8005EB04 0005B904  90 01 00 24 */	stw r0, 0x24(r1)
@@ -6503,7 +6515,10 @@ apply_motion__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc
 /* 8005EB8C 0005B98C  4E 80 00 20 */	blr 
 
 /* stop__Q313cruise_bubble30@unnamed@zEntCruiseBubble_cpp@16state_camera_aimFf */
-stop__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16state_camera_aimFf:
+/* changed from ... */
+/* stop__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16state_camera_aimFf: */
+/* ... so linker can find it */
+stop__Q213cruise_bubble16state_camera_aimFf:
 /* 8005EB90 0005B990  94 21 FF E0 */	stwu r1, -0x20(r1)
 /* 8005EB94 0005B994  7C 08 02 A6 */	mflr r0
 /* 8005EB98 0005B998  90 01 00 24 */	stw r0, 0x24(r1)
@@ -6542,7 +6557,10 @@ stop__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16st
 /* 8005EC1C 0005BA1C  4E 80 00 20 */	blr 
 
 /* move__Q313cruise_bubble30@unnamed@zEntCruiseBubble_cpp@16state_camera_aimFf */
-move__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16state_camera_aimFf:
+/* changed from ... */
+/* move__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16state_camera_aimFf: */
+/* ... so linker can find it */
+move__Q213cruise_bubble16state_camera_aimFf:
 /* 8005EC20 0005BA20  94 21 FF E0 */	stwu r1, -0x20(r1)
 /* 8005EC24 0005BA24  7C 08 02 A6 */	mflr r0
 /* 8005EC28 0005BA28  90 01 00 24 */	stw r0, 0x24(r1)

--- a/asm/Game/zEntCruiseBubble.s
+++ b/asm/Game/zEntCruiseBubble.s
@@ -116,7 +116,10 @@ lbl_80057470:
 /* 80057484 00054284  4E 80 00 20 */	blr 
 
 /* camera_taken__Q213cruise_bubble30@unnamed@zEntCruiseBubble_cpp@Fv */
-camera_taken__Q213cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_Fv:
+/* changed from ... */
+/* camera_taken__Q213cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_Fv: */
+/* ... so linker can find it */
+camera_taken__13cruise_bubbleFv:
 /* 800575FC 000543FC  94 21 FF F0 */	stwu r1, -0x10(r1)
 /* 80057600 00054400  7C 08 02 A6 */	mflr r0
 /* 80057604 00054404  90 01 00 14 */	stw r0, 0x14(r1)

--- a/asm/Game/zEntCruiseBubble.s
+++ b/asm/Game/zEntCruiseBubble.s
@@ -4115,14 +4115,6 @@ start__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16s
 /* 8005C8CC 000596CC  38 21 00 10 */	addi r1, r1, 0x10
 /* 8005C8D0 000596D0  4E 80 00 20 */	blr 
 
-/* get_player_mat__Q213cruise_bubble30@unnamed@zEntCruiseBubble_cpp@Fv */
-get_player_mat__Q213cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_Fv:
-/* 8005C8D4 000596D4  3C 60 80 3C */	lis r3, globals@ha
-/* 8005C8D8 000596D8  38 63 05 58 */	addi r3, r3, globals@l
-/* 8005C8DC 000596DC  80 63 07 04 */	lwz r3, 0x704(r3)
-/* 8005C8E0 000596E0  80 63 00 4C */	lwz r3, 0x4c(r3)
-/* 8005C8E4 000596E4  4E 80 00 20 */	blr 
-
 stop__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16state_player_aimFv:
 /* 8005C8E8 000596E8  3C 60 80 29 */	lis r3, lbl_80290000@ha
 /* 8005C8EC 000596EC  84 03 C2 A4 */	lwzu r0, -0x3d5c(r3)

--- a/asm/Game/zEntCruiseBubble.s
+++ b/asm/Game/zEntCruiseBubble.s
@@ -4449,10 +4449,6 @@ lbl_8005CD64:
 /* 8005CD88 00059B88  38 21 00 40 */	addi r1, r1, 0x40
 /* 8005CD8C 00059B8C  4E 80 00 20 */	blr 
 
-/* update_wand__Q313cruise_bubble30@unnamed@zEntCruiseBubble_cpp@17state_player_fireFf */
-update_wand__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_17state_player_fireFf:
-/* 8005CD90 00059B90  4E 80 00 20 */	blr 
-
 start__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_17state_player_waitFv:
 /* 8005CD94 00059B94  94 21 FF F0 */	stwu r1, -0x10(r1)
 /* 8005CD98 00059B98  7C 08 02 A6 */	mflr r0

--- a/asm/Game/zEntCruiseBubble.s
+++ b/asm/Game/zEntCruiseBubble.s
@@ -308,7 +308,10 @@ lbl_800578C8:
 /* 800578E4 000546E4  4E 80 00 20 */	blr 
 
 /* start_trail__Q213cruise_bubble30@unnamed@zEntCruiseBubble_cpp@Fv */
-start_trail__Q213cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_Fv:
+/* changed from ... */
+/* start_trail__Q213cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_Fv: */
+/* ... so linker can find it */
+start_trail__13cruise_bubbleFv:
 /* 80057C78 00054A78  94 21 FF F0 */	stwu r1, -0x10(r1)
 /* 80057C7C 00054A7C  7C 08 02 A6 */	mflr r0
 /* 80057C80 00054A80  3C 60 80 29 */	lis r3, shared__13cruise_bubble@ha

--- a/asm/Game/zEntCruiseBubble.s
+++ b/asm/Game/zEntCruiseBubble.s
@@ -331,7 +331,10 @@ start__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_10s
 stop__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_10state_typeFv:
 /* 80057D7C 00054B7C  4E 80 00 20 */	blr 
 
-abort__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_10state_typeFv:
+/* changed from ... */
+/* abort__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_10state_typeFv: */
+/* ... so linker can find it */
+abort__Q213cruise_bubble10state_typeFv:
 /* 80057FE4 00054DE4  4E 80 00 20 */	blr 
 
 /* update_player__Q213cruise_bubble30@unnamed@zEntCruiseBubble_cpp@FR6xScenef */
@@ -416,7 +419,10 @@ lbl_800580E8:
 /* 80058100 00054F00  38 21 00 50 */	addi r1, r1, 0x50
 /* 80058104 00054F04  4E 80 00 20 */	blr 
 
-render__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_10state_typeFv:
+/* changed from ... */
+/* render__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_10state_typeFv: */
+/* ... so linker can find it */
+render__Q213cruise_bubble10state_typeFv:
 /* 80058310 00055110  4E 80 00 20 */	blr 
 
 /* changed from ... */
@@ -4050,7 +4056,7 @@ lbl_8005C7C8:
 /* 8005C7F4 000595F4  90 81 00 18 */	stw r4, 0x18(r1)
 /* 8005C7F8 000595F8  90 01 00 1C */	stw r0, 0x1c(r1)
 /* 8005C7FC 000595FC  4B FA E9 01 */	bl length2__5xVec3CFv
-/* 8005C800 00059600  C0 02 89 C4 */	lfs f0, lbl_803CD344-_SDA2_BASE_(r2)
+/* 8005C800 00059600  C0 02 89 C4 */	lfs f0, zEntCruiseBubble_f_0_0001-_SDA2_BASE_(r2)
 /* 8005C804 00059604  FC 01 00 40 */	fcmpo cr0, f1, f0
 /* 8005C808 00059608  40 80 00 0C */	bge lbl_8005C814
 /* 8005C80C 0005960C  38 60 00 01 */	li r3, 1
@@ -6816,7 +6822,7 @@ update_turn__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc_
 /* 8005EF80 0005BD80  93 E1 00 3C */	stw r31, 0x3c(r1)
 /* 8005EF84 0005BD84  FF E0 08 90 */	fmr f31, f1
 /* 8005EF88 0005BD88  C0 22 89 C0 */	lfs f1, zEntCruiseBubble_f_1_0-_SDA2_BASE_(r2)
-/* 8005EF8C 0005BD8C  C0 02 89 C4 */	lfs f0, lbl_803CD344-_SDA2_BASE_(r2)
+/* 8005EF8C 0005BD8C  C0 02 89 C4 */	lfs f0, zEntCruiseBubble_f_0_0001-_SDA2_BASE_(r2)
 /* 8005EF90 0005BD90  7C 7F 1B 78 */	mr r31, r3
 /* 8005EF94 0005BD94  EC 3F 08 28 */	fsubs f1, f31, f1
 /* 8005EF98 0005BD98  FC 20 0A 10 */	fabs f1, f1
@@ -7297,7 +7303,7 @@ lbl_8005F64C:
 /* 8005F66C 0005C46C  7C 03 03 78 */	mr r3, r0
 /* 8005F670 0005C470  48 00 0E A5 */	bl __vc__86fixed_queue_esc__0_Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_data_esc__4_127_esc__1_Fi
 /* 8005F674 0005C474  57 80 10 3A */	slwi r0, r28, 2
-/* 8005F678 0005C478  C0 02 89 C4 */	lfs f0, lbl_803CD344-_SDA2_BASE_(r2)
+/* 8005F678 0005C478  C0 02 89 C4 */	lfs f0, zEntCruiseBubble_f_0_0001-_SDA2_BASE_(r2)
 /* 8005F67C 0005C47C  7C 9D 02 14 */	add r4, r29, r0
 /* 8005F680 0005C480  7C 7C 1B 78 */	mr r28, r3
 /* 8005F684 0005C484  C0 44 00 10 */	lfs f2, 0x10(r4)
@@ -8961,7 +8967,8 @@ lbl_803CD33C:
 .global zEntCruiseBubble_f_1_0
 zEntCruiseBubble_f_1_0:
 	.incbin "baserom.dol", 0x2B6BE0, 0x4
-lbl_803CD344:
+.global zEntCruiseBubble_f_0_0001
+zEntCruiseBubble_f_0_0001:
 	.incbin "baserom.dol", 0x2B6BE4, 0x4
 .global zEntCruiseBubble_f_0_5
 zEntCruiseBubble_f_0_5:

--- a/asm/Game/zEntCruiseBubble.s
+++ b/asm/Game/zEntCruiseBubble.s
@@ -4827,7 +4827,10 @@ lbl_8005D334:
 /* 8005D34C 0005A14C  4E 80 00 20 */	blr 
 
 /* update_engine_sound__Q313cruise_bubble30@unnamed@zEntCruiseBubble_cpp@16state_missle_flyFf */
-update_engine_sound__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16state_missle_flyFf:
+/* changed from ... */
+/* update_engine_sound__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16state_missle_flyFf: */
+/* ... so linker can find it */
+update_engine_sound__Q213cruise_bubble16state_missle_flyFf:
 /* 8005D3D4 0005A1D4  94 21 FF F0 */	stwu r1, -0x10(r1)
 /* 8005D3D8 0005A1D8  7C 08 02 A6 */	mflr r0
 /* 8005D3DC 0005A1DC  3C 80 80 29 */	lis r4, shared__13cruise_bubble@ha

--- a/asm/Game/zEntCruiseBubble.s
+++ b/asm/Game/zEntCruiseBubble.s
@@ -1968,7 +1968,10 @@ lbl_8005A298:
 /* 8005A2A8 000570A8  4E 80 00 20 */	blr 
 
 /* show_hud__Q213cruise_bubble30@unnamed@zEntCruiseBubble_cpp@Fv */
-show_hud__Q213cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_Fv:
+/* changed from ... */
+/* show_hud__Q213cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_Fv: */
+/* ... so linker can find it */
+show_hud__13cruise_bubbleFv:
 /* 8005A2AC 000570AC  94 21 FF E0 */	stwu r1, -0x20(r1)
 /* 8005A2B0 000570B0  7C 08 02 A6 */	mflr r0
 /* 8005A2B4 000570B4  3C 60 80 2E */	lis r3, hud__13cruise_bubble@ha

--- a/asm/Game/zEntCruiseBubble.s
+++ b/asm/Game/zEntCruiseBubble.s
@@ -4374,14 +4374,6 @@ lbl_8005CC5C:
 /* 8005CC68 00059A68  38 21 00 10 */	addi r1, r1, 0x10
 /* 8005CC6C 00059A6C  4E 80 00 20 */	blr 
 
-/* get_missle_mat__Q213cruise_bubble30@unnamed@zEntCruiseBubble_cpp@Fv */
-get_missle_mat__Q213cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_Fv:
-/* 8005CC70 00059A70  3C 60 80 29 */	lis r3, shared__13cruise_bubble@ha
-/* 8005CC74 00059A74  38 63 C2 A4 */	addi r3, r3, shared__13cruise_bubble@l
-/* 8005CC78 00059A78  80 63 00 68 */	lwz r3, 0x68(r3)
-/* 8005CC7C 00059A7C  80 63 00 4C */	lwz r3, 0x4c(r3)
-/* 8005CC80 00059A80  4E 80 00 20 */	blr 
-
 stop__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_17state_player_fireFv:
 /* 8005CC84 00059A84  94 21 FF F0 */	stwu r1, -0x10(r1)
 /* 8005CC88 00059A88  7C 08 02 A6 */	mflr r0

--- a/asm/Game/zEntCruiseBubble.s
+++ b/asm/Game/zEntCruiseBubble.s
@@ -4825,43 +4825,6 @@ lbl_8005D334:
 /* 8005D348 0005A148  38 21 00 50 */	addi r1, r1, 0x50
 /* 8005D34C 0005A14C  4E 80 00 20 */	blr 
 
-/* update_flash__Q313cruise_bubble30@unnamed@zEntCruiseBubble_cpp@16state_missle_flyFf */
-update_flash__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16state_missle_flyFf:
-/* 8005D350 0005A150  94 21 FF E0 */	stwu r1, -0x20(r1)
-/* 8005D354 0005A154  7C 08 02 A6 */	mflr r0
-/* 8005D358 0005A158  90 01 00 24 */	stw r0, 0x24(r1)
-/* 8005D35C 0005A15C  DB E1 00 10 */	stfd f31, 0x10(r1)
-/* 8005D360 0005A160  F3 E1 00 18 */	psq_st f31, 24(r1), 0, qr0
-/* 8005D364 0005A164  93 E1 00 0C */	stw r31, 0xc(r1)
-/* 8005D368 0005A168  7C 7F 1B 78 */	mr r31, r3
-/* 8005D36C 0005A16C  C0 03 00 38 */	lfs f0, 0x38(r3)
-/* 8005D370 0005A170  EC 00 08 2A */	fadds f0, f0, f1
-/* 8005D374 0005A174  D0 03 00 38 */	stfs f0, 0x38(r3)
-/* 8005D378 0005A178  80 6D 81 80 */	lwz r3, current_tweak__13cruise_bubble-_SDA_BASE_(r13)
-/* 8005D37C 0005A17C  C0 3F 00 08 */	lfs f1, 8(r31)
-/* 8005D380 0005A180  C0 03 00 14 */	lfs f0, 0x14(r3)
-/* 8005D384 0005A184  C0 43 00 4C */	lfs f2, 0x4c(r3)
-/* 8005D388 0005A188  EC 21 00 24 */	fdivs f1, f1, f0
-/* 8005D38C 0005A18C  C0 1F 00 38 */	lfs f0, 0x38(r31)
-/* 8005D390 0005A190  EF E2 00 72 */	fmuls f31, f2, f1
-/* 8005D394 0005A194  FC 00 F8 40 */	fcmpo cr0, f0, f31
-/* 8005D398 0005A198  40 81 00 20 */	ble lbl_8005D3B8
-/* 8005D39C 0005A19C  4B FF C6 2D */	bl flash_hud__Q213cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_Fv
-/* 8005D3A0 0005A1A0  C0 1F 00 38 */	lfs f0, 0x38(r31)
-/* 8005D3A4 0005A1A4  EC 20 F8 24 */	fdivs f1, f0, f31
-/* 8005D3A8 0005A1A8  4B FA 97 D1 */	bl floorf__3stdFf
-/* 8005D3AC 0005A1AC  C0 1F 00 38 */	lfs f0, 0x38(r31)
-/* 8005D3B0 0005A1B0  EC 01 07 FC */	fnmsubs f0, f1, f31, f0
-/* 8005D3B4 0005A1B4  D0 1F 00 38 */	stfs f0, 0x38(r31)
-lbl_8005D3B8:
-/* 8005D3B8 0005A1B8  E3 E1 00 18 */	psq_l f31, 24(r1), 0, qr0
-/* 8005D3BC 0005A1BC  80 01 00 24 */	lwz r0, 0x24(r1)
-/* 8005D3C0 0005A1C0  CB E1 00 10 */	lfd f31, 0x10(r1)
-/* 8005D3C4 0005A1C4  83 E1 00 0C */	lwz r31, 0xc(r1)
-/* 8005D3C8 0005A1C8  7C 08 03 A6 */	mtlr r0
-/* 8005D3CC 0005A1CC  38 21 00 20 */	addi r1, r1, 0x20
-/* 8005D3D0 0005A1D0  4E 80 00 20 */	blr 
-
 /* update_engine_sound__Q313cruise_bubble30@unnamed@zEntCruiseBubble_cpp@16state_missle_flyFf */
 update_engine_sound__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16state_missle_flyFf:
 /* 8005D3D4 0005A1D4  94 21 FF F0 */	stwu r1, -0x10(r1)

--- a/src/Core/x/containers.h
+++ b/src/Core/x/containers.h
@@ -40,11 +40,16 @@ template <class T> struct static_queue
     T* _buffer;
 };
 
-template <class T> struct fixed_queue
+template <class T, uint32 N> struct fixed_queue
 {
     uint32 _first;
     uint32 _last;
-    T _buffer[32];
+    T _buffer[N + 1];
+
+    void reset();
+    void push_front(const T& element);
+    bool full() const;
+    void pop_back();
 };
 
 #endif

--- a/src/Core/x/xCamera.h
+++ b/src/Core/x/xCamera.h
@@ -228,6 +228,7 @@ void xCameraSetFOV(xCamera* cam, float32 fov);
 void xCameraMove(xCamera* cam, uint32 flags, float32 dgoal, float32 hgoal, float32 pgoal,
                  float32 tm, float32 tm_acc, float32 tm_dec);
 void xCameraMove(xCamera* cam, const xVec3& loc);
+void xCameraRotate(xCamera* cam, const xMat3x3& m, float32 time, float32 accel, float32 decl);
 float32 xCameraGetFOV(const xCamera* cam);
 void xCameraDoCollisions(int32 do_collis, int32 owner);
 void xCameraSetTargetMatrix(xCamera* cam, xMat4x3* mat);

--- a/src/Core/x/xMath.h
+++ b/src/Core/x/xMath.h
@@ -51,6 +51,8 @@ void xAccelStop(float32& x, float32& v, float32 a, float32 dt);
 float32 xFuncPiece_Eval(xFuncPiece* func, float32 param, xFuncPiece** iterator);
 void xFuncPiece_EndPoints(xFuncPiece* func, float32 pi, float32 pf, float32 fi, float32 ff);
 void xFuncPiece_ShiftPiece(xFuncPiece* shift, xFuncPiece* func, float32 newZero);
+float32 xSCurve(float32 t, float32 softness);
+float32 xSCurve(float32 t);
 
 float32 xrmod(float32 ang);
 

--- a/src/Core/x/xMath2.h
+++ b/src/Core/x/xMath2.h
@@ -38,6 +38,7 @@ struct xVec2
     float32 y;
 
     xVec2& assign(float32 x, float32 y);
+    float32 length() const;
 
     xVec2& operator=(float32);
     xVec2 operator*(float32) const;

--- a/src/Core/x/xVec3.h
+++ b/src/Core/x/xVec3.h
@@ -14,6 +14,7 @@ struct xVec3
     static xVec3 m_UnitAxisY;
 
     static xVec3 create(float32 x, float32 y, float32 z);
+    static xVec3 create(float32 f);
 
     xVec3& operator=(float32);
     xVec3 operator+(const xVec3&) const;

--- a/src/Game/zEntCruiseBubble.cpp
+++ b/src/Game/zEntCruiseBubble.cpp
@@ -3027,10 +3027,24 @@ cruise_bubble::state_enum cruise_bubble::state_player_halt::update(float32 dt)
 #endif
 
 // func_8005C848
+#if 1
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
     "start__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16state_player_aimFv")
-
+#else
+void cruise_bubble::state_player_aim::start()
+{
+    shared.flags = shared.flags | 0x20;
+    
+    xVec3* player_dir = &get_player_mat()->at;
+    this->yaw = xatan2(player_dir->x, player_dir->z);
+    this->yaw_vel = zEntCruiseBubble_f_0_0;
+    this->turn_delay = zEntCruiseBubble_f_0_0;
+    
+    xAnimPlayStartTransition(globals.player.ent.model->Anim, shared.atran.player.aim);
+    set_state(THREAD_CAMERA, STATE_CAMERA_AIM);
+}
+#endif
 
 xMat4x3* cruise_bubble::get_player_mat()
 {
@@ -3038,29 +3052,55 @@ xMat4x3* cruise_bubble::get_player_mat()
 }
 
 // func_8005C8E8
+#if 1
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
     "stop__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16state_player_aimFv")
+#else
+void cruise_bubble::state_player_aim::stop()
+{
+  shared.flags = shared.flags & 0xffffffdf;
+}
+#endif
 
 // func_8005C8FC
+#if 1
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
     "update__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16state_player_aimFf")
+#else
+cruise_bubble::state_enum cruise_bubble::state_player_aim::update(float32 dt)
+{
+    this->turn_delay += dt;
+
+    if (this->turn_delay >= current_tweak->aim_delay) {
+        this->face_camera(dt);
+    }
+    this->apply_yaw();
+    this->update_animation(dt);
+
+    if ((globals.pad0->on & 0x100) == 0)
+    {
+        return STATE_PLAYER_FIRE;
+    }
+    return STATE_PLAYER_AIM;
+}
+#endif
 
 // func_8005C998
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
-    "update_animation__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16state_player_aimFf")
+    "update_animation__Q213cruise_bubble16state_player_aimFf")
 
 // func_8005CA00
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
-    "apply_yaw__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16state_player_aimFv")
+    "apply_yaw__Q213cruise_bubble16state_player_aimFv")
 
 // func_8005CA98
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
-    "face_camera__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16state_player_aimFf")
+    "face_camera__Q213cruise_bubble16state_player_aimFf")
 
 // func_8005CBB8
 #pragma GLOBAL_ASM(                                                                                \

--- a/src/Game/zEntCruiseBubble.cpp
+++ b/src/Game/zEntCruiseBubble.cpp
@@ -440,7 +440,7 @@ bool cruise_bubble::camera_taken()
 }
 #endif
 
-uint32 cruise_bubble::camera_leave()
+bool cruise_bubble::camera_leave()
 {
     return zCameraGetConvers() != 0;
 }
@@ -3967,19 +3967,66 @@ cruise_bubble::state_enum cruise_bubble::state_camera_survey::update(float32 dt)
     "control_jerked__Q213cruise_bubble19state_camera_surveyCFv")
 
 // func_8005FB4C
+#if 1
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
     "start__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_20state_camera_restoreFv")
+#else
+void cruise_bubble::state_camera_restore::start()
+{
+    this->control_delay = zEntCruiseBubble_f_0_0;
+    hide_hud();
+
+    if (!camera_leave())
+    {
+        xVec3 loc = get_player_loc() + start_cam_mat.pos;
+        xCameraMove(&globals.camera, loc);
+        xCameraRotate(&globals.camera, start_cam_mat, zEntCruiseBubble_f_0_0, zEntCruiseBubble_f_0_0, zEntCruiseBubble_f_0_0);
+    }
+
+    if (camera_taken())
+    {
+        release_camera();
+    }
+    else
+    {
+        capture_camera();
+    }
+
+    xSndSelectListenerMode(SND_LISTENER_MODE_PLAYER);
+}
+#endif
 
 // func_8005FC04
+#if 1
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
     "stop__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_20state_camera_restoreFv")
+#else
+void cruise_bubble::state_camera_restore::stop()
+{
+    set_state(THREAD_PLAYER, STATE_INVALID);
+    release_camera();
+}
+#endif
 
 // func_8005FC30
+#if 1
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
     "update__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_20state_camera_restoreFf")
+#else
+cruise_bubble::state_enum cruise_bubble::state_camera_restore::update(float32 dt)
+{
+    this->control_delay += dt;
+    if (this->control_delay >= current_tweak->camera.restore.control_delay)
+    {
+        return STATE_INVALID;
+    }
+    
+    return STATE_CAMERA_RESTORE;
+}
+#endif
 
 // func_8005FC64
 #pragma GLOBAL_ASM(                                                                                \

--- a/src/Game/zEntCruiseBubble.cpp
+++ b/src/Game/zEntCruiseBubble.cpp
@@ -70,9 +70,7 @@ extern struct _class_36
     {
         float32 samples;
         float32 bubbles;
-        // Offset: 0x114
         xMat4x3 mat;
-        // Offset: 0x154
         xQuat dir;
     } trail;
     struct _class_6
@@ -85,6 +83,7 @@ extern struct _class_36
         } player;
         struct _class_16
         {
+            // Offset: 0x170
             xAnimState* fire;
             xAnimState* fly;
         } missle;
@@ -681,7 +680,7 @@ void cruise_bubble::refresh_trail(xMat4x3& mat, xQuat& quat)
 
 // func_80057C78
 #ifndef NONMATCHING
-#pragma GLOBAL_ASM("asm/Game/zEntCruiseBubble.s", "start_trail__Q213cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_Fv")
+#pragma GLOBAL_ASM("asm/Game/zEntCruiseBubble.s", "start_trail__13cruise_bubbleFv")
 #else
 void cruise_bubble::start_trail()
 {
@@ -3210,9 +3209,20 @@ cruise_bubble::state_enum cruise_bubble::state_player_wait::update(float32)
 #endif
 
 // func_8005CDBC
+#if 1
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
     "start__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_19state_missle_appearFv")
+#else
+void cruise_bubble::state_missle_appear::start()
+{
+    cruise_bubble::show_missle();
+    shared.missle_model->Flags = shared.missle_model->Flags & 0xfffe;
+    shared.missle_model->Alpha = zEntCruiseBubble_f_1_0;
+    xAnimPlaySetState(shared.missle_model->Anim->Single, shared.astate.missle.fire, zEntCruiseBubble_f_0_0);
+    this->move();
+}
+#endif
 
 void cruise_bubble::state_missle_appear::move()
 {
@@ -3228,14 +3238,41 @@ void cruise_bubble::state_missle_appear::move()
 }
 
 // func_8005CEA0
+#if 1
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
     "stop__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_19state_missle_appearFv")
+#else
+void cruise_bubble::state_missle_appear::stop()
+{
+    hide_missle();
+}
+#endif
 
 // func_8005CEC0
+#if 1
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
     "update__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_19state_missle_appearFf")
+#else
+cruise_bubble::state_enum cruise_bubble::state_missle_appear::update(float32 dt)
+{
+    float32 time = shared.missle_model->Anim->Single->Time + dt;
+    if (time >= current_tweak->missle.appear.delay_show)
+    {
+        shared.missle_model->Flags = shared.missle_model->Flags | 0x1;
+        start_trail();
+    }
+    move();
+
+    if (time >= current_tweak->missle.appear.delay_fly) {
+        return STATE_MISSLE_FLY;
+    }
+
+    this->update_effects(dt);
+    return STATE_MISSLE_APPEAR;
+}
+#endif
 
 void cruise_bubble::state_missle_appear::update_effects(float32 dt)
 {

--- a/src/Game/zEntCruiseBubble.cpp
+++ b/src/Game/zEntCruiseBubble.cpp
@@ -237,6 +237,7 @@ extern float32 zEntCruiseBubble_f_0_047; // 0.047
 extern float32 zEntCruiseBubble_f_0_78; // 0.78
 extern float32 zEntCruiseBubble_f_0_86; // 0.86
 extern float32 zEntCruiseBubble_f_0_15; // 0.15
+extern float32 zEntCruiseBubble_f_0_0001; // 0.15
 
 extern iColor_tag zEntCruiseBubble_color_80_00_00_FF; // 128, 0, 0, 255
 extern iColor_tag zEntCruiseBubble_color_FF_14_14_FF; // 255, 20, 20, 255
@@ -823,7 +824,7 @@ void cruise_bubble::distort_screen(float32)
 #if 1
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
-    "abort__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_10state_typeFv")
+    "abort__Q213cruise_bubble10state_typeFv")
 #else
 void cruise_bubble::state_type::abort()
 {
@@ -922,7 +923,7 @@ void cruise_bubble::render_state()
 #if 1
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
-    "render__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_10state_typeFv")
+    "render__Q213cruise_bubble10state_typeFv")
 #else
 void cruise_bubble::state_type::render()
 {
@@ -2971,19 +2972,59 @@ bool cruise_bubble::event_handler(xBase* from, uint32 event, const float32* fpar
 }
 
 // func_8005C758
+#if 1
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
     "start__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_17state_player_haltFv")
+#else
+void cruise_bubble::state_player_halt::start()
+{
+    this->first_update = true;
+}
+#endif
 
 // func_8005C764
+#if 1
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
     "stop__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_17state_player_haltFv")
+#else
+void cruise_bubble::state_player_halt::stop()
+{
+    shared.flags = shared.flags & 0xffffffdf;
+}
+#endif
 
 // func_8005C778
+#if 1
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
     "update__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_17state_player_haltFf")
+#else
+cruise_bubble::state_enum cruise_bubble::state_player_halt::update(float32 dt)
+{
+    this->time += dt;
+    
+    if (this->first_update)
+    {
+        this->first_update = false;
+        this->last_motion = shared.player_motion;
+        return STATE_PLAYER_HALT;
+    }
+
+    xVec3 dmotion = shared.player_motion - this->last_motion;
+    if (dmotion.length2() < zEntCruiseBubble_f_0_0001) {
+        return STATE_PLAYER_AIM;
+    }
+
+    if (this->time > current_tweak->player.halt_time)
+    {
+        return STATE_INVALID;
+    }
+
+    return STATE_PLAYER_HALT;
+}
+#endif
 
 // func_8005C848
 #pragma GLOBAL_ASM(                                                                                \

--- a/src/Game/zEntCruiseBubble.cpp
+++ b/src/Game/zEntCruiseBubble.cpp
@@ -285,7 +285,7 @@ void cruise_bubble::stop_sound(int32 which, uint32 handle)
 // func_80057320
 // will match once file is complete, see comment below
 #if 1
-#pragma GLOBAL_ASM("asm/Game/zEntCruiseBubble.s", "play_sound__Q213cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_Fif")
+#pragma GLOBAL_ASM("asm/Game/zEntCruiseBubble.s", "play_sound__13cruise_bubbleFif")
 #else
 uint32 cruise_bubble::play_sound(int32 which, float32 volFactor)
 {
@@ -333,7 +333,7 @@ uint32 cruise_bubble::play_sound(int32 which, float32 volFactor)
 // func_80057404
 // will match once file is complete, see comment below
 #if 1
-#pragma GLOBAL_ASM("asm/Game/zEntCruiseBubble.s", "play_sound__Q213cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_FifPC5xVec3")
+#pragma GLOBAL_ASM("asm/Game/zEntCruiseBubble.s", "play_sound__13cruise_bubbleFifPC5xVec3")
 #else
 uint32 cruise_bubble::play_sound(int32 which, float32 volFactor, const xVec3* pos)
 {
@@ -3103,9 +3103,31 @@ cruise_bubble::state_enum cruise_bubble::state_player_aim::update(float32 dt)
     "face_camera__Q213cruise_bubble16state_player_aimFf")
 
 // func_8005CBB8
+#if 1
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
     "start__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_17state_player_fireFv")
+#else
+void cruise_bubble::state_player_fire::start()
+{
+    this->wand_shown = false;
+
+    play_sound(0, zEntCruiseBubble_f_1_0, &get_missle_mat()->pos);
+    xAnimPlayStartTransition(globals.player.ent.model->Anim, shared.atran.player.fire);
+    set_state(THREAD_MISSLE, STATE_MISSLE_APPEAR);
+
+    if (xurand() <= shared.dialog_freq)
+    {
+        play_sound(3, zEntCruiseBubble_f_1_0);
+        shared.dialog_freq *= current_tweak->dialog.decay;
+
+        if (shared.dialog_freq < current_tweak->dialog.min_freq) {
+            shared.dialog_freq = current_tweak->dialog.min_freq;
+        }
+    }
+}
+#endif
+
 
 xMat4x3* cruise_bubble::get_missle_mat()
 {
@@ -3113,14 +3135,51 @@ xMat4x3* cruise_bubble::get_missle_mat()
 }
 
 // func_8005CC84
+#if 1
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
     "stop__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_17state_player_fireFv")
+#else
+void cruise_bubble::state_player_fire::stop()
+{
+    cruise_bubble::hide_wand();
+}
+#endif
 
 // func_8005CCA4
+#if 1
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
     "update__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_17state_player_fireFf")
+#else
+cruise_bubble::state_enum cruise_bubble::state_player_fire::update(float32 dt)
+{
+    xAnimSingle* asingle = globals.player.ent.model->Anim->Single;
+    xAnimState* astate = asingle->State;
+
+    if (astate == shared.astate.player.fire)
+    {
+        float32 time = astate->Data->Duration;
+        float32 max_time = asingle->Time + dt;
+
+        if (this->wand_shown == 0 && max_time >= current_tweak->player.fire.delay_wand)
+        {
+            show_wand();
+        }
+        if (max_time >= time)
+        {
+            return STATE_PLAYER_WAIT;
+        }
+    }
+
+    if (this->wand_shown != 0)
+    {
+        this->update_wand(dt);
+    }
+
+    return  STATE_PLAYER_FIRE;
+}
+#endif
 
 void cruise_bubble::state_player_fire::update_wand(float32 dt)
 {

--- a/src/Game/zEntCruiseBubble.cpp
+++ b/src/Game/zEntCruiseBubble.cpp
@@ -1,8 +1,9 @@
+#include <cmath>
+#include <string.h>
+
 #include "stdio.h"
 #include "zEnt.h"
 #include "zRenderState.h"
-#include <cmath>
-#include <string.h>
 
 #include "zCamera.h"
 #include "zEntButton.h"
@@ -12,8 +13,11 @@
 #include "zEntTrigger.h"
 #include "zGameExtras.h"
 #include "zGlobals.h"
+#include "zNPCTypeCommon.h"
+#include "zPlatform.h"
 #include "zTalkBox.h"
 
+#include "../Core/p2/iMath.h"
 #include "../Core/x/xColor.h"
 #include "../Core/x/xDecal.h"
 #include "../Core/x/xFX.h"
@@ -25,8 +29,6 @@
 #include "../Core/x/xString.h"
 #include "../Core/x/xstransvc.h"
 #include "../Core/x/xVec3.h"
-#include "zNPCTypeCommon.h"
-#include "zPlatform.h"
 
 namespace cruise_bubble
 {
@@ -3320,9 +3322,23 @@ void cruise_bubble::state_missle_fly::update_flash(float32 dt)
 }
 
 // func_8005D3D4
+#ifdef NON_MATCHING
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
     "update_engine_sound__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16state_missle_flyFf")
+#else
+void cruise_bubble::state_missle_fly::update_engine_sound(float32 dt)
+{
+    // regalloc, i can't figure this out rn
+    float32 x = iabs(shared.last_sp.x);
+    float32 y = iabs(shared.last_sp.y);
+    float32 tmp = current_tweak->missle.fly.engine_pitch_max * (x + y);
+    tmp = tmp - this->engine_pitch;
+    this->engine_pitch += current_tweak->missle.fly.engine_pitch_sensitivity * tmp;
+
+    set_pitch(2, this->engine_pitch, 0);
+}
+#endif
 
 // func_8005D448
 #pragma GLOBAL_ASM(                                                                                \

--- a/src/Game/zEntCruiseBubble.cpp
+++ b/src/Game/zEntCruiseBubble.cpp
@@ -1593,7 +1593,7 @@ void cruise_bubble::render_hud()
 #if 1
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
-    "show_hud__Q213cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_Fv")
+    "show_hud__13cruise_bubbleFv")
 #else
 void cruise_bubble::show_hud()
 {
@@ -3712,19 +3712,68 @@ cruise_bubble::state_enum cruise_bubble::state_camera_aim::update(float32 dt)
     "move__Q213cruise_bubble16state_camera_aimFf")
 
 // func_8005ED1C
+#if 1
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
     "start__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18state_camera_seizeFv")
+#else
+void cruise_bubble::state_camera_seize::start()
+{
+    capture_camera();
+
+    this->blend_time = zEntCruiseBubble_f_0_0;
+    this->start_loc = globals.camera.mat.pos;
+    xQuatFromMat(&this->start_dir, &globals.camera.mat);
+    this->last_s = zEntCruiseBubble_f_0_0;
+    this->fov = zEntCruiseBubble_f_0_0;
+    this->wipe_bubbles = zEntCruiseBubble_f_0_0;
+
+    show_hud();
+    distort_screen(zEntCruiseBubble_f_0_0);
+}
+#endif
 
 // func_8005ED9C
+#if 1
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
     "stop__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18state_camera_seizeFv")
+#else
+void cruise_bubble::state_camera_seize::stop()
+{
+    release_camera();
+    xCameraSetFOV(&globals.camera, shared.fov_default);
+}
+#endif
 
 // func_8005EDD4
+#if 1
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
     "update__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18state_camera_seizeFf")
+#else
+cruise_bubble::state_enum cruise_bubble::state_camera_seize::update(float32 dt)
+{
+    this->blend_time += dt;
+    if (this->blend_time >= current_tweak->camera.seize.blend_time)
+    {
+        return STATE_CAMERA_ATTACH;
+    }
+
+    float32 time_frac = this->blend_time / current_tweak->camera.seize.blend_time;
+    float32 s = xSCurve(time_frac);
+    this->update_move(s);
+    this->update_turn(s);
+    xVec3 offset = get_missle_mat()->pos - globals.camera.mat.pos;
+    this->refresh_missle_alpha(offset.length());
+
+    float32 dist = current_tweak->camera.seize.fov - shared.fov_default;
+    xCameraSetFOV(&globals.camera, s * dist + shared.fov_default);
+    distort_screen(s);
+
+    return STATE_CAMERA_SEIZE;
+}
+#endif
 
 // func_8005EED4
 #pragma GLOBAL_ASM(                                                                                \

--- a/src/Game/zEntCruiseBubble.cpp
+++ b/src/Game/zEntCruiseBubble.cpp
@@ -3474,9 +3474,33 @@ void cruise_bubble::state_missle_fly::update_engine_sound(float32 dt)
     "calculate_rotation__Q213cruise_bubble16state_missle_flyCFR5xVec2R5xVec2fRC5xVec2RC5xVec2RC5xVec2RC5xVec2")
 
 // func_8005DC2C
+#if 1
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
     "start__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_20state_missle_explodeFv")
+#else
+void cruise_bubble::state_missle_explode::start()
+{
+    shared.flags = shared.flags | 0x40;
+    // scheduling for zEntCruiseBubble_f_0_0
+    this->hit_time = zEntCruiseBubble_f_0_0;
+
+    if (current_tweak->missle.explode.hit_duration <= zEntCruiseBubble_f_0_0)
+    {
+        this->apply_damage(current_tweak->missle.explode.hit_radius);
+    }
+    
+    float32 dist = (shared.hit_loc - get_player_loc()).length2();
+    // regalloc for current_tweak
+    float32 min_dist = current_tweak->camera.survey.min_dist * current_tweak->camera.survey.min_dist;
+    // scheduling for THREAD_CAMERA
+    set_state(THREAD_CAMERA, dist <= min_dist ? STATE_CAMERA_RESTORE : STATE_CAMERA_SURVEY);
+
+    
+    play_sound(1, zEntCruiseBubble_f_1_0, &get_missle_mat()->pos);
+    this->start_effects();
+}
+#endif
 
 // func_8005DCF8
 #pragma GLOBAL_ASM(                                                                                \
@@ -3524,14 +3548,36 @@ void cruise_bubble::state_missle_fly::update_engine_sound(float32 dt)
     "__ct__Q413cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_20state_missle_explode13cb_damage_entFf")
 
 // func_8005E578
+#if 1
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
     "stop__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_20state_missle_explodeFv")
+#else
+void cruise_bubble::state_missle_explode::stop()
+{
+    shared.flags = shared.flags & 0xffffffbf;
+}
+#endif
 
 // func_8005E58C
+#if 1
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
     "update__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_20state_missle_explodeFf")
+#else
+cruise_bubble::state_enum cruise_bubble::state_missle_explode::update(float32 dt)
+{
+    this->hit_time += dt;
+
+    if (this->hit_time <= current_tweak->missle.explode.hit_duration)
+    {
+        float32 t = this->hit_time / current_tweak->missle.explode.hit_duration;
+        this->apply_damage(t * current_tweak->missle.explode.hit_radius);
+    }
+    
+    return STATE_MISSLE_EXPLODE;
+}
+#endif
 
 // func_8005E5E0
 #pragma GLOBAL_ASM(                                                                                \

--- a/src/Game/zEntCruiseBubble.cpp
+++ b/src/Game/zEntCruiseBubble.cpp
@@ -3286,7 +3286,7 @@ void cruise_bubble::state_missle_appear::update_effects(float32 dt)
 }
 
 // func_8005CF84
-#if 1
+#ifndef NON_MATCHING
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
     "start__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16state_missle_flyFv")
@@ -3373,7 +3373,7 @@ cruise_bubble::state_enum cruise_bubble::state_missle_fly::update(float32 dt)
     if (this->life <= zEntCruiseBubble_f_0_0 || (globals.pad0->pressed & 0x100) != 0)
     {
         shared.hit_loc = get_missle_mat()->pos;
-        shared.hit_norm = get_missle_mat()->up;
+        shared.hit_norm = get_missle_mat()->at;
 
         return STATE_MISSLE_EXPLODE;
     }
@@ -3425,7 +3425,7 @@ void cruise_bubble::state_missle_fly::update_flash(float32 dt)
 #ifndef NON_MATCHING
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
-    "update_engine_sound__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16state_missle_flyFf")
+    "update_engine_sound__Q213cruise_bubble16state_missle_flyFf")
 #else
 void cruise_bubble::state_missle_fly::update_engine_sound(float32 dt)
 {
@@ -3476,7 +3476,7 @@ void cruise_bubble::state_missle_fly::update_engine_sound(float32 dt)
     "calculate_rotation__Q213cruise_bubble16state_missle_flyCFR5xVec2R5xVec2fRC5xVec2RC5xVec2RC5xVec2RC5xVec2")
 
 // func_8005DC2C
-#if 1
+#ifndef NON_MATCHING
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
     "start__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_20state_missle_explodeFv")
@@ -3582,7 +3582,7 @@ cruise_bubble::state_enum cruise_bubble::state_missle_explode::update(float32 dt
 #endif
 
 // func_8005E5E0
-#if 1
+#ifndef NON_MATCHING
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
     "start__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16state_camera_aimFv")
@@ -3593,13 +3593,8 @@ void cruise_bubble::state_camera_aim::start()
     xSndSelectListenerMode(SND_LISTENER_MODE_CAMERA);
     xCameraUpdate(&globals.camera, zEntCruiseBubble_f_0_001);
     
+    this->phi_vel = this->height_vel = this->dist_vel = zEntCruiseBubble_f_0_0;
     xMat4x3* mat = &globals.camera.mat;
-    // zero var needed for zEntCruiseBubble_f_0_0 to not be loaded for every assignment
-    float32 zero = zEntCruiseBubble_f_0_0;
-    this->dist_vel = zero;
-    this->height_vel = zero;
-    this->phi_vel = zero;
-
     xVec3& ploc = get_player_loc();
     // pretty sure the next 5 lines were originally just 1 looking like this:
     // xVec2 offset = {mat->pos.x - ploc.x, mat->pos.z - ploc.z};
@@ -3616,11 +3611,7 @@ void cruise_bubble::state_camera_aim::start()
     this->phi = xatan2(offset.x, offset.y);
     this->height = mat->pos.y - ploc.y;
     this->dist = offset.length();
-    
-    // zero var needed for zEntCruiseBubble_f_0_0 to not be loaded for every assignment
-    zero = zEntCruiseBubble_f_0_0;
-    this->seize_delay = zero;
-    this->control_delay = zero;
+    this->control_delay = this->seize_delay = zEntCruiseBubble_f_0_0;
     
     xQuatFromMat(&this->facing, mat);
     start_cam_mat = *mat;

--- a/src/Game/zEntCruiseBubble.cpp
+++ b/src/Game/zEntCruiseBubble.cpp
@@ -3729,17 +3729,17 @@ cruise_bubble::state_enum cruise_bubble::state_camera_aim::update(float32 dt)
 // func_8005EED4
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
-    "refresh_missle_alpha__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18state_camera_seizeFf")
+    "refresh_missle_alpha__Q213cruise_bubble18state_camera_seizeFf")
 
 // func_8005EF6C
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
-    "update_turn__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18state_camera_seizeFf")
+    "update_turn__Q213cruise_bubble18state_camera_seizeFf")
 
 // func_8005F058
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
-    "update_move__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18state_camera_seizeFf")
+    "update_move__Q213cruise_bubble18state_camera_seizeFf")
 
 // func_8005F100
 #pragma GLOBAL_ASM("asm/Game/zEntCruiseBubble.s", "xSCurve__Ff")

--- a/src/Game/zEntCruiseBubble.cpp
+++ b/src/Game/zEntCruiseBubble.cpp
@@ -3128,7 +3128,6 @@ void cruise_bubble::state_player_fire::start()
 }
 #endif
 
-
 xMat4x3* cruise_bubble::get_missle_mat()
 {
     return (xMat4x3*) shared.missle_model->Mat;
@@ -3215,10 +3214,18 @@ cruise_bubble::state_enum cruise_bubble::state_player_wait::update(float32)
     "asm/Game/zEntCruiseBubble.s",                                                                 \
     "start__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_19state_missle_appearFv")
 
-// func_8005CE2C
-#pragma GLOBAL_ASM(                                                                                \
-    "asm/Game/zEntCruiseBubble.s",                                                                 \
-    "move__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_19state_missle_appearFv")
+void cruise_bubble::state_missle_appear::move()
+{
+    xMat4x3& mat = *get_missle_mat();
+    xVec3 euler;
+    xVec3 prod;
+
+    mat = *get_player_mat();
+    xMat3x3GetEuler(&mat, &euler);
+    xMat3x3Euler(&mat, &euler);
+    xMat3x3RMulVec(&prod, &mat, &current_tweak->missle.appear.offset);
+    mat.pos += prod;
+}
 
 // func_8005CEA0
 #pragma GLOBAL_ASM(                                                                                \

--- a/src/Game/zEntCruiseBubble.cpp
+++ b/src/Game/zEntCruiseBubble.cpp
@@ -3481,42 +3481,42 @@ void cruise_bubble::state_missle_fly::update_engine_sound(float32 dt)
 // func_8005DCF8
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
-    "start_effects__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_20state_missle_explodeFv")
+    "start_effects__Q213cruise_bubble20state_missle_explodeFv")
 
 // func_8005DE20
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
-    "cb_droplet__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_20state_missle_explodeFP5zFragP10zFragAsset")
+    "cb_droplet__Q213cruise_bubble20state_missle_explodeFP5zFragP10zFragAsset")
 
 // func_8005DFBC
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
-    "perturb_direction__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_20state_missle_explodeFRC5xVec3ffff")
+    "perturb_direction__Q213cruise_bubble20state_missle_explodeFRC5xVec3ffff")
 
 // func_8005E178
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
-    "get_next_quadrant__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_20state_missle_explodeFRfRfRfRf")
+    "get_next_quadrant__Q213cruise_bubble20state_missle_explodeFRfRfRfRf")
 
 // func_8005E248
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
-    "reset_quadrants__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_20state_missle_explodeFUif")
+    "reset_quadrants__Q213cruise_bubble20state_missle_explodeFUif")
 
 // func_8005E3BC
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
-    "apply_damage__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_20state_missle_explodeFf")
+    "apply_damage__Q213cruise_bubble20state_missle_explodeFf")
 
 // func_8005E4A0
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
-    "apply_damage_hazards__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_20state_missle_explodeFf")
+    "apply_damage_hazards__Q213cruise_bubble20state_missle_explodeFf")
 
 // func_8005E4D8
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
-    "hazard_check__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_20state_missle_explodeFR9NPCHazardPv")
+    "hazard_check__Q213cruise_bubble20state_missle_explodeFR9NPCHazardPv")
 
 // func_8005E570
 #pragma GLOBAL_ASM(                                                                                \

--- a/src/Game/zEntCruiseBubble.cpp
+++ b/src/Game/zEntCruiseBubble.cpp
@@ -3870,27 +3870,27 @@ cruise_bubble::state_enum cruise_bubble::state_camera_attach::update(float32 dt)
 // func_8005F4F8
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
-    "move__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_19state_camera_surveyFv")
+    "move__Q213cruise_bubble19state_camera_surveyFv")
 
 // func_8005F5EC
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
-    "eval_missle_path__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_19state_camera_surveyCFfR5xVec3Rf")
+    "eval_missle_path__Q213cruise_bubble19state_camera_surveyCFfR5xVec3Rf")
 
 // func_8005F714
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
-    "lerp__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_19state_camera_surveyCFRffff")
+    "lerp__Q213cruise_bubble19state_camera_surveyCFRffff")
 
 // func_8005F724
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
-    "lerp__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_19state_camera_surveyCFR5xVec3fRC5xVec3RC5xVec3")
+    "lerp__Q213cruise_bubble19state_camera_surveyCFR5xVec3fRC5xVec3RC5xVec3")
 
 // func_8005F7C0
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
-    "find_nearest__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_19state_camera_surveyCFf")
+    "find_nearest__Q213cruise_bubble19state_camera_surveyCFf")
 
 // func_8005F864
 #pragma GLOBAL_ASM("asm/Game/zEntCruiseBubble.s", "xSCurve__Fff")
@@ -3898,7 +3898,7 @@ cruise_bubble::state_enum cruise_bubble::state_camera_attach::update(float32 dt)
 // func_8005F8C4
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
-    "init_path__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_19state_camera_surveyFv")
+    "init_path__Q213cruise_bubble19state_camera_surveyFv")
 
 // func_8005F9C0
 #pragma GLOBAL_ASM(                                                                                \
@@ -3913,7 +3913,7 @@ cruise_bubble::state_enum cruise_bubble::state_camera_attach::update(float32 dt)
 // func_8005FA94
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
-    "control_jerked__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_19state_camera_surveyCFv")
+    "control_jerked__Q213cruise_bubble19state_camera_surveyCFv")
 
 // func_8005FB4C
 #pragma GLOBAL_ASM(                                                                                \

--- a/src/Game/zEntCruiseBubble.cpp
+++ b/src/Game/zEntCruiseBubble.cpp
@@ -3287,10 +3287,10 @@ void cruise_bubble::state_missle_appear::update_effects(float32 dt)
     "asm/Game/zEntCruiseBubble.s",                                                                 \
     "start__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16state_missle_flyFv")
 
-// func_8005D08C
-#pragma GLOBAL_ASM(                                                                                \
-    "asm/Game/zEntCruiseBubble.s",                                                                 \
-    "__ct__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_18missle_record_dataFRC5xVec3f")
+
+cruise_bubble::missle_record_data::missle_record_data(const xVec3& loc, float32 roll)
+    : loc(loc), roll(roll)
+{ }
 
 // func_8005D0AC
 #pragma GLOBAL_ASM(                                                                                \

--- a/src/Game/zEntCruiseBubble.cpp
+++ b/src/Game/zEntCruiseBubble.cpp
@@ -728,7 +728,7 @@ void cruise_bubble::set_state(cruise_bubble::thread_enum thread, cruise_bubble::
 #if 1
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
-    "start__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_10state_typeFv")
+    "start__Q213cruise_bubble10state_typeFv")
 #else
 void cruise_bubble::state_type::start()
 {
@@ -740,7 +740,7 @@ void cruise_bubble::state_type::start()
 #if 1
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
-    "stop__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_10state_typeFv")
+    "stop__Q213cruise_bubble10state_typeFv")
 #else
 void cruise_bubble::state_type::stop()
 {

--- a/src/Game/zEntCruiseBubble.cpp
+++ b/src/Game/zEntCruiseBubble.cpp
@@ -3122,10 +3122,10 @@ xMat4x3* cruise_bubble::get_missle_mat()
     "asm/Game/zEntCruiseBubble.s",                                                                 \
     "update__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_17state_player_fireFf")
 
-// func_8005CD90
-#pragma GLOBAL_ASM(                                                                                \
-    "asm/Game/zEntCruiseBubble.s",                                                                 \
-    "update_wand__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_17state_player_fireFf")
+void cruise_bubble::state_player_fire::update_wand(float32 dt)
+{
+    // empty
+}
 
 // func_8005CD94
 #pragma GLOBAL_ASM(                                                                                \

--- a/src/Game/zEntCruiseBubble.cpp
+++ b/src/Game/zEntCruiseBubble.cpp
@@ -3811,22 +3811,22 @@ cruise_bubble::state_enum cruise_bubble::state_camera_seize::update(float32 dt)
 // func_8005F264
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
-    "lock_targets__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_19state_camera_attachFv")
+    "lock_targets__Q213cruise_bubble19state_camera_attachFv")
 
 // func_8005F2FC
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
-    "lock_hazard_targets__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_19state_camera_attachFv")
+    "lock_hazard_targets__Q213cruise_bubble19state_camera_attachFv")
 
 // func_8005F330
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
-    "hazard_check__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_19state_camera_attachFR9NPCHazardPv")
+    "hazard_check__Q213cruise_bubble19state_camera_attachFR9NPCHazardPv")
 
 // func_8005F358
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
-    "get_view_bound__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_19state_camera_attachCFR6xBound")
+    "get_view_bound__Q213cruise_bubble19state_camera_attachCFR6xBound")
 
 // func_8005F480
 #pragma GLOBAL_ASM(                                                                                \

--- a/src/Game/zEntCruiseBubble.cpp
+++ b/src/Game/zEntCruiseBubble.cpp
@@ -429,9 +429,9 @@ void cruise_bubble::release_camera()
 
 // func_800575FC
 #ifndef NONMATCHING
-#pragma GLOBAL_ASM("asm/Game/zEntCruiseBubble.s", "camera_taken__Q213cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_Fv")
+#pragma GLOBAL_ASM("asm/Game/zEntCruiseBubble.s", "camera_taken__13cruise_bubbleFv")
 #else
-uint32 cruise_bubble::camera_taken()
+bool cruise_bubble::camera_taken()
 {
     // dumb non match cause it seems the compiler doesnt assume the type of the return value correctly
     // to me it looks like the case Ninja shifts described in https://pastebin.com/XjJpBzah
@@ -3863,9 +3863,27 @@ cruise_bubble::state_enum cruise_bubble::state_camera_attach::update(float32 dt)
     "get_view_bound__Q213cruise_bubble19state_camera_attachCFR6xBound")
 
 // func_8005F480
+#if 1
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
     "start__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_19state_camera_surveyFv")
+#else
+void cruise_bubble::state_camera_survey::start()
+{
+    if (camera_taken())
+    {
+        release_camera();
+        this->time = current_tweak->camera.survey.duration;
+        return;
+    }
+    
+    capture_camera();
+    this->time = zEntCruiseBubble_f_0_0;
+    this->init_path();
+    this->move();
+    this->start_sp = shared.sp;
+}
+#endif
 
 // func_8005F4F8
 #pragma GLOBAL_ASM(                                                                                \
@@ -3901,14 +3919,47 @@ cruise_bubble::state_enum cruise_bubble::state_camera_attach::update(float32 dt)
     "init_path__Q213cruise_bubble19state_camera_surveyFv")
 
 // func_8005F9C0
+#if 1
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
     "stop__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_19state_camera_surveyFv")
+#else
+void cruise_bubble::state_camera_survey::stop()
+{
+    release_camera();
+}
+#endif
 
 // func_8005F9E0
+#if 1
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
     "update__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_19state_camera_surveyFf")
+#else
+cruise_bubble::state_enum cruise_bubble::state_camera_survey::update(float32 dt)
+{
+    this->time += dt;
+
+    if (camera_taken())
+    {
+        return STATE_CAMERA_RESTORE;
+    }
+    
+    if (this->time >= current_tweak->camera.survey.duration)
+    {
+        return STATE_CAMERA_RESTORE;
+    }
+    
+    if (this->time >= current_tweak->camera.survey.min_duration &&
+            ((globals.pad0->pressed & 0x100) != 0 || this->control_jerked()))
+    {
+        return STATE_CAMERA_RESTORE;
+    }
+
+    this->move();
+    return STATE_CAMERA_SURVEY;
+}
+#endif
 
 // func_8005FA94
 #pragma GLOBAL_ASM(                                                                                \

--- a/src/Game/zEntCruiseBubble.cpp
+++ b/src/Game/zEntCruiseBubble.cpp
@@ -1,6 +1,7 @@
 #include "stdio.h"
 #include "zEnt.h"
 #include "zRenderState.h"
+#include <cmath>
 #include <string.h>
 
 #include "zCamera.h"
@@ -3304,10 +3305,19 @@ void cruise_bubble::state_missle_appear::update_effects(float32 dt)
     "asm/Game/zEntCruiseBubble.s",                                                                 \
     "update__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16state_missle_flyFf")
 
-// func_8005D350
-#pragma GLOBAL_ASM(                                                                                \
-    "asm/Game/zEntCruiseBubble.s",                                                                 \
-    "update_flash__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16state_missle_flyFf")
+void cruise_bubble::state_missle_fly::update_flash(float32 dt)
+{
+    this->flash_time += dt;
+
+    float32 tflash = current_tweak->missle.fly.flash_interval * (this->life / current_tweak->missle.life);
+    if (this->flash_time > tflash)
+    {
+        flash_hud();
+        
+        float32 floor_frac = std::floorf(this->flash_time / tflash);
+        this->flash_time = this->flash_time - (floor_frac * tflash);
+    }
+}
 
 // func_8005D3D4
 #pragma GLOBAL_ASM(                                                                                \

--- a/src/Game/zEntCruiseBubble.cpp
+++ b/src/Game/zEntCruiseBubble.cpp
@@ -3237,10 +3237,10 @@ void cruise_bubble::state_missle_appear::move()
     "asm/Game/zEntCruiseBubble.s",                                                                 \
     "update__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_19state_missle_appearFf")
 
-// func_8005CF80
-#pragma GLOBAL_ASM(                                                                                \
-    "asm/Game/zEntCruiseBubble.s",                                                                 \
-    "update_effects__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_19state_missle_appearFf")
+void cruise_bubble::state_missle_appear::update_effects(float32 dt)
+{
+    //empty
+}
 
 // func_8005CF84
 #pragma GLOBAL_ASM(                                                                                \

--- a/src/Game/zEntCruiseBubble.cpp
+++ b/src/Game/zEntCruiseBubble.cpp
@@ -3597,32 +3597,32 @@ cruise_bubble::state_enum cruise_bubble::state_missle_explode::update(float32 dt
 // func_8005E808
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
-    "apply_turn__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16state_camera_aimCFv")
+    "apply_turn__Q213cruise_bubble16state_camera_aimCFv")
 
 // func_8005E84C
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
-    "turn__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16state_camera_aimFf")
+    "turn__Q213cruise_bubble16state_camera_aimFf")
 
 // func_8005E944
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
-    "collide_inward__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16state_camera_aimFv")
+    "collide_inward__Q213cruise_bubble16state_camera_aimFv")
 
 // func_8005EAFC
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
-    "apply_motion__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16state_camera_aimCFv")
+    "apply_motion__Q213cruise_bubble16state_camera_aimCFv")
 
 // func_8005EB90
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
-    "stop__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16state_camera_aimFf")
+    "stop__Q213cruise_bubble16state_camera_aimFf")
 
 // func_8005EC20
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
-    "move__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16state_camera_aimFf")
+    "move__Q213cruise_bubble16state_camera_aimFf")
 
 // func_8005ED1C
 #pragma GLOBAL_ASM(                                                                                \

--- a/src/Game/zEntCruiseBubble.cpp
+++ b/src/Game/zEntCruiseBubble.cpp
@@ -3031,10 +3031,11 @@ cruise_bubble::state_enum cruise_bubble::state_player_halt::update(float32 dt)
     "asm/Game/zEntCruiseBubble.s",                                                                 \
     "start__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_16state_player_aimFv")
 
-// func_8005C8D4
-#pragma GLOBAL_ASM(                                                                                \
-    "asm/Game/zEntCruiseBubble.s",                                                                 \
-    "get_player_mat__Q213cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_Fv")
+
+xMat4x3* cruise_bubble::get_player_mat()
+{
+    return (xMat4x3*) globals.player.ent.model->Mat;
+}
 
 // func_8005C8E8
 #pragma GLOBAL_ASM(                                                                                \

--- a/src/Game/zEntCruiseBubble.cpp
+++ b/src/Game/zEntCruiseBubble.cpp
@@ -3107,10 +3107,10 @@ cruise_bubble::state_enum cruise_bubble::state_player_aim::update(float32 dt)
     "asm/Game/zEntCruiseBubble.s",                                                                 \
     "start__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_17state_player_fireFv")
 
-// func_8005CC70
-#pragma GLOBAL_ASM(                                                                                \
-    "asm/Game/zEntCruiseBubble.s",                                                                 \
-    "get_missle_mat__Q213cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_Fv")
+xMat4x3* cruise_bubble::get_missle_mat()
+{
+    return (xMat4x3*) shared.missle_model->Mat;
+}
 
 // func_8005CC84
 #pragma GLOBAL_ASM(                                                                                \

--- a/src/Game/zEntCruiseBubble.cpp
+++ b/src/Game/zEntCruiseBubble.cpp
@@ -3187,14 +3187,28 @@ void cruise_bubble::state_player_fire::update_wand(float32 dt)
 }
 
 // func_8005CD94
+#if 1
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
     "start__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_17state_player_waitFv")
+#else
+void cruise_bubble::state_player_wait::start()
+{
+    cruise_bubble::hide_wand();
+}
+#endif
 
 // func_8005CDB4
+#if 1
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
     "update__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_17state_player_waitFf")
+#else
+cruise_bubble::state_enum cruise_bubble::state_player_wait::update(float32)
+{
+    return STATE_PLAYER_WAIT;
+}
+#endif
 
 // func_8005CDBC
 #pragma GLOBAL_ASM(                                                                                \

--- a/src/Game/zEntCruiseBubble.cpp
+++ b/src/Game/zEntCruiseBubble.cpp
@@ -3794,19 +3794,53 @@ cruise_bubble::state_enum cruise_bubble::state_camera_seize::update(float32 dt)
 #pragma GLOBAL_ASM("asm/Game/zEntCruiseBubble.s", "xSCurve__Ff")
 
 // func_8005F138
+#if 1
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
     "start__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_19state_camera_attachFv")
+#else
+void cruise_bubble::state_camera_attach::start()
+{
+    capture_camera();
+    xMat4x3* mat = get_missle_mat();
+    xCameraMove(&globals.camera, mat->pos);
+    xCameraRotate(&globals.camera, *mat, zEntCruiseBubble_f_0_0, zEntCruiseBubble_f_0_0, zEntCruiseBubble_f_0_0);
+    xCameraSetFOV(&globals.camera, current_tweak->camera.seize.fov);
+    distort_screen(zEntCruiseBubble_f_1_0);
+}
+#endif
 
 // func_8005F1B0
+#if 1
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
     "stop__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_19state_camera_attachFv")
+#else
+void cruise_bubble::state_camera_attach::stop()
+{
+    xCameraSetFOV(&globals.camera, shared.fov_default);
+    release_camera();
+    hide_hud();
+    distort_screen(zEntCruiseBubble_f_0_0);
+}
+#endif
 
 // func_8005F1F4
+#if 1
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
     "update__Q313cruise_bubble30_esc__2_unnamed_esc__2_zEntCruiseBubble_cpp_esc__2_19state_camera_attachFf")
+#else
+cruise_bubble::state_enum cruise_bubble::state_camera_attach::update(float32 dt)
+{
+    xMat4x3* mat = get_missle_mat();
+    xCameraMove(&globals.camera, mat->pos);
+    xCameraRotate(&globals.camera, *mat, zEntCruiseBubble_f_0_0, zEntCruiseBubble_f_0_0, zEntCruiseBubble_f_0_0);
+    this->lock_targets();
+
+    return STATE_CAMERA_ATTACH;
+}
+#endif
 
 // func_8005F264
 #pragma GLOBAL_ASM(                                                                                \

--- a/src/Game/zEntCruiseBubble.cpp
+++ b/src/Game/zEntCruiseBubble.cpp
@@ -3093,9 +3093,20 @@ cruise_bubble::state_enum cruise_bubble::state_player_aim::update(float32 dt)
 #endif
 
 // func_8005C998
+#ifndef NON_MATCHING
 #pragma GLOBAL_ASM(                                                                                \
     "asm/Game/zEntCruiseBubble.s",                                                                 \
     "update_animation__Q213cruise_bubble16state_player_aimFf")
+#else
+void cruise_bubble::state_player_aim::update_animation(float32 dt)
+{
+    float32 r = range_limit<float32>(
+            this->yaw_vel * current_tweak->player.aim.anim_delta,
+            zEntCruiseBubble_f_n1_0, zEntCruiseBubble_f_1_0);
+    xAnimSingle* s = globals.player.ent.model->Anim->Single;
+    s->BilinearLerp[0] = zEntCruiseBubble_f_0_5 * ((zEntCruiseBubble_f_1_0 + s->BilinearLerp[0]) + r);
+}
+#endif
 
 // func_8005CA00
 #pragma GLOBAL_ASM(                                                                                \
@@ -3294,7 +3305,8 @@ void cruise_bubble::state_missle_appear::update_effects(float32 dt)
 void cruise_bubble::state_missle_fly::start()
 {
     // lwzu
-    shared.flags = shared.flags | 0x8;
+    // & to match function size
+    shared.flags = (shared.flags | 0x8) & 0x4;
     this->life = current_tweak->missle.life;
     
     show_missle();

--- a/src/Game/zEntCruiseBubble.h
+++ b/src/Game/zEntCruiseBubble.h
@@ -279,7 +279,7 @@ namespace cruise_bubble
     struct tweak_group
     {
         float32 aim_delay;
-        // Size: 0x10
+        // Size: 0x10, Offset: 0x4
         struct _class_2
         {
             float32 halt_time;
@@ -293,8 +293,8 @@ namespace cruise_bubble
                 float32 delay_wand;
             } fire;
         } player;
-
-        // Size: 0x5c
+        
+        // Size: 0x5c, Offset: 0x14
         struct _class_22
         {
             float32 life;
@@ -332,7 +332,7 @@ namespace cruise_bubble
             } explode;
         } missle;
 
-        // Size: 0x5c
+        // Size: 0x5c, Offset: 0x70
         struct _class_10
         {
             struct _class_15
@@ -372,7 +372,7 @@ namespace cruise_bubble
             } restore;
         } camera;
 
-        // Size: 0x18
+        // Size: 0x18, Offset: 0xcc
         struct _class_48
         {
             float32 env_alpha;
@@ -383,7 +383,7 @@ namespace cruise_bubble
             uint32 fresnel_texture;
         } material;
 
-        // Size: 0x14
+        // Size: 0x14, Offset: 0xe4
         struct _class_9
         {
             // Offset: 0xe4
@@ -395,7 +395,7 @@ namespace cruise_bubble
             float32 delay_retarget;
         } reticle;
 
-        // Size: 0x10
+        // Size: 0x10, Offset: 0xf8
         struct _class_20
         {
             // Offset: 0xf8
@@ -404,8 +404,8 @@ namespace cruise_bubble
             float32 bubble_emit_radius;
             float32 wake_emit_radius;
         } trail;
-
-        // Size: 0x10
+        
+        // Size: 0x10, Offset: 0x108
         struct _class_29
         {
             uint32 emit;
@@ -414,7 +414,7 @@ namespace cruise_bubble
             float32 rand_vel;
         } blast;
 
-        // Size: 0x24
+        // Size: 0x24, Offset: 0x118
         struct _class_35
         {
             float32 dist_min;
@@ -427,8 +427,8 @@ namespace cruise_bubble
             float32 vel_angle;
             float32 rot_vel_max;
         } droplet;
-
-        // Size: 0x44
+        
+        // Size: 0x44, Offset: 0x13c
         struct _class_43
         {
             float32 glow_size;
@@ -467,8 +467,8 @@ namespace cruise_bubble
                 float32 glow_size;
             } timer;
         } hud;
-
-        // Size: 0xc
+        
+        // Size: 0xc, Offset: 0x180
         struct _class_34
         {
             float32 freq;

--- a/src/Game/zEntCruiseBubble.h
+++ b/src/Game/zEntCruiseBubble.h
@@ -74,6 +74,7 @@ namespace cruise_bubble
 
         void start();
         state_enum update(float32 dt);
+        void update_wand(float32 dt);
     };
 
     struct state_camera_aim : state_type

--- a/src/Game/zEntCruiseBubble.h
+++ b/src/Game/zEntCruiseBubble.h
@@ -205,7 +205,12 @@ namespace cruise_bubble
         state_camera_seize();
 
         void start();
+        void stop();
         state_enum update(float32 dt);
+
+        void refresh_missle_alpha(float32);
+        void update_turn(float32);
+        void update_move(float32);
     };
 
     struct state_player_aim : state_type

--- a/src/Game/zEntCruiseBubble.h
+++ b/src/Game/zEntCruiseBubble.h
@@ -135,9 +135,12 @@ namespace cruise_bubble
         float32 life;
         float32 vel;
         xVec3 rot;
+        // Offset: 0x1c
         xVec3 rot_vel;
+        // Offset: 0x28
         float32 engine_pitch;
         xVec3 last_loc;
+        // Offset: 0x38
         float32 flash_time;
 
         state_missle_fly();
@@ -145,6 +148,7 @@ namespace cruise_bubble
         void start();
         state_enum update(float32 dt);
         uint8 hit_test(xVec3& hit_loc, xVec3& hit_norm, xVec3& hit_depen, xEnt*& hit_ent) const;
+        void update_flash(float32 dt);
     };
 
     struct state_missle_appear : state_type

--- a/src/Game/zEntCruiseBubble.h
+++ b/src/Game/zEntCruiseBubble.h
@@ -212,6 +212,9 @@ namespace cruise_bubble
     struct state_player_wait : state_type
     {
         state_player_wait();
+
+        void start();
+        state_enum update(float32 dt);
     };
 
     struct sound_config

--- a/src/Game/zEntCruiseBubble.h
+++ b/src/Game/zEntCruiseBubble.h
@@ -118,8 +118,18 @@ namespace cruise_bubble
         state_missle_explode();
 
         void start();
+        void stop();
         state_enum update(float32 dt);
+
         float32 get_radius() const;
+        void start_effects();
+        void cb_droplet(zFrag* frag, zFragAsset* fa);
+        void perturb_direction(const xVec3&, float32, float32, float32, float32);
+        void get_next_quadrant(float32&, float32&, float32&, float32&);
+        void reset_quadrants(uint32 size, float32 ring);
+        void apply_damage(float32);
+        void apply_damage_hazards(float32);
+        uint8 hazard_check(NPCHazard& haz, void* context);
     };
 
     struct state_camera_attach : state_type

--- a/src/Game/zEntCruiseBubble.h
+++ b/src/Game/zEntCruiseBubble.h
@@ -104,6 +104,7 @@ namespace cruise_bubble
         state_player_halt();
 
         void start();
+        void stop();
         state_enum update(float32 dt);
     };
 

--- a/src/Game/zEntCruiseBubble.h
+++ b/src/Game/zEntCruiseBubble.h
@@ -127,7 +127,7 @@ namespace cruise_bubble
         void perturb_direction(const xVec3&, float32, float32, float32, float32);
         void get_next_quadrant(float32&, float32&, float32&, float32&);
         void reset_quadrants(uint32 size, float32 ring);
-        void apply_damage(float32);
+        void apply_damage(float32 radius);
         void apply_damage_hazards(float32);
         uint8 hazard_check(NPCHazard& haz, void* context);
     };

--- a/src/Game/zEntCruiseBubble.h
+++ b/src/Game/zEntCruiseBubble.h
@@ -265,7 +265,7 @@ namespace cruise_bubble
         void lerp(xVec3& v, float32 t, const xVec3& a, const xVec3& b) const;
         int32 find_nearest(float32) const;
         void init_path();
-        int32 control_jerked() const;
+        bool control_jerked() const;
     };
 
     struct state_player_wait : state_type
@@ -561,7 +561,7 @@ namespace cruise_bubble
     void hide_missle();
     void capture_camera();
     void release_camera();
-    uint32 camera_taken();
+    bool camera_taken();
     uint32 camera_leave();
     void start_damaging();
     void damage_entity(xEnt& ent, const xVec3& loc, const xVec3& dir, const xVec3& hit_norm,

--- a/src/Game/zEntCruiseBubble.h
+++ b/src/Game/zEntCruiseBubble.h
@@ -150,6 +150,8 @@ namespace cruise_bubble
     struct state_missle_appear : state_type
     {
         state_missle_appear();
+
+        void move();
     };
 
     struct state_camera_seize : state_type

--- a/src/Game/zEntCruiseBubble.h
+++ b/src/Game/zEntCruiseBubble.h
@@ -244,6 +244,7 @@ namespace cruise_bubble
         state_camera_restore();
 
         void start();
+        void stop();
         state_enum update(float32 dt);
     };
 
@@ -562,7 +563,7 @@ namespace cruise_bubble
     void capture_camera();
     void release_camera();
     bool camera_taken();
-    uint32 camera_leave();
+    bool camera_leave();
     void start_damaging();
     void damage_entity(xEnt& ent, const xVec3& loc, const xVec3& dir, const xVec3& hit_norm,
                        float32 radius, uint8 explosive);

--- a/src/Game/zEntCruiseBubble.h
+++ b/src/Game/zEntCruiseBubble.h
@@ -149,6 +149,7 @@ namespace cruise_bubble
         state_enum update(float32 dt);
         uint8 hit_test(xVec3& hit_loc, xVec3& hit_norm, xVec3& hit_depen, xEnt*& hit_ent) const;
         void update_flash(float32 dt);
+        void update_engine_sound(float32 dt);
     };
 
     struct state_missle_appear : state_type
@@ -322,6 +323,7 @@ namespace cruise_bubble
                 float32 max_vel;
                 float32 engine_pitch_max;
                 float32 engine_pitch_sensitivity;
+                // Offset: 0x4c
                 float32 flash_interval;
                 struct _class_38
                 {

--- a/src/Game/zEntCruiseBubble.h
+++ b/src/Game/zEntCruiseBubble.h
@@ -73,6 +73,7 @@ namespace cruise_bubble
         state_player_fire();
 
         void start();
+        void stop();
         state_enum update(float32 dt);
         void update_wand(float32 dt);
     };

--- a/src/Game/zEntCruiseBubble.h
+++ b/src/Game/zEntCruiseBubble.h
@@ -95,7 +95,15 @@ namespace cruise_bubble
         state_camera_aim();
 
         void start();
+        void stop();
         state_enum update(float32 dt);
+
+        void apply_turn() const;
+        void turn(float32);
+        void collide_inward();
+        void apply_motion() const;
+        void stop(float32);
+        void move(float32);
     };
 
     struct state_player_halt : state_type

--- a/src/Game/zEntCruiseBubble.h
+++ b/src/Game/zEntCruiseBubble.h
@@ -99,11 +99,11 @@ namespace cruise_bubble
         state_enum update(float32 dt);
 
         void apply_turn() const;
-        void turn(float32);
+        void turn(float32 dt);
         void collide_inward();
         void apply_motion() const;
-        void stop(float32);
-        void move(float32);
+        void stop(float32 dt);
+        void move(float32 dt);
     };
 
     struct state_player_halt : state_type

--- a/src/Game/zEntCruiseBubble.h
+++ b/src/Game/zEntCruiseBubble.h
@@ -563,6 +563,7 @@ namespace cruise_bubble
     // xBase* param names are guessed as they go unused and wont appear in dwarf
     bool event_handler(xBase* from, uint32 event, const float32* fparam, xBase* to);
     xMat4x3* get_player_mat();
+    xMat4x3* get_missle_mat();
 } // namespace cruise_bubble
 
 #endif

--- a/src/Game/zEntCruiseBubble.h
+++ b/src/Game/zEntCruiseBubble.h
@@ -557,6 +557,7 @@ namespace cruise_bubble
     void reset_life();
     // xBase* param names are guessed as they go unused and wont appear in dwarf
     bool event_handler(xBase* from, uint32 event, const float32* fparam, xBase* to);
+    xMat4x3* get_player_mat();
 } // namespace cruise_bubble
 
 #endif

--- a/src/Game/zEntCruiseBubble.h
+++ b/src/Game/zEntCruiseBubble.h
@@ -256,8 +256,16 @@ namespace cruise_bubble
         state_camera_survey();
 
         void start();
-        void eval_missle_path(float32 dist, xVec3& loc, float32& roll);
+        void stop();
         state_enum update(float32 dt);
+        
+        void move();
+        void eval_missle_path(float32 dist, xVec3& loc, float32& roll) const;
+        void lerp(float32& x, float32 t, float32 a, float32 b) const;
+        void lerp(xVec3& v, float32 t, const xVec3& a, const xVec3& b) const;
+        int32 find_nearest(float32) const;
+        void init_path();
+        int32 control_jerked() const;
     };
 
     struct state_player_wait : state_type

--- a/src/Game/zEntCruiseBubble.h
+++ b/src/Game/zEntCruiseBubble.h
@@ -148,7 +148,7 @@ namespace cruise_bubble
 
         void start();
         void stop();
-        state_enum update();
+        state_enum update(float32 dt);
 
         void lock_targets();
         void lock_hazard_targets();

--- a/src/Game/zEntCruiseBubble.h
+++ b/src/Game/zEntCruiseBubble.h
@@ -151,6 +151,9 @@ namespace cruise_bubble
     {
         state_missle_appear();
 
+        void start();
+        void stop();
+        state_enum update(float32 dt);
         void move();
         void update_effects(float32 dt);
     };

--- a/src/Game/zEntCruiseBubble.h
+++ b/src/Game/zEntCruiseBubble.h
@@ -146,7 +146,14 @@ namespace cruise_bubble
 
         state_camera_attach();
 
+        void start();
+        void stop();
         state_enum update();
+
+        void lock_targets();
+        void lock_hazard_targets();
+        uint8 hazard_check(NPCHazard& haz, void* context);
+        void get_view_bound(xBound& bound) const;
     };
 
     struct state_missle_fly : state_type

--- a/src/Game/zEntCruiseBubble.h
+++ b/src/Game/zEntCruiseBubble.h
@@ -493,6 +493,15 @@ namespace cruise_bubble
         void load(xModelAssetParam* params, uint32 size);
     };
 
+    struct missle_record_data
+    {
+        xVec3 loc;
+        float32 roll;
+        
+        missle_record_data(const xVec3& loc, float32 roll);
+    };
+
+
     void init_sound();
     void stop_sound(int32 which, uint32 handle);
     uint32 play_sound(int32 which, float32 volFactor);

--- a/src/Game/zEntCruiseBubble.h
+++ b/src/Game/zEntCruiseBubble.h
@@ -1,6 +1,7 @@
 #ifndef ZENTCRUISEBUBBLE_H
 #define ZENTCRUISEBUBBLE_H
 
+#include "zNPCHazard.h"
 #include "zShrapnel.h"
 #include <types.h>
 
@@ -146,10 +147,19 @@ namespace cruise_bubble
         state_missle_fly();
 
         void start();
+        void stop();
         state_enum update(float32 dt);
-        uint8 hit_test(xVec3& hit_loc, xVec3& hit_norm, xVec3& hit_depen, xEnt*& hit_ent) const;
+        void abort();
         void update_flash(float32 dt);
         void update_engine_sound(float32 dt);
+
+        uint8 collide_hazards();
+        uint8 hazard_check(NPCHazard& haz, void* context);
+        uint8 collide();
+        uint8 hit_test(xVec3& hit_loc, xVec3& hit_norm, xVec3& hit_depen, xEnt*& hit_ent) const;
+        void update_move(float32 dt);
+        void update_turn(float32 dt);
+        void calculate_rotation(xVec2& d1, xVec2& v1, float32 dt, const xVec2& d0, const xVec2& v0, const xVec2& a0, const xVec2& a1) const;
     };
 
     struct state_missle_appear : state_type

--- a/src/Game/zEntCruiseBubble.h
+++ b/src/Game/zEntCruiseBubble.h
@@ -152,6 +152,7 @@ namespace cruise_bubble
         state_missle_appear();
 
         void move();
+        void update_effects(float32 dt);
     };
 
     struct state_camera_seize : state_type

--- a/src/Game/zEntCruiseBubble.h
+++ b/src/Game/zEntCruiseBubble.h
@@ -176,7 +176,12 @@ namespace cruise_bubble
         state_player_aim();
 
         void start();
+        void stop();
         state_enum update(float32 dt);
+
+        void update_animation(float32 dt);
+        void apply_yaw();
+        void face_camera(float32 dt);
     };
 
     struct state_camera_restore : state_type

--- a/src/Game/zNPCTypePrawn.h
+++ b/src/Game/zNPCTypePrawn.h
@@ -60,7 +60,7 @@ struct aqua_beam
     {
         RpAtomic* model_data;
         float32 emit_time;
-        fixed_queue<ring_segment> queue;
+        fixed_queue<ring_segment, 31> queue;
     } ring;
     struct
     {


### PR DESCRIPTION
About two weeks ago i decompiled all the virtual functions of `state_type`s child structs. while most of them match they are atm `ifdef`'d out since i couldnt make the compiler generate the correct vtables back then. Now I wanna get back to decomping but not want to get worked up in that thing again. So Ill save it up for the future, PR it and move on back to simpler individual functions.