### PR TITLE
Correct operator overload definitions

### DIFF
--- a/src/SB/Core/x/xHud.h
+++ b/src/SB/Core/x/xHud.h
@@ -47,6 +47,28 @@ namespace xhud
         F32 g;
         F32 b;
         F32 a;
+
+        render_context& operator=(const render_context& rhs)
+        {
+            *(S32*)(&loc.x) = *(S32*)(&rhs.loc.x);
+            *(S32*)(&loc.y) = *(S32*)(&rhs.loc.y);
+            *(S32*)(&loc.z) = *(S32*)(&rhs.loc.z);
+
+            *(S32*)(&size.x) = *(S32*)(&rhs.size.x);
+            *(S32*)(&size.y) = *(S32*)(&rhs.size.y);
+            *(S32*)(&size.z) = *(S32*)(&rhs.size.z);
+
+            *(S32*)(&rot.x) = *(S32*)(&rhs.rot.x);
+            *(S32*)(&rot.y) = *(S32*)(&rhs.rot.y);
+            *(S32*)(&rot.z) = *(S32*)(&rhs.rot.z);
+
+            r = rhs.r;
+            g = rhs.g;
+            b = rhs.b;
+            a = rhs.a;
+
+            return *this;
+        }
     };
 
     struct asset : xDynAsset

--- a/src/SB/Core/x/xMath3.h
+++ b/src/SB/Core/x/xMath3.h
@@ -13,6 +13,29 @@ struct xMat3x3
     U32 pad1;
     xVec3 at;
     U32 pad2;
+
+    xMat3x3& operator=(const xMat3x3& rhs)
+    {
+        *(S32*)(&right.x) = *(S32*)(&rhs.right.x);
+        *(S32*)(&right.y) = *(S32*)(&rhs.right.y);
+        *(S32*)(&right.z) = *(S32*)(&rhs.right.z);
+
+        flags = rhs.flags;
+
+        *(S32*)(&up.x) = *(S32*)(&rhs.up.x);
+        *(S32*)(&up.y) = *(S32*)(&rhs.up.y);
+        *(S32*)(&up.z) = *(S32*)(&rhs.up.z);
+
+        pad1 = rhs.pad1;
+
+        *(S32*)(&at.x) = *(S32*)(&rhs.at.x);
+        *(S32*)(&at.y) = *(S32*)(&rhs.at.y);
+        *(S32*)(&at.z) = *(S32*)(&rhs.at.z);
+
+        pad2 = rhs.pad2;
+
+        return *this;
+    }
 };
 
 // Size: 0x40
@@ -20,12 +43,35 @@ struct xMat4x3 : xMat3x3
 {
     xVec3 pos;
     U32 pad3;
+
+    xMat4x3& operator=(const xMat4x3& rhs)
+    {
+        *this = rhs;
+
+        *(S32*)(&pos.x) = *(S32*)(&rhs.pos.x);
+        *(S32*)(&pos.y) = *(S32*)(&rhs.pos.y);
+        *(S32*)(&pos.z) = *(S32*)(&rhs.pos.z);
+
+        pad3 = rhs.pad3;
+
+        return *this;
+    }
 };
 
 struct xSphere
 {
     xVec3 center;
     F32 r;
+
+    xSphere& operator=(const xSphere& rhs)
+    {
+        *(S32*)(&center.x) = *(S32*)(&rhs.center.x);
+        *(S32*)(&center.y) = *(S32*)(&rhs.center.y);
+        *(S32*)(&center.z) = *(S32*)(&rhs.center.z);
+        r = rhs.r;
+
+        return *this;
+    }
 };
 
 // Size: 0x18
@@ -33,6 +79,19 @@ struct xBox
 {
     xVec3 upper;
     xVec3 lower;
+
+    xBox& operator=(const xBox& rhs)
+    {
+        *(S32*)(&upper.x) = *(S32*)(&rhs.upper.x);
+        *(S32*)(&upper.y) = *(S32*)(&rhs.upper.y);
+        *(S32*)(&upper.z) = *(S32*)(&rhs.upper.z);
+
+        *(S32*)(&lower.x) = *(S32*)(&rhs.lower.x);
+        *(S32*)(&lower.y) = *(S32*)(&rhs.lower.y);
+        *(S32*)(&lower.z) = *(S32*)(&rhs.lower.z);
+
+        return *this;
+    }
 };
 
 struct xBBox
@@ -52,6 +111,17 @@ struct xQuat
 {
     xVec3 v;
     F32 s;
+
+    xQuat& operator=(const xQuat& rhs)
+    {
+        *(S32*)(&v.x) = *(S32*)(&rhs.v.x);
+        *(S32*)(&v.y) = *(S32*)(&rhs.v.y);
+        *(S32*)(&v.z) = *(S32*)(&rhs.v.z);
+
+        s = rhs.s;
+
+        return *this;
+    }
 };
 
 struct xVec4

--- a/src/SB/Core/x/xVec3.h
+++ b/src/SB/Core/x/xVec3.h
@@ -17,7 +17,16 @@ struct xVec3
     static xVec3 create(F32 f);
 
     xVec3& operator=(F32);
-    xVec3& operator=(const xVec3&);
+
+    xVec3& operator=(const xVec3& rhs)
+    {
+        x = rhs.x;
+        y = rhs.y;
+        z = rhs.z;
+
+        return *this;
+    }
+
     xVec3 operator+(const xVec3&) const;
     xVec3 operator-(const xVec3&) const;
     xVec3 operator*(F32) const;

--- a/src/SB/Game/zParPTank.cpp
+++ b/src/SB/Game/zParPTank.cpp
@@ -55,6 +55,28 @@ namespace
         F32 life;
         F32 u;
         F32 pad[3];
+
+        snow_particle_data& operator=(const snow_particle_data& rhs)
+        {
+            *(S32*)(&loc.x) = *(S32*)(&rhs.loc.x);
+            *(S32*)(&loc.y) = *(S32*)(&rhs.loc.y);
+            *(S32*)(&loc.z) = *(S32*)(&rhs.loc.z);
+
+            size = rhs.size;
+
+            *(S32*)(&vel.x) = *(S32*)(&rhs.vel.x);
+            *(S32*)(&vel.y) = *(S32*)(&rhs.vel.y);
+            *(S32*)(&vel.z) = *(S32*)(&rhs.vel.z);
+
+            life = rhs.life;
+            u = rhs.u;
+
+            *(S32*)(&pad[0]) = *(S32*)(&rhs.pad[0]);
+            *(S32*)(&pad[1]) = *(S32*)(&rhs.pad[1]);
+            *(S32*)(&pad[2]) = *(S32*)(&rhs.pad[2]);
+			
+			return *this;
+        }
     };
 
     static ptank_pool__pos_color_size_uv2 snow_pool;


### PR DESCRIPTION
Should fix a couple regressions that came up after adding `xVec3& operator=(const xVec3&)`, causing the implicit operator definitions to become incorrect.