### PR TITLE
zEntPlayerOOBState work

### DIFF
--- a/src/SB/Core/x/xMath2.h
+++ b/src/SB/Core/x/xMath2.h
@@ -41,9 +41,13 @@ struct xVec2
     }
     xVec2& assign(F32 x, F32 y);
     F32 length() const;
+    F32 normal() const;
+    xVec2& normalize();
+    F32 dot(const xVec2&) const;
 
     xVec2& operator=(F32);
     xVec2 operator*(F32) const;
+    xVec2 operator/=(F32);
     xVec2& operator+=(const xVec2&);
     xVec2& operator*=(F32);
 };

--- a/src/SB/Game/zEntPlayerOOBState.cpp
+++ b/src/SB/Game/zEntPlayerOOBState.cpp
@@ -1,3 +1,124 @@
 #include "zEntPlayerOOBState.h"
 
+#include "xMath.h"
+
 #include <types.h>
+
+bool oob_player_teleported;
+
+namespace oob_state {
+namespace
+{
+    _class_9 shared =
+    {
+        1,
+        NULL,
+        0,
+        { NULL, NULL, NULL, NULL },
+        0.0f, 0.0f, 0.0f,
+        NULL,
+        NULL, NULL,
+        0.0f,
+        0,
+        0,
+        0.0f, 0.0f,
+        0,
+        0,
+        NULL,
+
+        { 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, NULL, NULL }
+    };
+
+    static idiot_level_data idiot_levels[6] =
+    {
+        { NULL },
+        { 0, 'HB01' },
+        { 0, 'JF01' },
+        { 0, 'JF03' },
+        { 0, 'BB01' },
+        { 0, 'GL01' },
+    };
+
+    xMat4x3 shared_target;
+    tagFixed fixed;
+}}
+
+float oob_state::oob_timer()
+{
+    if (shared.reset_time == fixed.reset_time)
+    {
+        return shared.out_time;
+    }
+
+    return -1.0f;
+}
+
+void oob_state::in_state_type::start()
+{
+    shared.reset_time = 1e38;
+    shared.out_time = 1e38;
+    shared.control = 0;
+};
+
+void oob_state::in_state_type::stop()
+{
+
+};
+
+void oob_state::out_state_type::start()
+{
+    shared.out_time = shared.max_out_time;
+    shared.reset_time = fixed.reset_time;
+};
+
+void oob_state::out_state_type::stop()
+{
+
+};
+
+void oob_state::state_type::start()
+{
+
+};
+
+void oob_state::state_type::stop()
+{
+
+};
+
+bool oob_state::grab_state_type::update_reorient(xScene&, F32&)
+{
+    return true;
+};
+
+void oob_state::grab_state_type::stop()
+{
+
+};
+
+void oob_state::grab_state_type::tutorial_callback::on_stop()
+{
+    owner.finished_tutorial = true;
+};
+
+bool oob_state::IsPlayerInControl()
+{
+    return oob_state::shared.control == 0;
+}
+
+WEAK ztalkbox::callback::callback() { }
+WEAK void ztalkbox::callback::on_signal(U32) { }
+WEAK void ztalkbox::callback::on_start() { }
+WEAK void ztalkbox::callback::on_stop() { }
+WEAK void ztalkbox::callback::on_answer(ztalkbox::answer_enum) { }
+
+WEAK F32 xVec2::dot(const xVec2& b) const
+{
+    return (x * b.x) + (y * b.y);
+}
+
+WEAK xVec2& xVec2::normalize()
+{
+    *this /= length();
+    return *this;
+}

--- a/src/SB/Game/zEntPlayerOOBState.h
+++ b/src/SB/Game/zEntPlayerOOBState.h
@@ -2,6 +2,8 @@
 #define ZENTPLAYEROOBSTATE_H
 
 #include "xserializer.h"
+#include "zTalkBox.h"
+#include "zTaskBox.h"
 
 extern bool oob_player_teleported;
 
@@ -13,6 +15,178 @@ namespace oob_state
     void write_persistent(xSerial& s);
 
     float oob_timer();
