### PR TITLE
Remove unused padding in zRenderState and mark it as Matching

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -380,7 +380,7 @@ config.libs = [
             Object(Matching, "SB/Game/zPickupTable.cpp"),
             Object(NonMatching, "SB/Game/zPlatform.cpp"),
             Object(Matching, "SB/Game/zPortal.cpp"),
-            Object(NonMatching, "SB/Game/zRenderState.cpp"),
+            Object(Matching, "SB/Game/zRenderState.cpp"),
             Object(NonMatching, "SB/Game/zRumble.cpp"),
             Object(Equivalent, "SB/Game/zSaveLoad.cpp"),
             Object(NonMatching, "SB/Game/zScene.cpp"),

--- a/src/SB/Game/zRenderState.cpp
+++ b/src/SB/Game/zRenderState.cpp
@@ -8,9 +8,6 @@
 
 volatile _SDRenderState sRS;
 
-// For things to line up right this has to be present.
-int32 padding;
-
 void zRenderStateInit()
 {
     sRS = SDRS_Unknown;


### PR DESCRIPTION
This padding is no longer needed, and the file completely matches otherwise.