### PR TITLE
Use patched mwcc compiler 2.0p1

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -133,7 +133,7 @@ if args.no_asm:
 
 # Tool versions
 config.binutils_tag = "2.42-1"
-config.compilers_tag = "20231018"
+config.compilers_tag = "20240702"
 config.dtk_tag = "v0.9.0"
 config.sjiswrap_tag = "v1.1.1"
 config.wibo_tag = "0.6.11"
@@ -209,8 +209,6 @@ cflags_rel = [
 cflags_bfbb = [
     *cflags_base,
     "-common on",
-    "-schedule on",
-    "-opt level=4,peephole,speed",
     "-char unsigned",
     "-str reuse,pool,readonly",
     "-use_lmw_stmw on",
@@ -229,7 +227,7 @@ cflags_bfbb = [
     "-DGAMECUBE",
 ]
 
-config.linker_version = "GC/2.0"
+config.linker_version = "GC/2.0p1"
 
 
 # Helper function for Dolphin libraries

--- a/tools/project.py
+++ b/tools/project.py
@@ -1027,6 +1027,7 @@ def generate_objdiff_config(
         "GC/1.3.2": "mwcc_242_81",
         "GC/1.3.2r": "mwcc_242_81r",
         "GC/2.0": "mwcc_247_92",
+        "GC/2.0p1": "mwcc_247_92p1",
         "GC/2.5": "mwcc_247_105",
         "GC/2.6": "mwcc_247_107",
         "GC/2.7": "mwcc_247_108",


### PR DESCRIPTION
The new compiler contains two patches:
- Disable `const` qualifier for generated float literals in `createfloatconstant` @ [TOC.c](https://git.wuffs.org/MWCC/tree/compiler_and_linker/BackEnd/PowerPC/CodeGenerator/TOC.c?h=094b96ca1df4a035b5f93c351f773306c0241f3f#n200)
- Mark lfs/lfd and related instructions as immovable in `maymove` @ [CodeMotion.c](https://git.wuffs.org/MWCC/tree/compiler_and_linker/BackEnd/PowerPC/GlobalOptimizer/CodeMotion.c?h=094b96ca1df4a035b5f93c351f773306c0241f3f#n266)

Together, these appear to fix a lot of existing fp scheduling issues.

decomp.me integration won't work until the new compiler is added to decomp.me, but that's in progress.

The build container needs to be updated with the new compilers zip.