+
+    bool IsPlayerInControl();
+
+    struct callback
+    {
+        virtual void on_stop();
+    };
+
+    enum state_enum
+    {
+        STATE_INVALID = -1,
+        BEGIN_STATE,
+        STATE_IN = 0,
+        STATE_OUT,
+        STATE_GRAB,
+        STATE_DROP,
+        END_STATE,
+        MAX_STATE = 0x4
+    };
+
+    namespace
+    {
+        struct state_type
+        {
+            state_enum type;
+
+            void start();
+            void stop();
+        };
+
+        extern xMat4x3 shared_target;
+
+        struct in_state_type : state_type
+        {
+            void start();
+            void stop();
+        };
+
+        struct out_state_type : state_type
+        {
+            void start();
+            void stop();
+        };
+
+        struct grab_state_type : state_type
+        {
+            enum substate_enum
+            {
+                SS_INVALID = -1,
+                SS_REORIENT,
+                SS_BEGIN_WAIT,
+                SS_MOVING_IN,
+                SS_STOPPING,
+                SS_STOPPED,
+                SS_TUTORIAL,
+                SS_STARTING,
+                SS_MOVING_OUT,
+                SS_START_FADE_OUT,
+                SS_FADE_OUT,
+                MAX_SS
+            };
+
+            struct tutorial_callback : callback
+            {
+                grab_state_type& owner;
+
+                void on_stop();
+            };
+
+            tutorial_callback cb;
+            substate_enum move_substate;
+            substate_enum fade_substate;
+            xVec3 player_start;
+            float reorient_time;
+            float angle_delta;
+            float delay;
+            float fade_start_time;
+            float fade_time;
+            unsigned int scene_reset;
+
+            // Todo: this is not in the DWARF, but is required for
+            //       tutorial_callback::on_stop to match. Probably
+            //       not correct.
+            char pad[4];
+
+            unsigned char finished_tutorial;
+
+            substate_enum(*updatess)(grab_state_type&, xScene&, float&)[10];
+            bool update_reorient(xScene&, F32&);
+
+            void start();
+            void stop();
+        };
+
+        struct _class_9
+        {
+            int flags;
+            state_type* state;
+            unsigned char control;
+            state_type* states[4];
+            float out_time;
+            float max_out_time;
+            float reset_time;
+            xModelInstance* model;
+            xVec2 loc;
+            xVec2 dir;
+            float fade_alpha;
+            unsigned char render_hand;
+            unsigned char vertical;
+            float vel;
+            float accel;
+            ztalkbox* tutorial;
+            struct
+            {
+                float near_d;
+                float near_h;
+                float near_pitch;
+                float far_d;
+                float far_h;
+                float far_pitch;
+                xMat4x3* tgt_mat;
+                xMat4x3* tgt_omat;
+            } cam_data;
+        };
+
+        struct tagFixed
+        {
+            float out_time;
+            float reset_time;
+            float cam_dist;
+            float cam_height;
+            float cam_pitch;
+            float reorient_time;
+            char* hand_model;
+            xVec2 in_loc;
+            xVec2 out_loc;
+            struct
+            {
+                float in_wait_time;
+                float in_vel;
+                float in_stop_dist;
+                float out_wait_time;
+                float out_vel;
+                float out_start_dist;
+                float fade_start_time;
+                float fade_time;
+            } grab;
+            struct
+            {
+                float in_vel;
+                float in_stop_dist;
+                float out_wait_time;
+                float out_vel;
+                float out_start_dist;
+                float fade_start_time;
+                float fade_time;
+            } drop;
+            float hand_size_x;
+            float hand_size_y;
+            float hand_yaw;
+            float hand_pitch;
+            float hand_roll;
+        };
+    }
+
+    struct idiot_level_data
+    {
+        unsigned char triggered;
+        unsigned int scene;
+    };
+
+    extern idiot_level_data idiot_levels[];
 } // namespace oob_state
 
 #endif


### PR DESCRIPTION
Needed to add 4 bytes of padding to `grab_state_type` to allow `tutorial_callback::on_stop()` to perfectly match, for whatever reason. Otherwise, the store offset is 4 bytes off.