### PR TITLE
Matches and improved non-matches

### DIFF
--- a/src/SB/Core/x/xSnd.cpp
+++ b/src/SB/Core/x/xSnd.cpp
@@ -312,35 +312,37 @@ void xSndSetExternalCallback(void (*callback)(U32))
 }
 
 #if 0
-// Subtle issue with the register use in the setup of the loop
-U8 xSndStreamReady(U32 owner)
+U32 xSndStreamReady(U32 owner)
 {
-    for (xSndVoiceInfo* voice = gSnd.voice; voice != gSnd.voice + 6; voice++)
+    xSndVoiceInfo* begin = gSnd.voice;
+    xSndVoiceInfo* end = begin + 6;
+
+    for (xSndVoiceInfo* v = begin; v != end; v++)
     {
-        if (voice->lock_owner == owner)
+        if (v->lock_owner == owner)
         {
-            return !(voice->flags & 1);
+            return (v->flags & 1) >> 5; // Missing cntlzw instruction.
         }
     }
+
     return 0;
 }
 #endif
 
-#if 0
-// Same issue as xSndStreamReady
 void xSndStreamUnlock(U32 owner)
 {
-    xSndVoiceInfo* voice = gSnd.voice;
-    for (; voice != gSnd.voice + 6; voice++)
+    xSndVoiceInfo* begin = gSnd.voice;
+    xSndVoiceInfo* end = begin + 6;
+
+    for (xSndVoiceInfo* v = begin; v != end; v++)
     {
-        if (voice->lock_owner == owner)
+        if (v->lock_owner == owner)
         {
-            voice->lock_owner = 0;
+            v->lock_owner = 0;
             return;
         }
     }
 }
-#endif
 
 #if 0
 U32 xSndCategoryGetsEffects(sound_category category)

--- a/src/SB/Game/zCamera.cpp
+++ b/src/SB/Game/zCamera.cpp
@@ -205,7 +205,6 @@ F32 EaseInOut(F32 param)
     return param * (param * (zCamera_f_2_0 - zCamera_f_1_5 * param) + zCamera_f_0_5);
 }
 
-#if 0
 void zCameraConversUpdate(xCamera* cam, F32 dt)
 {
     if (zcam_dest == NULL)
@@ -213,15 +212,13 @@ void zCameraConversUpdate(xCamera* cam, F32 dt)
         return;
     }
 
-    // zcam_tmr should use f2 instead of f1
-    if (zcam_tmr <= zCamera_f_0_0)
+    if (zcam_tmr <= 0.0f)
     {
-        zcam_tmr = zCamera_f_0_0;
+        zcam_tmr = 0.0f;
         return;
     }
 
-    // zCamera_f_1_0 should use f1 instead of f2
-    if ((dt / zcam_tmr) > zCamera_f_1_0)
+    if ((dt / zcam_tmr) > 1.0f)
     {
         cam->mat.right = zcam_dest->right;
         cam->mat.up = zcam_dest->up;
@@ -232,9 +229,9 @@ void zCameraConversUpdate(xCamera* cam, F32 dt)
     }
     else
     {
-        F32 ease1 = EaseInOut(zCamera_f_1_0 - (zcam_tmr / zcam_ttm));
-        F32 ease2 = EaseInOut(zCamera_f_1_0 - (zcam_tmr - dt) / zcam_ttm);
-        F32 t = (ease2 - ease1) / (zCamera_f_1_0 - ease1);
+        F32 ease1 = EaseInOut(1.0f - (zcam_tmr / zcam_ttm));
+        F32 ease2 = EaseInOut(1.0f - (zcam_tmr - dt) / zcam_ttm);
+        F32 t = (ease2 - ease1) / (1.0f - ease1);
 
         xQuat tOld;
         xQuat tNew;
@@ -247,7 +244,6 @@ void zCameraConversUpdate(xCamera* cam, F32 dt)
 
     zcam_tmr = zcam_tmr - dt;
 }
-#endif
 
 F32 TranSpeed(zFlyKey keys[])
 {
@@ -308,7 +304,6 @@ void zCameraFlyStart(U32 assetID)
 }
 #endif
 
-#if 0
 void zCameraFreeLookSetGoals(xCamera* cam, F32 pitch_s, F32& dgoal, F32& hgoal,
                              F32& pitch_goal, F32& lktm, F32 dt)
 {
@@ -408,20 +403,18 @@ void zCameraFreeLookSetGoals(xCamera* cam, F32 pitch_s, F32& dgoal, F32& hgoal,
         pitch_goal = -pitch_s * (zcam_above_pitch - p) + p;
     }
 
-    // f0 and f1 should be swapped from here
-    if (lktm > zCamera_f_0_1)
+    if (lktm > 0.1f)
     {
         lktm -= dt;
-        if (lktm < zCamera_f_0_1)
+        if (lktm < 0.1f)
         {
-            lktm = zCamera_f_0_1;
+            lktm = 0.1f;
         }
         return;
     }
 
-    lktm = zCamera_f_0_1;
+    lktm = 0.1f;
 }
-#endif
 
 void zCameraSetBbounce(S32 bbouncing)
 {

--- a/src/SB/Game/zFX.cpp
+++ b/src/SB/Game/zFX.cpp
@@ -88,25 +88,21 @@ void zFXGoo_SceneEnter()
     goo_timer_textbox = (ztextbox*)zSceneFindObject(gameID);
 }
 
