### PR TITLE
Oops

### DIFF
--- a/src/SB/Game/zHud.cpp
+++ b/src/SB/Game/zHud.cpp
@@ -10,7 +10,7 @@ namespace zhud
     {
         widget widgets[];
         bool inited;
-        bool last_paused;
+        bool last_paused = true;
     }
     
     void zhud::render()


### PR DESCRIPTION
Missing from previous PR: initialize last_paused to true, enabling match for that variable.