### PR TITLE
Finish matching zConditional and mark xFog as matching

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -294,7 +294,7 @@ config.libs = [
             Object(Matching, "SB/Core/x/xEnv.cpp"),
             Object(Matching, "SB/Core/x/xEvent.cpp"),
             Object(NonMatching, "SB/Core/x/xFFX.cpp"),
-            Object(Equivalent, "SB/Core/x/xFog.cpp"),
+            Object(Matching, "SB/Core/x/xFog.cpp"),
             Object(NonMatching, "SB/Core/x/xFont.cpp"),
             Object(NonMatching, "SB/Core/x/xFX.cpp"),
             Object(Matching, "SB/Core/x/xGroup.cpp"),

--- a/configure.py
+++ b/configure.py
@@ -340,7 +340,7 @@ config.libs = [
             Object(Equivalent, "SB/Game/zAnimList.cpp"),
             Object(NonMatching, "SB/Game/zAssetTypes.cpp"),
             Object(NonMatching, "SB/Game/zCamera.cpp"),
-            Object(NonMatching, "SB/Game/zConditional.cpp"),
+            Object(Matching, "SB/Game/zConditional.cpp"),
             Object(NonMatching, "SB/Game/zCutsceneMgr.cpp"),
             Object(NonMatching, "SB/Game/zDispatcher.cpp"),
             Object(NonMatching, "SB/Game/zEGenerator.cpp"),

--- a/src/SB/Core/x/xFog.cpp
+++ b/src/SB/Core/x/xFog.cpp
@@ -5,8 +5,6 @@
 
 #include <types.h>
 
-// NON_MATCHING:
-// function parameter loading order is swapped
 void xFogClearFog()
 {
     iCameraSetFogParams(NULL, 0.0f);

--- a/src/SB/Game/zConditional.h
+++ b/src/SB/Game/zConditional.h
@@ -27,6 +27,6 @@ void zConditionalInit(xBase* base, zCondAsset* asset);
 void zConditionalInit(void* b, void* asset);
 void zConditionalLoad(_zConditional* ent, xSerial* s);
 void zConditionalSave(_zConditional* ent, xSerial* s);
-bool zConditional_Evaluate(_zConditional* c);
+uint32 zConditional_Evaluate(_zConditional* c);
 
 #endif


### PR DESCRIPTION
I don't know how I managed to randomly guess the fix for the last function, but I'll take it, I guess.

This PR also marks xFog as matching, since the new patched compiler fixes that file.