-#if 0
 void zFXGoo_SceneReset()
 {
-    // This almost matches, only two instructions are flipped.
-    // otherwise, its perfect.
     S32 i;
     zFXGooInstance* goo = zFXGooInstances;
 
-    for (i = 0; i < 24; i++)
+    for (i = 0; i < 24;)
     {
         if (goo->state != zFXGooStateInactive)
         {
             goo->state = zFXGooStateNormal;
         }
+        i++;
         goo++;
     }
 }
-
-#endif
 
 void zFXGoo_SceneExit()
 {
@@ -128,15 +124,16 @@ void zFXUpdate(F32 dt)
     xFXUpdate(dt);
 }
 
-#if 0
-// Idk what the name of the other function is.
+namespace
+{
+    void add_popper_tweaks() { }
+}
+
 void init_poppers()
 {
     reset_poppers();
-    add_popper_tweaks__17 @unnamed @zFX_cpp @Fv();
+    add_popper_tweaks();
 }
-
-#endif
 
 void xDebugAddTweak(const char* unk1, const char* unk2, const tweak_callback* unk3, void* unk4,
                     U32 unk5)

--- a/src/SB/Game/zFX.h
+++ b/src/SB/Game/zFX.h
@@ -152,7 +152,7 @@ void reset_poppers();
 
 void reset_entrails();
 
-void init_poppers();
+static void init_poppers();
 
 void update_poppers(F32 dt);
 

--- a/src/SB/Game/zGame.cpp
+++ b/src/SB/Game/zGame.cpp
@@ -39,6 +39,8 @@ extern F32 lbl_803CF5AC; // A
 extern F32 lbl_803CDA54;
 extern F32 lbl_803CDA58;
 
+extern char stringBase0[];
+
 #ifdef NON_MATCHING
 // Scheduling, I guess
 void zGameInit(U32 theSceneID)
@@ -214,30 +216,27 @@ S32 zGameOkToPause()
     return uVar1;
 }
 
-#ifdef NON_MATCHING
 void zGamePause()
 {
     if (!zGameIsPaused())
     {
-        if ((globals.sceneCur)->sceneID == 0x50473132)
+        if ((globals.sceneCur)->sceneID == 'PG12')
         {
             zGameStall();
         }
         else
         {
-            zEntEvent("techbutton6_click", 24);
-            zEntEvent("SAVING GAME ICON UI", 4);
-            zEntEvent("MNU4 AUTO SAVE FAILED", 4);
-            zEntEvent("MNU4 SAVE COMPLETED", 4);
+            zEntEvent(stringBase0 + 0xff, 24); // "techbutton6_click"
+            zEntEvent(stringBase0 + 0x111, 4); // "SAVING GAME ICON UI"
+            zEntEvent(stringBase0 + 0x125, 4); // "MNU4 AUTO SAVE FAILED"
+            zEntEvent(stringBase0 + 0x13b, 4); // "MNU4 SAVE COMPLETED"
             iPadStopRumble(globals.pad0);
             zGameModeSwitch(eGameMode_Pause);
             zGameStateSwitch(0);
         }
     }
 }
-#endif
 
-#ifdef NON_MATCHING
 void zGameStall()
 {
     if (!zGameIsPaused())
@@ -245,10 +244,9 @@ void zGameStall()
         zGameModeSwitch(eGameMode_Stall);
         xSndPauseAll(1, 1);
         iPadStopRumble(globals.pad0);
-        zEntEvent("techbutton6_click", 24);
+        zEntEvent(stringBase0 + 0xff, 24); // "techbutton6_click"
     }
 }
-#endif
 
 void zGameTakeSnapShot(RwCamera*)
 {

--- a/src/SB/Game/zLight.cpp
+++ b/src/SB/Game/zLight.cpp
@@ -228,7 +228,7 @@ void zLightAddLocalEnv()
             iLight* light = &zlight->light;
             iLightEnv(light, 1);
             light->hw->inWorld.prev = gLightWorld->directionalLightList.link.prev;
-            light->hw->inWorld.next = gLightWorld->directionalLightList.link.next;
+            light->hw->inWorld.next = &gLightWorld->directionalLightList.link;
             gLightWorld->directionalLightList.link.prev->next = &light->hw->inWorld;
             gLightWorld->directionalLightList.link.prev = &light->hw->inWorld;
 

--- a/src/SB/Game/zTaskBox.cpp
+++ b/src/SB/Game/zTaskBox.cpp
@@ -219,16 +219,13 @@ bool ztaskbox::exists(state_enum stage)
     return state != STATE_BEGIN && xSTFindAsset(state, NULL);
 }
 
-#if 0
 void ztaskbox::on_talk_start()
 {
     if (this->cb != NULL)
     {
-        // SOMETHING.
+        cb->on_talk_start();
     }
 }
-
-#endif
 
 void ztaskbox::talk_callback::on_start()
 {


### PR DESCRIPTION
`zGamePause` matches when using the `extern char stringBase0[]` trick. Obviously can be replaced with the actual strings later. `xSndStreamReady` is just missing a single instruction now.