### PR TITLE
zEntPlayer

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,7 @@
   },
   "[cpp]": {
     "files.encoding": "utf8",
-    "editor.defaultFormatter": "ms-vscode.cpptools"
+    "editor.defaultFormatter": "xaver.clang-format"
   },
   "[python]": {
     "editor.defaultFormatter": "ms-python.black-formatter"

--- a/src/SB/Game/zCamera.h
+++ b/src/SB/Game/zCamera.h
@@ -63,6 +63,7 @@ void zCameraDisableLassoCam();
 void zCameraEnableLassoCam();
 void zCameraSetLassoCamFactor(F32 new_factor);
 F32 zCameraGetLassoCamFactor();
+void zCameraEnableWallJump(xCamera* cam, const xVec3& collNormal);
 S32 zCameraGetConvers();
 void zCameraTranslate(xCamera* cam, F32 x, F32 y, F32 z);
 void zCameraDisableWallJump(xCamera* cam);

--- a/src/SB/Game/zEntPlayer.cpp
+++ b/src/SB/Game/zEntPlayer.cpp
@@ -2109,7 +2109,7 @@ static void DoWallJumpCheck()
 
         zSurfaceProps* surfaceProperties = (zSurfaceProps*)surf->moprops;
 
-        if(!(surfaceProperties->asset->phys_flags & 0x20))
+        if (!(surfaceProperties->asset->phys_flags & 0x20))
         {
             return;
         }
@@ -2124,6 +2124,29 @@ static void DoWallJumpCheck()
             }
         }
     }
+}
+
+static U32 WallJumpLaunchCheck(class xAnimTransition*, class xAnimSingle*, void*)
+{
+    if (globals.player.ControlOff || !(globals.pad0->pressed & XPAD_BUTTON_X) ||
+        !globals.player.IsJumping || globals.player.s->Wall.PeakHeight <= 0.0f)
+    {
+        return false;
+    }
+    return sWallJumpResult == WallJumpResult_Jump;
+}
+
+static U32 WallJumpLaunchCallback(class xAnimTransition*, class xAnimSingle*, void*)
+{
+    globals.player.WallJumpState = k_WALLJUMP_LAUNCH;
+    zCameraEnableWallJump(&globals.camera, sWallNormal);
+    sWallJumpResult = WallJumpResult_NoJump;
+    return 0;
+}
+
+static U32 WallJumpFlightLandCheck(class xAnimTransition*, class xAnimSingle*, void*)
+{
+    return sWallJumpResult == WallJumpResult_Jump;
 }
 
 static U32 WallJumpFlightLandCallback(xAnimTransition* tran, xAnimSingle* anim, void* param_3)

--- a/src/SB/Game/zEntPlayer.cpp
+++ b/src/SB/Game/zEntPlayer.cpp
@@ -37,6 +37,7 @@
 #include "zParPTank.h"
 #include "zRumble.h"
 #include "zSaveLoad.h"
+#include "zSurface.h"
 #include "zThrown.h"
 
 static F32 sHackStuckTimer;
@@ -173,6 +174,14 @@ static U32 sShouldBubbleBowl;
 static F32 sBubbleBowlTimer;
 static U32 sSpatulaGrabbed;
 S32 gWaitingToAutoSave;
+
+static enum {
+    WallJumpResult_NoJump,
+    WallJumpResult_Jump,
+} sWallJumpResult;
+static class xVec3 sWallNormal;
+static class zSurfaceProps* sWallCollisionSurface;
+static float sTongueDblSpeedMult;
 
 static void PlayerSwingUpdate(xEnt* ent, F32 mag, F32 angle, F32 dt);
 
@@ -2053,6 +2062,68 @@ static U32 StopLCopterCB(xAnimTransition*, xAnimSingle*, void* data)
     sLassoInfo->canCopter = 0;
     sLasso->flags = 0;
     return 0;
+}
+
+// Equivalent: static initializer scheduling (probably sda relocations?)
+static void DoWallJumpCheck()
+{
+    sWallJumpResult = WallJumpResult_NoJump;
+    xEnt* ent = &globals.player.ent;
+
+    static F32 sAtdist = 0.65f;
+    static F32 sSweptrad = 0.4f;
+    static F32 sVerticalCos = 0.2588f;
+
+    xVec3 start;
+    start.x = ent->model->Mat->pos.x;
+    start.y = ent->model->Mat->pos.y + ent->bound.cyl.r;
+    start.z = ent->model->Mat->pos.z;
+
+    // hack: compiler isn't calling operator=
+    xVec3 end;
+    end.operator=(start);
+    end.x += ent->model->Mat->at.x * sAtdist;
+    end.z += ent->model->Mat->at.z * sAtdist;
+
+    xSweptSphere sws;
+    xSweptSpherePrepare(&sws, &start, &end, sSweptrad);
+
+    if (xSweptSphereToScene(&sws, globals.sceneCur, ent, 0x16))
+    {
+        xSweptSphereGetResults(&sws);
+
+        xSurface* surf;
+        if (sws.optr && sws.mptr)
+        {
+            surf = sws.mptr->Surf;
+        }
+        else
+        {
+            surf = zSurfaceGetSurface(sws.oid);
+        }
+
+        if (!surf)
+        {
+            return;
+        }
+
+        zSurfaceProps* surfaceProperties = (zSurfaceProps*)surf->moprops;
+
+        if(!(surfaceProperties->asset->phys_flags & 0x20))
+        {
+            return;
+        }
+
+        if (xabs(sws.worldNormal.y) < sVerticalCos)
+        {
+            if (xVec3Dot(&sws.worldNormal, &sws.worldPolynorm) > 0.999f)
+            {
+                sWallNormal = sws.worldNormal;
+                sWallJumpResult = WallJumpResult_Jump;
+                sWallCollisionSurface = surfaceProperties;
+            }
+        }
+    }
 }
 
 static U32 WallJumpFlightLandCallback(xAnimTransition* tran, xAnimSingle* anim, void* param_3)

--- a/src/SB/Game/zEntPlayer.h
+++ b/src/SB/Game/zEntPlayer.h
@@ -244,13 +244,6 @@ enum _CurrentPlayer
     eCurrentPlayerCount
 };
 
-// was originally called _enum in DWARF data
-enum _zPlayerWallJumpResult
-{
-    WallJumpResult_NoJump,
-    WallJumpResult_Jump
-};
-
 enum _zPlayerWallJumpState
 {
     k_WALLJUMP_NOT,


### PR DESCRIPTION
Accidentally included a change for the default formatter to be a clang-format extension, but I suggest we keep it since we have a clang-format file and the cpptools extension doesn't support them (at least it wasn't working for me).