### PR TITLE
Couple fixes + match UVAModelInfo::SetColor

### DIFF
--- a/src/SB/Game/zNPCHazard.cpp
+++ b/src/SB/Game/zNPCHazard.cpp
@@ -296,17 +296,17 @@ S32 UVAModelInfo::GetUV(RwTexCoords*& coords, S32& numVertices, RpAtomic* model)
 
 #endif
 
-RwV3d* NPCHazard::At()
+RwV3d* NPCHazard::At() const
 {
     return &this->mdl_hazard->Mat->at;
 }
 
-RwV3d* NPCHazard::Right()
+RwV3d* NPCHazard::Right() const
 {
     return &this->mdl_hazard->Mat->right;
 }
 
-RwV3d* NPCHazard::Up()
+RwV3d* NPCHazard::Up() const
 {
     return &this->mdl_hazard->Mat->up;
 }
@@ -323,4 +323,22 @@ NPCHazard::NPCHazard(en_npchaz haztype)
 F32 xVec2Length2(const xVec2* v)
 {
     return xVec2Dot(v, v);
+}
+
+void UVAModelInfo::SetColor(iColor_tag color)
+{
+    RpGeometry* geo = model->geometry;
+
+    RwRGBA col;
+    col.red   = color.r;
+    col.green = color.g;
+    col.blue  = color.b;
+    col.alpha = color.a;
+
+    int numMats = model->geometry->matList.numMaterials;
+
+    for (int i = 0; i < numMats; i++)
+    {
+        geo->matList.materials[i]->color = col;
+    }
 }

--- a/src/SB/Game/zNPCHazard.h
+++ b/src/SB/Game/zNPCHazard.h
@@ -23,6 +23,7 @@ struct UVAModelInfo
     void Clear();
     void UVVelSet(float, float);
     S32 GetUV(RwTexCoords*& coords, S32& numVertices, RpAtomic* model);
+    void SetColor(iColor_tag);
 };
 
 struct NPCHazard;
@@ -137,7 +138,6 @@ struct HAZTarTar : HAZCollide
     F32 spd_lob;
     xVec3 pos_tgt;
     U32 streakID;
-    U32 pad; // This is needed to ensure the correct size!
 };
 
 struct HAZCatProd : HAZBall
@@ -231,9 +231,9 @@ struct NPCHazard
     void ColResp_Default(xSweptSphere* swdata, F32 tym_inFuture);
     void CollideResponse(xSweptSphere* swdata, F32 tym_inFuture);
     void Upd_Patriot(F32);
-    RwV3d* At();
-    RwV3d* Right();
-    RwV3d* Up();
+    RwV3d* At() const;
+    RwV3d* Right() const;
+    RwV3d* Up() const;
     void Discard();
 };
 


### PR DESCRIPTION
- Remove unnecessary padding in HAZTarTar that was preventing matches elsewhere.
- Fix missing consts for some NPCHazard funcs.
- Match UVAModelInfo::SetColor because why not.