### PR TITLE
iFMV: match cursed function aramfree

### DIFF
--- a/src/SB/Core/gc/iFMV.cpp
+++ b/src/SB/Core/gc/iFMV.cpp
@@ -64,13 +64,12 @@ void arammalloc(size_t size)
     ARAlloc(size);
 }
 
-#ifdef NON_MATCHING
 // Something weird is going on here...
-void aramfree(void* mem)
+static void aramfree(void* mem)
 {
-    ARFree(mem);
+    void* vol;
+    ARFree(&vol);
 }
-#endif
 
 #if 0
 // WIP.

--- a/src/SB/Core/gc/iFMV.h
+++ b/src/SB/Core/gc/iFMV.h
@@ -19,7 +19,7 @@ static void Setup_surface_array();
 void Decompress_frame(HBINK bnk, HRAD3DIMAGE rad_image, S64 flags);
 
 void arammalloc(size_t size);
-void aramfree(void* mem);
+static void aramfree(void* mem);
 void PlayFMV(char* filename, size_t buttons, F32 time);
 
 #endif


### PR DESCRIPTION
Tiny PR. Found this match very interesting, though. Instead of passing the parameter `mem` to `ARFree`, it just creates a local and passes its memory address to it. This function is referenced in `FMVPlay`, as a parameter to `RADSetAudioMemory`.
That function was actually [removed in version 1.5p (Oct 18 2002) of the audio codec](http://web.archive.org/web/20240531115717/https://www.radgametools.com/bnkhist.htm), curiously enough.

Making smaller PRs cus I've been having Git skill issues lately.