### PR TITLE
iFMV Equivalent

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -397,7 +397,7 @@ config.libs = [
             Object(Matching, "SB/Core/gc/iDraw.cpp"),
             Object(Equivalent, "SB/Core/gc/iEnv.cpp"),
             Object(NonMatching, "SB/Core/gc/iFile.cpp"),
-            Object(NonMatching, "SB/Core/gc/iFMV.cpp"),
+            Object(Equivalent, "SB/Core/gc/iFMV.cpp"),
             Object(NonMatching, "SB/Core/gc/iFX.cpp"),
             Object(Matching, "SB/Core/gc/iLight.cpp"),
             Object(Matching, "SB/Core/gc/iMath.cpp"),

--- a/include/bink/bink.h
+++ b/include/bink/bink.h
@@ -1,6 +1,8 @@
 #ifndef __BINK_H__
 #define __BINK_H__
 
+#include <size_t.h>
+
 #define BINKSURFACE8P 0
 #define BINKSURFACE24 1
 #define BINKSURFACE24R 2

--- a/include/bink/bink.h
+++ b/include/bink/bink.h
@@ -22,6 +22,16 @@
 struct BINK
 {
     // Do the members really need to be defined?
+    U32 unk_0;
+    U32 unk_4;
+    U32 unk_8;
+    U32 unk_c;
+    U32 unk_10;
+    U32 unk_14;
+    U32 unk_18;
+    U32 unk_1c;
+    U8 unk_20[0xd0];
+    S32 unk_f0;
 };
 
 typedef struct BINK* HBINK;
@@ -37,8 +47,20 @@ extern int BinkDoFrame(HBINK bnk);
 extern int BinkCopyToBuffer(HBINK bnk, void* dest, int destpitch, unsigned int destheight,
                             unsigned int destx, unsigned int desty, unsigned int flags);
 extern int Lock_RAD_3D_image(HRAD3DIMAGE rad_image, void* out_pixel_buffer,
-                             unsigned int* out_buffer_pitch);
+                             unsigned int* out_buffer_pitch, unsigned int* arg3);
 extern void Unlock_RAD_3D_image(HRAD3DIMAGE rad_image);
+extern void Blit_RAD_3D_image(HRAD3DIMAGE Image, float, float, float, float, float);
+extern void RADSetAudioMemory(void* (*malloc)(size_t), void (*free)(void*));
+extern void RADSetMemory(void* (*malloc)(size_t), void (*free)(void*));
+extern HBINK BinkOpen(const char* fname, void*);
+extern void BinkGetError();
+extern void BinkSetVolume(HBINK bink, unsigned int, int volume);
+extern HRAD3DIMAGE Open_RAD_3D_image(HBINK bink, unsigned int, unsigned int, unsigned int);
+extern void Close_RAD_3D_image(HRAD3DIMAGE rad_image);
+extern void BinkGoto(HBINK bink, int frame, unsigned int);
+extern int BinkWait(HBINK bink);
+extern void BinkNextFrame(HBINK bink);
+extern void BinkClose(HBINK bink);
 
 #ifdef __cplusplus
 }

--- a/include/dolphin/dolphin.h
+++ b/include/dolphin/dolphin.h
@@ -75,13 +75,6 @@ u8 __gUnknown800030E3 : (OS_BASE_CACHED | 0x30E3);
 extern "C" {
 #endif
 
-typedef u8 GXBool;
-
-#define GX_TRUE ((GXBool)1)
-#define GX_FALSE ((GXBool)0)
-#define GX_ENABLE ((GXBool)1)
-#define GX_DISABLE ((GXBool)0)
-
 typedef struct DVDDiskID DVDDiskID;
 
 struct DVDDiskID
@@ -235,17 +228,16 @@ extern volatile OSHeapHandle __OSCurrHeap;
 #define OSAlloc(size) OSAllocFromHeap(__OSCurrHeap, (size))
 #define OSFree(ptr) OSFreeToHeap(__OSCurrHeap, (ptr))
 
-void ARAlloc(u32 size);
-void ARFree(void* mem);
 BOOL DVDFastOpen(s32 entrynum, DVDFileInfo* fileInfo);
 BOOL DVDReadAsyncPrio(DVDFileInfo* fileInfo, void* addr, s32 length, s32 offset,
                       DVDCallback callback, s32 prio);
+s32 DVDCancel(volatile DVDCommandBlock* block);
 BOOL DVDClose(DVDFileInfo* fileInfo);
+int DVDSeekAsyncPrio(DVDFileInfo* fileInfo, s32 offset, void (*callback)(s32, DVDFileInfo*),
+                     s32 prio);
 s32 DVDGetCommandBlockStatus(const DVDCommandBlock* block);
 s32 DVDConvertPathToEntrynum(const char* pathPtr);
 BOOL DVDCancelAllAsync(DVDCBCallback callback);
-void GXSetColorUpdate(GXBool update_enable);
-void GXSetAlphaUpdate(GXBool update_enable);
 void OSPanic(const char* file, int line, const char* msg, ...);
 void* OSAllocFromHeap(OSHeapHandle heap, u32 size);
 void OSFreeToHeap(OSHeapHandle heap, void* ptr);
@@ -406,6 +398,12 @@ s32 CARDSetAttributes(s32 chan, s32 fileNo, u8 attr);
 s32 CARDFormat(s32 chan);
 // CARDRdwr
 s32 CARDGetXferredBytes(s32 chan);
+
+// GX
+#include <dolphin/mtx.h>
+#include <dolphin/vi.h>
+#include <dolphin/gx.h>
+#include <dolphin/ar.h>
 
 #ifdef __cplusplus
 }

--- a/include/dolphin/dolphin/ar.h
+++ b/include/dolphin/dolphin/ar.h
@@ -1,0 +1,69 @@
+#ifndef _DOLPHIN_AR_H_
+#define _DOLPHIN_AR_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef void (*ARQCallback)(u32 pointerToARQRequest);
+
+struct ARQRequest {
+    /* 0x00 */ struct ARQRequest *next;
+    /* 0x04 */ u32 owner;
+    /* 0x08 */ u32 type;
+    /* 0x0C */ u32 priority;
+    /* 0x10 */ u32 source;
+    /* 0x14 */ u32 dest;
+    /* 0x18 */ u32 length;
+    /* 0x1C */ ARQCallback callback;
+};
+
+#define ARQ_DMA_ALIGNMENT 32
+
+#define ARAM_DIR_MRAM_TO_ARAM 0x00
+#define ARAM_DIR_ARAM_TO_MRAM 0x01
+
+#define ARStartDMARead(mmem, aram, len) \
+    ARStartDMA(ARAM_DIR_ARAM_TO_MRAM, mmem, aram, len)
+#define ARStartDMAWrite(mmem, aram, len) \
+    ARStartDMA(ARAM_DIR_MRAM_TO_ARAM, mmem, aram, len)
+
+typedef struct ARQRequest ARQRequest;
+
+#define ARQ_TYPE_MRAM_TO_ARAM ARAM_DIR_MRAM_TO_ARAM
+#define ARQ_TYPE_ARAM_TO_MRAM ARAM_DIR_ARAM_TO_MRAM
+
+#define ARQ_PRIORITY_LOW  0
+#define ARQ_PRIORITY_HIGH 1
+
+// AR
+ARQCallback ARRegisterDMACallback(ARQCallback callback);
+u32 ARGetDMAStatus(void);
+void ARStartDMA(u32 type, u32 mainmem_addr, u32 aram_addr, u32 length);
+u32 ARAlloc(u32 length);
+u32 ARFree(u32* length);
+BOOL ARCheckInit(void);
+u32 ARInit(u32* stack_index_addr, u32 num_entries);
+void ARReset(void);
+void ARSetSize(void);
+u32 ARGetBaseAddress(void);
+u32 ARGetSize(void);
+u32 ARGetInternalSize(void);
+void ARClear(u32 flag);
+
+// ARQ
+void ARQInit(void);
+void ARQReset(void);
+void ARQPostRequest(ARQRequest* request, u32 owner, u32 type, u32 priority, u32 source, u32 dest, u32 length, ARQCallback callback);
+void ARQRemoveRequest(ARQRequest* request);
+void ARQRemoveOwnerRequest(u32 owner);
+void ARQFlushQueue(void);
+void ARQSetChunkSize(u32 size);
+u32 ARQGetChunkSize(void);
+BOOL ARQCheckInit(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/dolphin/dolphin/gx.h
+++ b/include/dolphin/dolphin/gx.h
@@ -1,0 +1,40 @@
+#ifndef _DOLPHIN_GX_H_
+#define _DOLPHIN_GX_H_
+
+#include <dolphin/gx/GXStruct.h>
+#include <dolphin/gx/GXTransform.h>
+#include <dolphin/gx/GXTev.h>
+#include <dolphin/gx/GXPixel.h>
+#include <dolphin/gx/GXManage.h>
+#include <dolphin/gx/GXFifo.h>
+#include <dolphin/gx/GXCull.h>
+#include <dolphin/gx/GXGeometry.h>
+#include <dolphin/gx/GXVert.h>
+#include <dolphin/gx/GXTexture.h>
+#include <dolphin/gx/GXTev.h>
+#include <dolphin/gx/GXLighting.h>
+#include <dolphin/gx/GXDispList.h>
+#include <dolphin/gx/GXCommandList.h>
+#include <dolphin/gx/GXBump.h>
+#include <dolphin/gx/GXFrameBuffer.h>
+#include <dolphin/gx/GXGet.h>
+#include <dolphin/gx/GXDraw.h>
+#include <dolphin/gx/GXPerf.h>
+#include <dolphin/gx/GXCpu2Efb.h>
+#include <dolphin/gx/GXVerify.h>
+
+// unsorted GX externs
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// GXMisc
+void (*GXSetDrawSyncCallback(void (*cb)(u16)))(u16);
+void GXSetDrawSync(u16 token);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/dolphin/dolphin/gx/GXBump.h
+++ b/include/dolphin/dolphin/gx/GXBump.h
@@ -1,0 +1,29 @@
+#ifndef _DOLPHIN_GX_GXBUMP_H_
+#define _DOLPHIN_GX_GXBUMP_H_
+
+#include <dolphin/gx/GXEnum.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void GXSetTevIndirect(GXTevStageID tev_stage, GXIndTexStageID ind_stage, GXIndTexFormat format, GXIndTexBiasSel bias_sel, GXIndTexMtxID matrix_sel, GXIndTexWrap wrap_s, GXIndTexWrap wrap_t, GXBool add_prev, GXBool utc_lod, GXIndTexAlphaSel alpha_sel);
+void GXSetIndTexMtx(GXIndTexMtxID mtx_id, const f32 offset[2][3], s8 scale_exp);
+void GXSetIndTexCoordScale(GXIndTexStageID ind_state, GXIndTexScale scale_s, GXIndTexScale scale_t);
+void GXSetIndTexOrder(GXIndTexStageID ind_stage, GXTexCoordID tex_coord, GXTexMapID tex_map);
+void GXSetNumIndStages(u8 nIndStages);
+void GXSetTevDirect(GXTevStageID tev_stage);
+void GXSetTevIndWarp(GXTevStageID tev_stage, GXIndTexStageID ind_stage, u8 signed_offset, u8 replace_mode, GXIndTexMtxID matrix_sel);
+void GXSetTevIndTile(GXTevStageID tev_stage, GXIndTexStageID ind_stage, u16 tilesize_s,
+    u16 tilesize_t, u16 tilespacing_s, u16 tilespacing_t, GXIndTexFormat format,
+    GXIndTexMtxID matrix_sel, GXIndTexBiasSel bias_sel, GXIndTexAlphaSel alpha_sel);
+void GXSetTevIndBumpST(GXTevStageID tev_stage, GXIndTexStageID ind_stage, GXIndTexMtxID matrix_sel);
+void GXSetTevIndBumpXYZ(GXTevStageID tev_stage, GXIndTexStageID ind_stage, GXIndTexMtxID matrix_sel);
+void GXSetTevIndRepeat(GXTevStageID tev_stage);
+void __GXSetIndirectMask(u32 mask);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/dolphin/dolphin/gx/GXCommandList.h
+++ b/include/dolphin/dolphin/gx/GXCommandList.h
@@ -1,0 +1,35 @@
+#ifndef _DOLPHIN_GX_GXCOMMANDLIST_H_
+#define _DOLPHIN_GX_GXCOMMANDLIST_H_
+
+#define GX_NOP                 0x00
+#define GX_LOAD_CP_REG         0x08
+#define GX_LOAD_XF_REG         0x10
+#define GX_LOAD_INDX_A         0x20
+#define GX_LOAD_INDX_B         0x28
+#define GX_LOAD_INDX_C         0x30
+#define GX_LOAD_INDX_D         0x38
+#define GX_LOAD_BP_REG         0x61
+
+#define GX_DRAW_QUADS          0x80
+#define GX_DRAW_TRIANGLES      0x90
+#define GX_DRAW_TRIANGLE_STRIP 0x98
+#define GX_DRAW_TRIANGLE_FAN   0xA0
+#define GX_DRAW_LINES          0xA8
+#define GX_DRAW_LINE_STRIP     0xB0
+#define GX_DRAW_POINTS         0xB8
+
+#define GX_CMD_CALL_DL   0x40
+#define GX_CMD_INVAL_VTX 0x48
+
+#define GX_OPCODE_MASK 0xF8
+#define GX_VAT_MASK    0x07
+
+extern u8 GXTexMode0Ids[8];
+extern u8 GXTexMode1Ids[8];
+extern u8 GXTexImage0Ids[8];
+extern u8 GXTexImage1Ids[8];
+extern u8 GXTexImage2Ids[8];
+extern u8 GXTexImage3Ids[8];
+extern u8 GXTexTlutIds[8];
+
+#endif

--- a/include/dolphin/dolphin/gx/GXCpu2Efb.h
+++ b/include/dolphin/dolphin/gx/GXCpu2Efb.h
@@ -1,0 +1,29 @@
+#ifndef _DOLPHIN_GX_GXCPU2EFB_H_
+#define _DOLPHIN_GX_GXCPU2EFB_H_
+
+#include <dolphin/gx/GXEnum.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void GXPokeAlphaMode(GXCompare func, u8 threshold);
+void GXPokeAlphaRead(GXAlphaReadMode mode);
+void GXPokeAlphaUpdate(GXBool update_enable);
+void GXPokeBlendMode(GXBlendMode type, GXBlendFactor src_factor, GXBlendFactor dst_factor, GXLogicOp op);
+void GXPokeColorUpdate(GXBool update_enable);
+void GXPokeDstAlpha(GXBool enable, u8 alpha);
+void GXPokeDither(GXBool dither);
+void GXPokeZMode(GXBool compare_enable, GXCompare func, GXBool update_enable);
+void GXPeekARGB(u16 x, u16 y, u32* color);
+void GXPokeARGB(u16 x, u16 y, u32 color);
+void GXPeekZ(u16 x, u16 y, u32* z);
+void GXPokeZ(u16 x, u16 y, u32 z);
+u32 GXCompressZ16(u32 z24, GXZFmt16 zfmt);
+u32 GXDecompressZ16(u32 z16, GXZFmt16 zfmt);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/dolphin/dolphin/gx/GXCull.h
+++ b/include/dolphin/dolphin/gx/GXCull.h
@@ -1,0 +1,18 @@
+#ifndef _DOLPHIN_GX_GXCULL_H_
+#define _DOLPHIN_GX_GXCULL_H_
+
+#include <dolphin/gx/GXEnum.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void GXSetScissor(u32 left, u32 top, u32 wd, u32 ht);
+void GXSetCullMode(GXCullMode mode);
+void GXSetCoPlanar(GXBool enable);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/dolphin/dolphin/gx/GXDispList.h
+++ b/include/dolphin/dolphin/gx/GXDispList.h
@@ -1,0 +1,16 @@
+#ifndef _DOLPHIN_GX_GXDISPLIST_H_
+#define _DOLPHIN_GX_GXDISPLIST_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void GXBeginDisplayList(void* list, u32 size);
+u32 GXEndDisplayList(void);
+void GXCallDisplayList(void* list, u32 nbytes);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/dolphin/dolphin/gx/GXDraw.h
+++ b/include/dolphin/dolphin/gx/GXDraw.h
@@ -1,0 +1,22 @@
+#ifndef _DOLPHIN_GX_GXDRAW_H_
+#define _DOLPHIN_GX_GXDRAW_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void GXDrawCylinder(u8 numEdges);
+void GXDrawTorus(f32 rc, u8 numc, u8 numt);
+void GXDrawSphere(u8 numMajor, u8 numMinor);
+void GXDrawCube(void);
+void GXDrawDodeca(void);
+void GXDrawOctahedron(void);
+void GXDrawIcosahedron(void);
+void GXDrawSphere1(u8 depth);
+u32 GXGenNormalTable(u8 depth, f32* table);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/dolphin/dolphin/gx/GXEnum.h
+++ b/include/dolphin/dolphin/gx/GXEnum.h
@@ -1,0 +1,898 @@
+#ifndef _DOLPHIN_GX_GXENUM_H_
+#define _DOLPHIN_GX_GXENUM_H_
+
+typedef u8 GXBool;
+
+#define GX_FALSE ((GXBool)0)
+#define GX_TRUE ((GXBool)1)
+
+#define GX_ENABLE ((GXBool)1)
+#define GX_DISABLE ((GXBool)0)
+
+typedef enum _GXProjectionType {
+    GX_PERSPECTIVE,
+    GX_ORTHOGRAPHIC,
+} GXProjectionType;
+
+typedef enum _GXCompare {
+    GX_NEVER,
+    GX_LESS,
+    GX_EQUAL,
+    GX_LEQUAL,
+    GX_GREATER,
+    GX_NEQUAL,
+    GX_GEQUAL,
+    GX_ALWAYS,
+} GXCompare;
+
+typedef enum _GXAlphaOp {
+    GX_AOP_AND,
+    GX_AOP_OR,
+    GX_AOP_XOR,
+    GX_AOP_XNOR,
+    GX_MAX_ALPHAOP,
+} GXAlphaOp;
+
+typedef enum _GXZFmt16 {
+    GX_ZC_LINEAR,
+    GX_ZC_NEAR,
+    GX_ZC_MID,
+    GX_ZC_FAR,
+} GXZFmt16;
+
+typedef enum _GXGamma {
+    GX_GM_1_0,
+    GX_GM_1_7,
+    GX_GM_2_2,
+} GXGamma;
+
+typedef enum _GXPixelFmt {
+    GX_PF_RGB8_Z24,
+    GX_PF_RGBA6_Z24,
+    GX_PF_RGB565_Z16,
+    GX_PF_Z24,
+    GX_PF_Y8,
+    GX_PF_U8,
+    GX_PF_V8,
+    GX_PF_YUV420,
+} GXPixelFmt;
+
+typedef enum _GXPrimitive {
+    GX_QUADS = 0x80,
+    GX_TRIANGLES = 0x90,
+    GX_TRIANGLESTRIP = 0x98,
+    GX_TRIANGLEFAN = 0xA0,
+    GX_LINES = 0xA8,
+    GX_LINESTRIP = 0xB0,
+    GX_POINTS = 0xB8,
+} GXPrimitive;
+
+typedef enum _GXVtxFmt {
+    GX_VTXFMT0,
+    GX_VTXFMT1,
+    GX_VTXFMT2,
+    GX_VTXFMT3,
+    GX_VTXFMT4,
+    GX_VTXFMT5,
+    GX_VTXFMT6,
+    GX_VTXFMT7,
+    GX_MAX_VTXFMT,
+} GXVtxFmt;
+
+typedef enum _GXAttr {
+    GX_VA_PNMTXIDX,
+    GX_VA_TEX0MTXIDX,
+    GX_VA_TEX1MTXIDX,
+    GX_VA_TEX2MTXIDX,
+    GX_VA_TEX3MTXIDX,
+    GX_VA_TEX4MTXIDX,
+    GX_VA_TEX5MTXIDX,
+    GX_VA_TEX6MTXIDX,
+    GX_VA_TEX7MTXIDX,
+    GX_VA_POS,
+    GX_VA_NRM,
+    GX_VA_CLR0,
+    GX_VA_CLR1,
+    GX_VA_TEX0,
+    GX_VA_TEX1,
+    GX_VA_TEX2,
+    GX_VA_TEX3,
+    GX_VA_TEX4,
+    GX_VA_TEX5,
+    GX_VA_TEX6,
+    GX_VA_TEX7,
+    GX_POS_MTX_ARRAY,
+    GX_NRM_MTX_ARRAY,
+    GX_TEX_MTX_ARRAY,
+    GX_LIGHT_ARRAY,
+    GX_VA_NBT,
+    GX_VA_MAX_ATTR,
+    GX_VA_NULL = 0xFF,
+} GXAttr;
+
+typedef enum _GXAttrType {
+    GX_NONE,
+    GX_DIRECT,
+    GX_INDEX8,
+    GX_INDEX16,
+} GXAttrType;
+
+#define _GX_TF_CTF 0x20
+#define _GX_TF_ZTF 0x10
+
+typedef enum _GXTexFmt {
+    GX_TF_I4 = 0x0,
+    GX_TF_I8 = 0x1,
+    GX_TF_IA4 = 0x2,
+    GX_TF_IA8 = 0x3,
+    GX_TF_RGB565 = 0x4,
+    GX_TF_RGB5A3 = 0x5,
+    GX_TF_RGBA8 = 0x6,
+    GX_TF_CMPR = 0xE,
+
+    GX_CTF_R4 = 0x0 | _GX_TF_CTF,
+    GX_CTF_RA4 = 0x2 | _GX_TF_CTF,
+    GX_CTF_RA8 = 0x3 | _GX_TF_CTF,
+    GX_CTF_YUVA8 = 0x6 | _GX_TF_CTF,
+    GX_CTF_A8 = 0x7 | _GX_TF_CTF,
+    GX_CTF_R8 = 0x8 | _GX_TF_CTF,
+    GX_CTF_G8 = 0x9 | _GX_TF_CTF,
+    GX_CTF_B8 = 0xA | _GX_TF_CTF,
+    GX_CTF_RG8 = 0xB | _GX_TF_CTF,
+    GX_CTF_GB8 = 0xC | _GX_TF_CTF,
+
+    GX_TF_Z8 = 0x1 | _GX_TF_ZTF,
+    GX_TF_Z16 = 0x3 | _GX_TF_ZTF,
+    GX_TF_Z24X8 = 0x6 | _GX_TF_ZTF,
+
+    GX_CTF_Z4 = 0x0 | _GX_TF_ZTF | _GX_TF_CTF,
+    GX_CTF_Z8M = 0x9 | _GX_TF_ZTF | _GX_TF_CTF,
+    GX_CTF_Z8L = 0xA | _GX_TF_ZTF | _GX_TF_CTF,
+    GX_CTF_Z16L = 0xC | _GX_TF_ZTF | _GX_TF_CTF,
+
+    GX_TF_A8 = GX_CTF_A8,
+} GXTexFmt;
+
+typedef enum _GXCITexFmt {
+    GX_TF_C4 = 0x8,
+    GX_TF_C8 = 0x9,
+    GX_TF_C14X2 = 0xA,
+} GXCITexFmt;
+
+typedef enum _GXTexWrapMode {
+    GX_CLAMP,
+    GX_REPEAT,
+    GX_MIRROR,
+    GX_MAX_TEXWRAPMODE,
+} GXTexWrapMode;
+
+typedef enum _GXTexFilter {
+    GX_NEAR,
+    GX_LINEAR,
+    GX_NEAR_MIP_NEAR,
+    GX_LIN_MIP_NEAR,
+    GX_NEAR_MIP_LIN,
+    GX_LIN_MIP_LIN,
+} GXTexFilter;
+
+typedef enum _GXAnisotropy {
+    GX_ANISO_1,
+    GX_ANISO_2,
+    GX_ANISO_4,
+    GX_MAX_ANISOTROPY,
+} GXAnisotropy;
+
+typedef enum _GXTexMapID {
+    GX_TEXMAP0,
+    GX_TEXMAP1,
+    GX_TEXMAP2,
+    GX_TEXMAP3,
+    GX_TEXMAP4,
+    GX_TEXMAP5,
+    GX_TEXMAP6,
+    GX_TEXMAP7,
+    GX_MAX_TEXMAP,
+    GX_TEXMAP_NULL = 0xFF,
+    GX_TEX_DISABLE = 0x100,
+} GXTexMapID;
+
+typedef enum _GXTexCoordID {
+    GX_TEXCOORD0,
+    GX_TEXCOORD1,
+    GX_TEXCOORD2,
+    GX_TEXCOORD3,
+    GX_TEXCOORD4,
+    GX_TEXCOORD5,
+    GX_TEXCOORD6,
+    GX_TEXCOORD7,
+    GX_MAX_TEXCOORD,
+    GX_TEXCOORD_NULL = 0xFF,
+} GXTexCoordID;
+
+typedef enum _GXTevStageID {
+    GX_TEVSTAGE0,
+    GX_TEVSTAGE1,
+    GX_TEVSTAGE2,
+    GX_TEVSTAGE3,
+    GX_TEVSTAGE4,
+    GX_TEVSTAGE5,
+    GX_TEVSTAGE6,
+    GX_TEVSTAGE7,
+    GX_TEVSTAGE8,
+    GX_TEVSTAGE9,
+    GX_TEVSTAGE10,
+    GX_TEVSTAGE11,
+    GX_TEVSTAGE12,
+    GX_TEVSTAGE13,
+    GX_TEVSTAGE14,
+    GX_TEVSTAGE15,
+    GX_MAX_TEVSTAGE,
+} GXTevStageID;
+
+typedef enum _GXTevMode {
+    GX_MODULATE,
+    GX_DECAL,
+    GX_BLEND,
+    GX_REPLACE,
+    GX_PASSCLR,
+} GXTevMode;
+
+typedef enum _GXTexMtxType {
+    GX_MTX3x4,
+    GX_MTX2x4,
+} GXTexMtxType;
+
+typedef enum _GXTexGenType {
+    GX_TG_MTX3x4,
+    GX_TG_MTX2x4,
+    GX_TG_BUMP0,
+    GX_TG_BUMP1,
+    GX_TG_BUMP2,
+    GX_TG_BUMP3,
+    GX_TG_BUMP4,
+    GX_TG_BUMP5,
+    GX_TG_BUMP6,
+    GX_TG_BUMP7,
+    GX_TG_SRTG,
+} GXTexGenType;
+
+typedef enum _GXPosNrmMtx {
+    GX_PNMTX0 = 0,
+    GX_PNMTX1 = 3,
+    GX_PNMTX2 = 6,
+    GX_PNMTX3 = 9,
+    GX_PNMTX4 = 12,
+    GX_PNMTX5 = 15,
+    GX_PNMTX6 = 18,
+    GX_PNMTX7 = 21,
+    GX_PNMTX8 = 24,
+    GX_PNMTX9 = 27,
+} GXPosNrmMtx;
+
+typedef enum _GXTexMtx {
+    GX_TEXMTX0 = 30,
+    GX_TEXMTX1 = 33,
+    GX_TEXMTX2 = 36,
+    GX_TEXMTX3 = 39,
+    GX_TEXMTX4 = 42,
+    GX_TEXMTX5 = 45,
+    GX_TEXMTX6 = 48,
+    GX_TEXMTX7 = 51,
+    GX_TEXMTX8 = 54,
+    GX_TEXMTX9 = 57,
+    GX_IDENTITY = 60,
+} GXTexMtx;
+
+typedef enum _GXChannelID {
+    GX_COLOR0,
+    GX_COLOR1,
+    GX_ALPHA0,
+    GX_ALPHA1,
+    GX_COLOR0A0,
+    GX_COLOR1A1,
+    GX_COLOR_ZERO,
+    GX_ALPHA_BUMP,
+    GX_ALPHA_BUMPN,
+    GX_COLOR_NULL = 0xFF,
+} GXChannelID;
+
+typedef enum _GXTexGenSrc {
+    GX_TG_POS,
+    GX_TG_NRM,
+    GX_TG_BINRM,
+    GX_TG_TANGENT,
+    GX_TG_TEX0,
+    GX_TG_TEX1,
+    GX_TG_TEX2,
+    GX_TG_TEX3,
+    GX_TG_TEX4,
+    GX_TG_TEX5,
+    GX_TG_TEX6,
+    GX_TG_TEX7,
+    GX_TG_TEXCOORD0,
+    GX_TG_TEXCOORD1,
+    GX_TG_TEXCOORD2,
+    GX_TG_TEXCOORD3,
+    GX_TG_TEXCOORD4,
+    GX_TG_TEXCOORD5,
+    GX_TG_TEXCOORD6,
+    GX_TG_COLOR0,
+    GX_TG_COLOR1,
+} GXTexGenSrc;
+
+typedef enum _GXBlendMode {
+    GX_BM_NONE,
+    GX_BM_BLEND,
+    GX_BM_LOGIC,
+    GX_BM_SUBTRACT,
+    GX_MAX_BLENDMODE,
+} GXBlendMode;
+
+typedef enum _GXBlendFactor {
+    GX_BL_ZERO,
+    GX_BL_ONE,
+    GX_BL_SRCCLR,
+    GX_BL_INVSRCCLR,
+    GX_BL_SRCALPHA,
+    GX_BL_INVSRCALPHA,
+    GX_BL_DSTALPHA,
+    GX_BL_INVDSTALPHA,
+    GX_BL_DSTCLR = GX_BL_SRCCLR,
+    GX_BL_INVDSTCLR = GX_BL_INVSRCCLR,
+} GXBlendFactor;
+
+typedef enum _GXLogicOp {
+    GX_LO_CLEAR,
+    GX_LO_AND,
+    GX_LO_REVAND,
+    GX_LO_COPY,
+    GX_LO_INVAND,
+    GX_LO_NOOP,
+    GX_LO_XOR,
+    GX_LO_OR,
+    GX_LO_NOR,
+    GX_LO_EQUIV,
+    GX_LO_INV,
+    GX_LO_REVOR,
+    GX_LO_INVCOPY,
+    GX_LO_INVOR,
+    GX_LO_NAND,
+    GX_LO_SET,
+} GXLogicOp;
+
+typedef enum _GXCompCnt {
+    GX_POS_XY   = 0,
+    GX_POS_XYZ  = 1,
+    GX_NRM_XYZ  = 0,
+    GX_NRM_NBT  = 1,
+    GX_NRM_NBT3 = 2,
+    GX_CLR_RGB = 0,
+    GX_CLR_RGBA = 1,
+    GX_TEX_S = 0,
+    GX_TEX_ST = 1,
+} GXCompCnt;
+
+typedef enum _GXCompType {
+    GX_U8 = 0,
+    GX_S8 = 1,
+    GX_U16 = 2,
+    GX_S16 = 3,
+    GX_F32 = 4,
+    GX_RGB565 = 0,
+    GX_RGB8 = 1,
+    GX_RGBX8 = 2,
+    GX_RGBA4 = 3,
+    GX_RGBA6 = 4,
+    GX_RGBA8 = 5,
+} GXCompType;
+
+typedef enum _GXPTTexMtx {
+    GX_PTTEXMTX0 = 64,
+    GX_PTTEXMTX1 = 67,
+    GX_PTTEXMTX2 = 70,
+    GX_PTTEXMTX3 = 73,
+    GX_PTTEXMTX4 = 76,
+    GX_PTTEXMTX5 = 79,
+    GX_PTTEXMTX6 = 82,
+    GX_PTTEXMTX7 = 85,
+    GX_PTTEXMTX8 = 88,
+    GX_PTTEXMTX9 = 91,
+    GX_PTTEXMTX10 = 94,
+    GX_PTTEXMTX11 = 97,
+    GX_PTTEXMTX12 = 100,
+    GX_PTTEXMTX13 = 103,
+    GX_PTTEXMTX14 = 106,
+    GX_PTTEXMTX15 = 109,
+    GX_PTTEXMTX16 = 112,
+    GX_PTTEXMTX17 = 115,
+    GX_PTTEXMTX18 = 118,
+    GX_PTTEXMTX19 = 121,
+    GX_PTIDENTITY = 125,
+} GXPTTexMtx;
+
+typedef enum _GXTevRegID {
+    GX_TEVPREV,
+    GX_TEVREG0,
+    GX_TEVREG1,
+    GX_TEVREG2,
+    GX_MAX_TEVREG,
+} GXTevRegID;
+
+typedef enum _GXDiffuseFn {
+    GX_DF_NONE,
+    GX_DF_SIGN,
+    GX_DF_CLAMP,
+} GXDiffuseFn;
+
+typedef enum _GXColorSrc {
+    GX_SRC_REG,
+    GX_SRC_VTX,
+} GXColorSrc;
+
+typedef enum _GXAttnFn {
+    GX_AF_SPEC,
+    GX_AF_SPOT,
+    GX_AF_NONE,
+} GXAttnFn;
+
+typedef enum _GXLightID {
+    GX_LIGHT0 = 0x001,
+    GX_LIGHT1 = 0x002,
+    GX_LIGHT2 = 0x004,
+    GX_LIGHT3 = 0x008,
+    GX_LIGHT4 = 0x010,
+    GX_LIGHT5 = 0x020,
+    GX_LIGHT6 = 0x040,
+    GX_LIGHT7 = 0x080,
+    GX_MAX_LIGHT = 0x100,
+    GX_LIGHT_NULL = 0,
+} GXLightID;
+
+typedef enum _GXTexOffset {
+    GX_TO_ZERO,
+    GX_TO_SIXTEENTH,
+    GX_TO_EIGHTH,
+    GX_TO_FOURTH,
+    GX_TO_HALF,
+    GX_TO_ONE,
+    GX_MAX_TEXOFFSET,
+} GXTexOffset;
+
+typedef enum _GXSpotFn {
+    GX_SP_OFF,
+    GX_SP_FLAT,
+    GX_SP_COS,
+    GX_SP_COS2,
+    GX_SP_SHARP,
+    GX_SP_RING1,
+    GX_SP_RING2,
+} GXSpotFn;
+
+typedef enum _GXDistAttnFn {
+    GX_DA_OFF,
+    GX_DA_GENTLE,
+    GX_DA_MEDIUM,
+    GX_DA_STEEP,
+} GXDistAttnFn;
+
+typedef enum _GXCullMode {
+    GX_CULL_NONE,
+    GX_CULL_FRONT,
+    GX_CULL_BACK,
+    GX_CULL_ALL
+} GXCullMode;
+
+typedef enum _GXTevSwapSel {
+    GX_TEV_SWAP0 = 0,
+    GX_TEV_SWAP1,
+    GX_TEV_SWAP2,
+    GX_TEV_SWAP3,
+    GX_MAX_TEVSWAP
+} GXTevSwapSel;
+
+typedef enum _GXTevColorChan {
+    GX_CH_RED = 0,
+    GX_CH_GREEN,
+    GX_CH_BLUE,
+    GX_CH_ALPHA
+} GXTevColorChan;
+
+typedef enum _GXFogType {
+    GX_FOG_NONE = 0,
+    GX_FOG_PERSP_LIN = 2,
+    GX_FOG_PERSP_EXP = 4,
+    GX_FOG_PERSP_EXP2 = 5,
+    GX_FOG_PERSP_REVEXP = 6,
+    GX_FOG_PERSP_REVEXP2 = 7,
+    GX_FOG_ORTHO_LIN = 10,
+    GX_FOG_ORTHO_EXP = 12,
+    GX_FOG_ORTHO_EXP2 = 13,
+    GX_FOG_ORTHO_REVEXP = 14,
+    GX_FOG_ORTHO_REVEXP2 = 15,
+    GX_FOG_LIN = 2,
+    GX_FOG_EXP = 4,
+    GX_FOG_EXP2 = 5,
+    GX_FOG_REVEXP = 6,
+    GX_FOG_REVEXP2 = 7,
+} GXFogType;
+
+typedef enum _GXTevColorArg {
+    GX_CC_CPREV = 0,
+    GX_CC_APREV = 1,
+    GX_CC_C0 = 2,
+    GX_CC_A0 = 3,
+    GX_CC_C1 = 4,
+    GX_CC_A1 = 5,
+    GX_CC_C2 = 6,
+    GX_CC_A2 = 7,
+    GX_CC_TEXC = 8,
+    GX_CC_TEXA = 9,
+    GX_CC_RASC = 10,
+    GX_CC_RASA = 11,
+    GX_CC_ONE = 12,
+    GX_CC_HALF = 13,
+    GX_CC_KONST = 14,
+    GX_CC_ZERO = 15,
+    GX_CC_TEXRRR = 16,
+    GX_CC_TEXGGG = 17,
+    GX_CC_TEXBBB = 18,
+    GX_CC_QUARTER = 14,
+} GXTevColorArg;
+
+typedef enum _GXTevAlphaArg {
+    GX_CA_APREV = 0,
+    GX_CA_A0 = 1,
+    GX_CA_A1 = 2,
+    GX_CA_A2 = 3,
+    GX_CA_TEXA = 4,
+    GX_CA_RASA = 5,
+    GX_CA_KONST = 6,
+    GX_CA_ZERO = 7,
+    GX_CA_ONE = 6,
+} GXTevAlphaArg;
+
+typedef enum _GXTevOp {
+    GX_TEV_ADD = 0,
+    GX_TEV_SUB = 1,
+    GX_TEV_COMP_R8_GT = 8,
+    GX_TEV_COMP_R8_EQ = 9,
+    GX_TEV_COMP_GR16_GT = 10,
+    GX_TEV_COMP_GR16_EQ = 11,
+    GX_TEV_COMP_BGR24_GT = 12,
+    GX_TEV_COMP_BGR24_EQ = 13,
+    GX_TEV_COMP_RGB8_GT = 14,
+    GX_TEV_COMP_RGB8_EQ = 15,
+    GX_TEV_COMP_A8_GT = GX_TEV_COMP_RGB8_GT,
+    GX_TEV_COMP_A8_EQ = GX_TEV_COMP_RGB8_EQ
+} GXTevOp;
+
+typedef enum _GXTevBias {
+    GX_TB_ZERO,
+    GX_TB_ADDHALF,
+    GX_TB_SUBHALF,
+    GX_MAX_TEVBIAS
+} GXTevBias;
+
+typedef enum _GXTevScale {
+    GX_CS_SCALE_1,
+    GX_CS_SCALE_2,
+    GX_CS_SCALE_4,
+    GX_CS_DIVIDE_2,
+    GX_MAX_TEVSCALE
+} GXTevScale;
+
+typedef enum _GXTevKColorSel {
+    GX_TEV_KCSEL_1    = 0x00,
+    GX_TEV_KCSEL_7_8  = 0x01,
+    GX_TEV_KCSEL_3_4  = 0x02,
+    GX_TEV_KCSEL_5_8  = 0x03,
+    GX_TEV_KCSEL_1_2  = 0x04,
+    GX_TEV_KCSEL_3_8  = 0x05,
+    GX_TEV_KCSEL_1_4  = 0x06,
+    GX_TEV_KCSEL_1_8  = 0x07,
+    GX_TEV_KCSEL_K0   = 0x0C,
+    GX_TEV_KCSEL_K1   = 0x0D,
+    GX_TEV_KCSEL_K2   = 0x0E,
+    GX_TEV_KCSEL_K3   = 0x0F,
+    GX_TEV_KCSEL_K0_R = 0x10,
+    GX_TEV_KCSEL_K1_R = 0x11,
+    GX_TEV_KCSEL_K2_R = 0x12,
+    GX_TEV_KCSEL_K3_R = 0x13,
+    GX_TEV_KCSEL_K0_G = 0x14,
+    GX_TEV_KCSEL_K1_G = 0x15,
+    GX_TEV_KCSEL_K2_G = 0x16,
+    GX_TEV_KCSEL_K3_G = 0x17,
+    GX_TEV_KCSEL_K0_B = 0x18,
+    GX_TEV_KCSEL_K1_B = 0x19,
+    GX_TEV_KCSEL_K2_B = 0x1A,
+    GX_TEV_KCSEL_K3_B = 0x1B,
+    GX_TEV_KCSEL_K0_A = 0x1C,
+    GX_TEV_KCSEL_K1_A = 0x1D,
+    GX_TEV_KCSEL_K2_A = 0x1E,
+    GX_TEV_KCSEL_K3_A = 0x1F
+} GXTevKColorSel;
+
+typedef enum _GXTevKAlphaSel {
+    GX_TEV_KASEL_1    = 0x00,
+    GX_TEV_KASEL_7_8  = 0x01,
+    GX_TEV_KASEL_3_4  = 0x02,
+    GX_TEV_KASEL_5_8  = 0x03,
+    GX_TEV_KASEL_1_2  = 0x04,
+    GX_TEV_KASEL_3_8  = 0x05,
+    GX_TEV_KASEL_1_4  = 0x06,
+    GX_TEV_KASEL_1_8  = 0x07,
+    GX_TEV_KASEL_K0_R = 0x10,
+    GX_TEV_KASEL_K1_R = 0x11,
+    GX_TEV_KASEL_K2_R = 0x12,
+    GX_TEV_KASEL_K3_R = 0x13,
+    GX_TEV_KASEL_K0_G = 0x14,
+    GX_TEV_KASEL_K1_G = 0x15,
+    GX_TEV_KASEL_K2_G = 0x16,
+    GX_TEV_KASEL_K3_G = 0x17,
+    GX_TEV_KASEL_K0_B = 0x18,
+    GX_TEV_KASEL_K1_B = 0x19,
+    GX_TEV_KASEL_K2_B = 0x1A,
+    GX_TEV_KASEL_K3_B = 0x1B,
+    GX_TEV_KASEL_K0_A = 0x1C,
+    GX_TEV_KASEL_K1_A = 0x1D,
+    GX_TEV_KASEL_K2_A = 0x1E,
+    GX_TEV_KASEL_K3_A = 0x1F
+} GXTevKAlphaSel;
+
+typedef enum _GXTevKColorID {
+    GX_KCOLOR0 = 0,
+    GX_KCOLOR1,
+    GX_KCOLOR2,
+    GX_KCOLOR3,
+    GX_MAX_KCOLOR
+} GXTevKColorID;
+
+typedef enum _GXZTexOp {
+    GX_ZT_DISABLE,
+    GX_ZT_ADD,
+    GX_ZT_REPLACE,
+    GX_MAX_ZTEXOP,
+} GXZTexOp;
+
+typedef enum _GXIndTexFormat {
+    GX_ITF_8,
+    GX_ITF_5,
+    GX_ITF_4,
+    GX_ITF_3,
+    GX_MAX_ITFORMAT,
+} GXIndTexFormat;
+
+typedef enum _GXIndTexBiasSel {
+    GX_ITB_NONE,
+    GX_ITB_S,
+    GX_ITB_T,
+    GX_ITB_ST,
+    GX_ITB_U,
+    GX_ITB_SU,
+    GX_ITB_TU,
+    GX_ITB_STU,
+    GX_MAX_ITBIAS,
+} GXIndTexBiasSel;
+
+typedef enum _GXIndTexAlphaSel {
+    GX_ITBA_OFF,
+    GX_ITBA_S,
+    GX_ITBA_T,
+    GX_ITBA_U,
+    GX_MAX_ITBALPHA,
+} GXIndTexAlphaSel;
+
+typedef enum _GXIndTexMtxID {
+    GX_ITM_OFF,
+    GX_ITM_0,
+    GX_ITM_1,
+    GX_ITM_2,
+    GX_ITM_S0 = 5,
+    GX_ITM_S1,
+    GX_ITM_S2,
+    GX_ITM_T0 = 9,
+    GX_ITM_T1,
+    GX_ITM_T2,
+} GXIndTexMtxID;
+
+typedef enum _GXIndTexWrap {
+    GX_ITW_OFF,
+    GX_ITW_256,
+    GX_ITW_128,
+    GX_ITW_64,
+    GX_ITW_32,
+    GX_ITW_16,
+    GX_ITW_0,
+    GX_MAX_ITWRAP,
+} GXIndTexWrap;
+
+typedef enum _GXIndTexStageID {
+    GX_INDTEXSTAGE0,
+    GX_INDTEXSTAGE1,
+    GX_INDTEXSTAGE2,
+    GX_INDTEXSTAGE3,
+    GX_MAX_INDTEXSTAGE,
+} GXIndTexStageID;
+
+typedef enum _GXIndTexScale {
+    GX_ITS_1,
+    GX_ITS_2,
+    GX_ITS_4,
+    GX_ITS_8,
+    GX_ITS_16,
+    GX_ITS_32,
+    GX_ITS_64,
+    GX_ITS_128,
+    GX_ITS_256,
+    GX_MAX_ITSCALE,
+} GXIndTexScale;
+
+typedef enum _GXPerf0 {
+    GX_PERF0_VERTICES,
+    GX_PERF0_CLIP_VTX,
+    GX_PERF0_CLIP_CLKS,
+    GX_PERF0_XF_WAIT_IN,
+    GX_PERF0_XF_WAIT_OUT,
+    GX_PERF0_XF_XFRM_CLKS,
+    GX_PERF0_XF_LIT_CLKS,
+    GX_PERF0_XF_BOT_CLKS,
+    GX_PERF0_XF_REGLD_CLKS,
+    GX_PERF0_XF_REGRD_CLKS,
+    GX_PERF0_CLIP_RATIO,
+
+    GX_PERF0_TRIANGLES,
+    GX_PERF0_TRIANGLES_CULLED,
+    GX_PERF0_TRIANGLES_PASSED,
+    GX_PERF0_TRIANGLES_SCISSORED,
+    GX_PERF0_TRIANGLES_0TEX,
+    GX_PERF0_TRIANGLES_1TEX,
+    GX_PERF0_TRIANGLES_2TEX,
+    GX_PERF0_TRIANGLES_3TEX,
+    GX_PERF0_TRIANGLES_4TEX,
+    GX_PERF0_TRIANGLES_5TEX,
+    GX_PERF0_TRIANGLES_6TEX,
+    GX_PERF0_TRIANGLES_7TEX,
+    GX_PERF0_TRIANGLES_8TEX,
+    GX_PERF0_TRIANGLES_0CLR,
+    GX_PERF0_TRIANGLES_1CLR,
+    GX_PERF0_TRIANGLES_2CLR,
+
+    GX_PERF0_QUAD_0CVG,
+    GX_PERF0_QUAD_NON0CVG,
+    GX_PERF0_QUAD_1CVG,
+    GX_PERF0_QUAD_2CVG,
+    GX_PERF0_QUAD_3CVG,
+    GX_PERF0_QUAD_4CVG,
+    GX_PERF0_AVG_QUAD_CNT,
+
+    GX_PERF0_CLOCKS,
+    GX_PERF0_NONE,
+} GXPerf0;
+
+typedef enum _GXPerf1 {
+    GX_PERF1_TEXELS,
+    GX_PERF1_TX_IDLE,
+    GX_PERF1_TX_REGS,
+    GX_PERF1_TX_MEMSTALL,
+    GX_PERF1_TC_CHECK1_2,
+    GX_PERF1_TC_CHECK3_4,
+    GX_PERF1_TC_CHECK5_6,
+    GX_PERF1_TC_CHECK7_8,
+    GX_PERF1_TC_MISS,
+
+    GX_PERF1_VC_ELEMQ_FULL,
+    GX_PERF1_VC_MISSQ_FULL,
+    GX_PERF1_VC_MEMREQ_FULL,
+    GX_PERF1_VC_STATUS7,
+    GX_PERF1_VC_MISSREP_FULL,
+    GX_PERF1_VC_STREAMBUF_LOW,
+    GX_PERF1_VC_ALL_STALLS,
+    GX_PERF1_VERTICES,
+
+    GX_PERF1_FIFO_REQ,
+    GX_PERF1_CALL_REQ,
+    GX_PERF1_VC_MISS_REQ,
+    GX_PERF1_CP_ALL_REQ,
+
+    GX_PERF1_CLOCKS,
+    GX_PERF1_NONE,
+} GXPerf1;
+
+typedef enum _GXVCachePerf {
+    GX_VC_POS = 0,
+    GX_VC_NRM = 1,
+    GX_VC_CLR0 = 2,
+    GX_VC_CLR1 = 3,
+    GX_VC_TEX0 = 4,
+    GX_VC_TEX1 = 5,
+    GX_VC_TEX2 = 6,
+    GX_VC_TEX3 = 7,
+    GX_VC_TEX4 = 8,
+    GX_VC_TEX5 = 9,
+    GX_VC_TEX6 = 10,
+    GX_VC_TEX7 = 11,
+    GX_VC_ALL = 15,
+} GXVCachePerf;
+
+typedef enum _GXClipMode {
+    GX_CLIP_ENABLE = 0,
+    GX_CLIP_DISABLE = 1,
+} GXClipMode;
+
+typedef enum _GXFBClamp {
+    GX_CLAMP_NONE = 0,
+    GX_CLAMP_TOP = 1,
+    GX_CLAMP_BOTTOM = 2,
+} GXFBClamp;
+
+typedef enum _GXCopyMode {
+    GX_COPY_PROGRESSIVE = 0,
+    GX_COPY_INTLC_EVEN = 2,
+    GX_COPY_INTLC_ODD = 3,
+} GXCopyMode;
+
+typedef enum _GXAlphaReadMode {
+    GX_READ_00,
+    GX_READ_FF,
+    GX_READ_NONE,
+} GXAlphaReadMode;
+
+typedef enum _GXTexCacheSize {
+    GX_TEXCACHE_32K,
+    GX_TEXCACHE_128K,
+    GX_TEXCACHE_512K,
+    GX_TEXCACHE_NONE,
+} GXTexCacheSize;
+
+typedef enum _GXTlut {
+    GX_TLUT0,
+    GX_TLUT1,
+    GX_TLUT2,
+    GX_TLUT3,
+    GX_TLUT4,
+    GX_TLUT5,
+    GX_TLUT6,
+    GX_TLUT7,
+    GX_TLUT8,
+    GX_TLUT9,
+    GX_TLUT10,
+    GX_TLUT11,
+    GX_TLUT12,
+    GX_TLUT13,
+    GX_TLUT14,
+    GX_TLUT15,
+    GX_BIGTLUT0,
+    GX_BIGTLUT1,
+    GX_BIGTLUT2,
+    GX_BIGTLUT3,
+} GXTlut;
+
+typedef enum _GXTlutFmt {
+    GX_TL_IA8,
+    GX_TL_RGB565,
+    GX_TL_RGB5A3,
+    GX_MAX_TLUTFMT,
+} GXTlutFmt;
+
+typedef enum _GXTlutSize {
+    GX_TLUT_16 = 1,
+    GX_TLUT_32 = 2,
+    GX_TLUT_64 = 4,
+    GX_TLUT_128 = 8,
+    GX_TLUT_256 = 16,
+    GX_TLUT_512 = 32,
+    GX_TLUT_1K = 64,
+    GX_TLUT_2K = 128,
+    GX_TLUT_4K = 256,
+    GX_TLUT_8K = 512,
+    GX_TLUT_16K = 1024,
+} GXTlutSize;
+
+typedef enum _GXMiscToken {
+    GX_MT_XF_FLUSH = 1,
+    GX_MT_DL_SAVE_CONTEXT = 2,
+    GX_MT_ABORT_WAIT_COPYOUT = 3,
+    GX_MT_NULL = 0,
+} GXMiscToken;
+
+#endif

--- a/include/dolphin/dolphin/gx/GXFifo.h
+++ b/include/dolphin/dolphin/gx/GXFifo.h
@@ -1,0 +1,50 @@
+#ifndef _DOLPHIN_GX_GXFIFO_H_
+#define _DOLPHIN_GX_GXFIFO_H_
+
+#include <dolphin/gx/GXEnum.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct OSThread;
+
+typedef struct
+{
+    u8 pad[128];
+} GXFifoObj;
+
+typedef void (*GXBreakPtCallback)(void);
+
+void GXInitFifoBase(GXFifoObj* fifo, void* base, u32 size);
+void GXInitFifoPtrs(GXFifoObj* fifo, void* readPtr, void* writePtr);
+void GXInitFifoLimits(GXFifoObj* fifo, u32 hiWatermark, u32 loWatermark);
+void GXSetCPUFifo(GXFifoObj* fifo);
+void GXSetGPFifo(GXFifoObj* fifo);
+void GXSaveCPUFifo(GXFifoObj* fifo);
+void GXSaveGPFifo(GXFifoObj* fifo);
+void GXGetGPStatus(GXBool* overhi, GXBool* underlow, GXBool* readIdle, GXBool* cmdIdle,
+                   GXBool* brkpt);
+void GXGetFifoStatus(GXFifoObj* fifo, GXBool* overhi, GXBool* underflow, u32* fifoCount,
+                     GXBool* cpuWrite, GXBool* gpRead, GXBool* fifowrap);
+void GXGetFifoPtrs(GXFifoObj* fifo, void** readPtr, void** writePtr);
+void* GXGetFifoBase(const GXFifoObj* fifo);
+u32 GXGetFifoSize(const GXFifoObj* fifo);
+void GXGetFifoLimits(const GXFifoObj* fifo, u32* hi, u32* lo);
+GXBreakPtCallback GXSetBreakPtCallback(GXBreakPtCallback cb);
+void GXEnableBreakPt(void* break_pt);
+void GXDisableBreakPt(void);
+OSThread* GXSetCurrentGXThread(void);
+OSThread* GXGetCurrentGXThread(void);
+GXFifoObj* GXGetCPUFifo(void);
+GXFifoObj* GXGetGPFifo(void);
+u32 GXGetOverflowCount(void);
+u32 GXResetOverflowCount(void);
+volatile void* GXRedirectWriteGatherPipe(void* ptr);
+void GXRestoreWriteGatherPipe(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/dolphin/dolphin/gx/GXFrameBuffer.h
+++ b/include/dolphin/dolphin/gx/GXFrameBuffer.h
@@ -1,0 +1,66 @@
+#ifndef _DOLPHIN_GX_GXFRAMEBUFFER_H_
+#define _DOLPHIN_GX_GXFRAMEBUFFER_H_
+
+#include <dolphin/gx/GXStruct.h>
+#include <dolphin/gx/GXEnum.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define	GX_MAX_Z24	0x00ffffff
+
+extern GXRenderModeObj GXNtsc240Ds;
+extern GXRenderModeObj GXNtsc240DsAa;
+extern GXRenderModeObj GXNtsc240Int;
+extern GXRenderModeObj GXNtsc240IntAa;
+extern GXRenderModeObj GXNtsc480IntDf;
+extern GXRenderModeObj GXNtsc480Int;
+extern GXRenderModeObj GXNtsc480IntAa;
+extern GXRenderModeObj GXNtsc480Prog;
+extern GXRenderModeObj GXNtsc480ProgAa;
+extern GXRenderModeObj GXMpal240Ds;
+extern GXRenderModeObj GXMpal240DsAa;
+extern GXRenderModeObj GXMpal240Int;
+extern GXRenderModeObj GXMpal240IntAa;
+extern GXRenderModeObj GXMpal480IntDf;
+extern GXRenderModeObj GXMpal480Int;
+extern GXRenderModeObj GXMpal480IntAa;
+extern GXRenderModeObj GXPal264Ds;
+extern GXRenderModeObj GXPal264DsAa;
+extern GXRenderModeObj GXPal264Int;
+extern GXRenderModeObj GXPal264IntAa;
+extern GXRenderModeObj GXPal528IntDf;
+extern GXRenderModeObj GXPal528Int;
+extern GXRenderModeObj GXPal528IntAa;
+extern GXRenderModeObj GXEurgb60Hz240Ds;
+extern GXRenderModeObj GXEurgb60Hz240DsAa;
+extern GXRenderModeObj GXEurgb60Hz240Int;
+extern GXRenderModeObj GXEurgb60Hz240IntAa;
+extern GXRenderModeObj GXEurgb60Hz480IntDf;
+extern GXRenderModeObj GXEurgb60Hz480Int;
+extern GXRenderModeObj GXEurgb60Hz480IntAa;
+
+void GXAdjustForOverscan(const GXRenderModeObj* rmin, GXRenderModeObj* rmout, u16 hor, u16 ver);
+void GXSetDispCopySrc(u16 left, u16 top, u16 wd, u16 ht);
+void GXSetTexCopySrc(u16 left, u16 top, u16 wd, u16 ht);
+void GXSetDispCopyDst(u16 wd, u16 ht);
+void GXSetTexCopyDst(u16 wd, u16 ht, GXTexFmt fmt, GXBool mipmap);
+void GXSetDispCopyFrame2Field(GXCopyMode mode);
+void GXSetCopyClamp(GXFBClamp clamp);
+u32 GXSetDispCopyYScale(f32 vscale);
+void GXSetCopyClear(GXColor clear_clr, u32 clear_z);
+void GXSetCopyFilter(GXBool aa, const u8 sample_pattern[12][2], GXBool vf, const u8 vfilter[7]);
+void GXSetDispCopyGamma(GXGamma gamma);
+void GXCopyDisp(void* dest, GXBool clear);
+void GXCopyTex(void* dest, GXBool clear);
+void GXClearBoundingBox(void);
+void GXReadBoundingBox(u16* left, u16* top, u16* right, u16* bottom);
+u16 GXGetNumXfbLines(u16 efbHeight, f32 yScale);
+f32 GXGetYScaleFactor(u16 efbHeight, u16 xfbHeight);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/dolphin/dolphin/gx/GXGeometry.h
+++ b/include/dolphin/dolphin/gx/GXGeometry.h
@@ -1,0 +1,47 @@
+#ifndef _DOLPHIN_GX_GXGEOMETRY_H_
+#define _DOLPHIN_GX_GXGEOMETRY_H_
+
+#include <dolphin/gx/GXEnum.h>
+#include <dolphin/gx/GXStruct.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void __GXCalculateVLim();
+void GXSetVtxDesc(GXAttr attr, GXAttrType type);
+void GXSetVtxDescv(const GXVtxDescList* attrPtr);
+void GXClearVtxDesc(void);
+void GXSetVtxAttrFmt(GXVtxFmt vtxfmt, GXAttr attr, GXCompCnt cnt, GXCompType type, u8 frac);
+void GXSetVtxAttrFmtv(GXVtxFmt vtxfmt, const GXVtxAttrFmtList* list);
+void GXSetArray(GXAttr attr, void* base_ptr, u8 stride);
+void GXInvalidateVtxCache(void);
+void GXSetTexCoordGen2(GXTexCoordID dst_coord, GXTexGenType func, GXTexGenSrc src_param, u32 mtx, GXBool normalize, u32 pt_texmtx);
+void GXSetNumTexGens(u8 nTexGens);
+
+static inline void GXSetTexCoordGen(GXTexCoordID dst_coord, GXTexGenType func, GXTexGenSrc src_param, u32 mtx) {
+    GXSetTexCoordGen2(dst_coord, func, src_param, mtx, GX_FALSE, GX_PTIDENTITY);
+}
+
+void GXBegin(GXPrimitive type, GXVtxFmt vtxfmt, u16 nverts);
+
+static inline void GXEnd(void) {
+#if DEBUG
+    extern GXBool __GXinBegin;
+    extern void OSPanic(char* file, int line, char* msg, ...);
+    if (!__GXinBegin) {
+        OSPanic(__FILE__, 118, "GXEnd: called without a GXBegin");
+    }
+    __GXinBegin = GX_FALSE;
+#endif
+}
+
+void GXSetLineWidth(u8 width, GXTexOffset texOffsets);
+void GXSetPointSize(u8 pointSize, GXTexOffset texOffsets);
+void GXEnableTexOffsets(GXTexCoordID coord, u8 line_enable, u8 point_enable);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/dolphin/dolphin/gx/GXGet.h
+++ b/include/dolphin/dolphin/gx/GXGet.h
@@ -1,0 +1,64 @@
+#ifndef _DOLPHIN_GX_GXGET_H_
+#define _DOLPHIN_GX_GXGET_H_
+
+#include <dolphin/gx/GXEnum.h>
+#include <dolphin/gx/GXStruct.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Attr
+void GXGetVtxDesc(GXAttr attr, GXAttrType* type);
+void GXGetVtxDescv(GXVtxDescList* vcd);
+void GXGetVtxAttrFmt(GXVtxFmt fmt, GXAttr attr, GXCompCnt* cnt, GXCompType* type, u8* frac);
+void GXGetVtxAttrFmtv(GXVtxFmt fmt, GXVtxAttrFmtList* vat);
+
+// Geometry
+void GXGetLineWidth(u8* width, GXTexOffset* texOffsets);
+void GXGetPointSize(u8* pointSize, GXTexOffset* texOffsets);
+void GXGetCullMode(GXCullMode* mode);
+
+// Light
+void GXGetLightAttnA(const GXLightObj* lt_obj, f32* a0, f32* a1, f32* a2);
+void GXGetLightAttnK(const GXLightObj* lt_obj, f32* k0, f32* k1, f32* k2);
+void GXGetLightPos(const GXLightObj* lt_obj, f32* x, f32* y, f32* z);
+void GXGetLightDir(const GXLightObj* lt_obj, f32* nx, f32* ny, f32* nz);
+void GXGetLightColor(const GXLightObj* lt_obj, GXColor* color);
+
+// Texture
+GXBool GXGetTexObjMipMap(const GXTexObj* to);
+GXTexFmt GXGetTexObjFmt(const GXTexObj* to);
+u16 GXGetTexObjWidth(const GXTexObj* to);
+u16 GXGetTexObjHeight(const GXTexObj* to);
+GXTexWrapMode GXGetTexObjWrapS(const GXTexObj* to);
+GXTexWrapMode GXGetTexObjWrapT(const GXTexObj* to);
+void* GXGetTexObjData(const GXTexObj* to);;
+void GXGetTexObjAll(const GXTexObj* obj, void** image_ptr, u16* width, u16* height, GXTexFmt* format, GXTexWrapMode* wrap_s, GXTexWrapMode* wrap_t, u8* mipmap);
+void GXGetTexObjLODAll(const GXTexObj* tex_obj, GXTexFilter* min_filt, GXTexFilter* mag_filt, f32* min_lod, f32* max_lod, f32* lod_bias, u8* bias_clamp, u8* do_edge_lod, GXAnisotropy* max_aniso);
+GXTexFilter GXGetTexObjMinFilt(const GXTexObj* tex_obj);
+GXTexFilter GXGetTexObjMagFilt(const GXTexObj* tex_obj);
+f32 GXGetTexObjMinLOD(const GXTexObj* tex_obj);
+f32 GXGetTexObjMaxLOD(const GXTexObj* tex_obj);
+f32 GXGetTexObjLODBias(const GXTexObj* tex_obj);
+GXBool GXGetTexObjBiasClamp(const GXTexObj* tex_obj);
+GXBool GXGetTexObjEdgeLOD(const GXTexObj* tex_obj);
+GXAnisotropy GXGetTexObjMaxAniso(const GXTexObj* tex_obj);
+u32 GXGetTexObjTlut(const GXTexObj* tex_obj);
+void GXGetTlutObjAll(const GXTlutObj* tlut_obj, void** data, GXTlutFmt* format, u16* numEntries);
+void* GXGetTlutObjData(const GXTlutObj* tlut_obj);
+GXTlutFmt GXGetTlutObjFmt(const GXTlutObj* tlut_obj);
+u16 GXGetTlutObjNumEntries(const GXTlutObj* tlut_obj);
+void GXGetTexRegionAll(const GXTexRegion* region, u8* is_cached, u8* is_32b_mipmap, u32* tmem_even, u32* size_even, u32* tmem_odd, u32* size_odd);
+void GXGetTlutRegionAll(const GXTlutRegion* region, u32* tmem_addr, GXTlutSize* tlut_size);
+
+// Transform
+void GXGetProjectionv(f32* ptr);
+void GXGetViewportv(f32* vp);
+void GXGetScissor(u32* left, u32* top, u32* wd, u32* ht);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/dolphin/dolphin/gx/GXLighting.h
+++ b/include/dolphin/dolphin/gx/GXLighting.h
@@ -1,0 +1,32 @@
+#ifndef _DOLPHIN_GX_GXLIGHTING_H_
+#define _DOLPHIN_GX_GXLIGHTING_H_
+
+#include <dolphin/gx/GXEnum.h>
+#include <dolphin/gx/GXStruct.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void GXInitLightAttn(GXLightObj* lt_obj, f32 a0, f32 a1, f32 a2, f32 k0, f32 k1, f32 k2);
+void GXInitLightAttnA(GXLightObj* lt_obj, f32 a0, f32 a1, f32 a2);
+void GXInitLightAttnK(GXLightObj* lt_obj, f32 k0, f32 k1, f32 k2);
+void GXInitLightSpot(GXLightObj* lt_obj, f32 cutoff, GXSpotFn spot_func);
+void GXInitLightDistAttn(GXLightObj* lt_obj, f32 ref_dist, f32 ref_br, GXDistAttnFn dist_func);
+void GXInitLightPos(GXLightObj* lt_obj, f32 x, f32 y, f32 z);
+void GXInitLightDir(GXLightObj* lt_obj, f32 nx, f32 ny, f32 nz);
+void GXInitSpecularDir(GXLightObj* lt_obj, f32 nx, f32 ny, f32 nz);
+void GXInitSpecularDirHA(GXLightObj* lt_obj, f32 nx, f32 ny, f32 nz, f32 hx, f32 hy, f32 hz);
+void GXInitLightColor(GXLightObj* lt_obj, GXColor color);
+void GXLoadLightObjImm(const GXLightObj* lt_obj, GXLightID light);
+void GXLoadLightObjIndx(u32 lt_obj_indx, GXLightID light);
+void GXSetChanAmbColor(GXChannelID chan, GXColor amb_color);
+void GXSetChanMatColor(GXChannelID chan, GXColor mat_color);
+void GXSetNumChans(u8 nChans);
+void GXSetChanCtrl(GXChannelID chan, GXBool enable, GXColorSrc amb_src, GXColorSrc mat_src, u32 light_mask, GXDiffuseFn diff_fn, GXAttnFn attn_fn);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/dolphin/dolphin/gx/GXManage.h
+++ b/include/dolphin/dolphin/gx/GXManage.h
@@ -1,0 +1,36 @@
+#ifndef _DOLPHIN_GX_GXMANAGE_H_
+#define _DOLPHIN_GX_GXMANAGE_H_
+
+#include <dolphin/gx/GXFifo.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef void (*GXDrawSyncCallback)(u16 token);
+typedef void (*GXDrawDoneCallback)(void);
+
+// Init
+BOOL IsWriteGatherBufferEmpty(void);
+GXFifoObj* GXInit(void* base, u32 size);
+
+// Misc
+void GXSetMisc(GXMiscToken token, u32 val);
+void GXFlush(void);
+void GXResetWriteGatherPipe(void);
+void GXAbortFrame(void);
+void GXSetDrawSync(u16 token);
+u16 GXReadDrawSync(void);
+void GXSetDrawDone(void);
+void GXWaitDrawDone(void);
+void GXDrawDone(void);
+void GXPixModeSync(void);
+void GXTexModeSync(void);
+GXDrawSyncCallback GXSetDrawSyncCallback(GXDrawSyncCallback cb);
+GXDrawDoneCallback GXSetDrawDoneCallback(GXDrawDoneCallback cb);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/dolphin/dolphin/gx/GXPerf.h
+++ b/include/dolphin/dolphin/gx/GXPerf.h
@@ -1,0 +1,30 @@
+#ifndef _DOLPHIN_GX_GXPERF_H_
+#define _DOLPHIN_GX_GXPERF_H_
+
+#include <dolphin/gx/GXEnum.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void GXSetGPMetric(GXPerf0 perf0, GXPerf1 perf1);
+void GXReadGPMetric(u32* cnt0, u32* cnt1);
+void GXClearGPMetric(void);
+u32 GXReadGP0Metric(void);
+u32 GXReadGP1Metric(void);
+void GXReadMemMetric(u32* cp_req, u32* tc_req, u32* cpu_rd_req, u32* cpu_wr_req, u32* dsp_req, u32* io_req, u32* vi_req, u32* pe_req, u32* rf_req, u32* fi_req);
+void GXClearMemMetric(void);
+void GXReadPixMetric(u32* top_pixels_in, u32* top_pixels_out, u32* bot_pixels_in, u32* bot_pixels_out, u32* clr_pixels_in, u32* copy_clks);
+void GXClearPixMetric(void);
+void GXSetVCacheMetric(GXVCachePerf attr);
+void GXReadVCacheMetric(u32* check, u32* miss, u32* stall);
+void GXClearVCacheMetric(void);
+void GXInitXfRasMetric(void);
+void GXReadXfRasMetric(u32* xf_wait_in, u32* xf_wait_out, u32* ras_busy, u32* clocks);
+u32 GXReadClksPerVtx(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/dolphin/dolphin/gx/GXPixel.h
+++ b/include/dolphin/dolphin/gx/GXPixel.h
@@ -1,0 +1,30 @@
+#ifndef _DOLPHIN_GX_GXPIXEL_H_
+#define _DOLPHIN_GX_GXPIXEL_H_
+
+#include <dolphin/gx/GXEnum.h>
+#include <dolphin/gx/GXStruct.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void GXSetFog(GXFogType type, f32 startz, f32 endz, f32 nearz, f32 farz, GXColor color);
+void GXInitFogAdjTable(GXFogAdjTable* table, u16 width, const f32 projmtx[4][4]);
+void GXSetFogRangeAdj(GXBool enable, u16 center, const GXFogAdjTable* table);
+void GXSetBlendMode(GXBlendMode type, GXBlendFactor src_factor, GXBlendFactor dst_factor, GXLogicOp op);
+void GXSetColorUpdate(GXBool update_enable);
+void GXSetAlphaUpdate(GXBool update_enable);
+void GXSetZMode(GXBool compare_enable, GXCompare func, GXBool update_enable);
+void GXSetZCompLoc(GXBool before_tex);
+void GXSetPixelFmt(GXPixelFmt pix_fmt, GXZFmt16 z_fmt);
+void GXSetDither(GXBool dither);
+void GXSetDstAlpha(GXBool enable, u8 alpha);
+void GXSetFieldMask(GXBool odd_mask, GXBool even_mask);
+void GXSetFieldMode(GXBool field_mode, GXBool half_aspect_ratio);
+void GXSetFogColor(GXColor color);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/dolphin/dolphin/gx/GXStruct.h
+++ b/include/dolphin/dolphin/gx/GXStruct.h
@@ -1,0 +1,75 @@
+#ifndef _DOLPHIN_GX_GXSTRUCT_H_
+#define _DOLPHIN_GX_GXSTRUCT_H_
+
+#include <dolphin/gx/GXEnum.h>
+#include <dolphin/vi/vitypes.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct _GXRenderModeObj {
+    /* 0x00 */ VITVMode viTVmode;
+    /* 0x04 */ u16 fbWidth;
+    /* 0x06 */ u16 efbHeight;
+    /* 0x08 */ u16 xfbHeight;
+    /* 0x0A */ u16 viXOrigin;
+    /* 0x0C */ u16 viYOrigin;
+    /* 0x0E */ u16 viWidth;
+    /* 0x10 */ u16 viHeight;
+    /* 0x14 */ VIXFBMode xFBmode;
+    /* 0x18 */ u8 field_rendering;
+    /* 0x19 */ u8 aa;
+    /* 0x20 */ u8 sample_pattern[12][2];
+    /* 0x38 */ u8 vfilter[7];
+} GXRenderModeObj;
+
+typedef struct _GXColor {
+    u8 r, g, b, a;
+} GXColor;
+
+typedef struct _GXColorS10 {
+    s16 r, g, b, a;
+} GXColorS10;
+
+typedef struct _GXTexObj {
+    u32 dummy[8];
+} GXTexObj;
+
+typedef struct _GXLightObj {
+    u32 dummy[16];
+} GXLightObj;
+
+typedef struct _GXTexRegion {
+    u32 dummy[4];
+} GXTexRegion;
+
+typedef struct _GXTlutObj {
+    u32 dummy[3];
+} GXTlutObj;
+
+typedef struct _GXTlutRegion {
+    u32 dummy[4];
+} GXTlutRegion;
+
+typedef struct _GXFogAdjTable {
+    u16 r[10];
+} GXFogAdjTable;
+
+typedef struct _GXVtxDescList {
+    GXAttr attr;
+    GXAttrType type;
+} GXVtxDescList;
+
+typedef struct _GXVtxAttrFmtList {
+    GXAttr attr;
+    GXCompCnt cnt;
+    GXCompType type;
+    u8 frac;
+} GXVtxAttrFmtList;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/dolphin/dolphin/gx/GXTev.h
+++ b/include/dolphin/dolphin/gx/GXTev.h
@@ -1,0 +1,33 @@
+#ifndef _DOLPHIN_GX_GXTEV_H_
+#define _DOLPHIN_GX_GXTEV_H_
+
+#include <dolphin/gx/GXEnum.h>
+#include <dolphin/gx/GXStruct.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void GXSetTevOp(GXTevStageID id, GXTevMode mode);
+void GXSetTevColorIn(GXTevStageID stage, GXTevColorArg a, GXTevColorArg b, GXTevColorArg c, GXTevColorArg d);
+void GXSetTevAlphaIn(GXTevStageID stage, GXTevAlphaArg a, GXTevAlphaArg b, GXTevAlphaArg c, GXTevAlphaArg d);
+void GXSetTevColorOp(GXTevStageID stage, GXTevOp op, GXTevBias bias, GXTevScale scale, GXBool clamp, GXTevRegID out_reg);
+void GXSetTevAlphaOp(GXTevStageID stage, GXTevOp op, GXTevBias bias, GXTevScale scale, GXBool clamp, GXTevRegID out_reg);
+void GXSetTevColor(GXTevRegID id, GXColor color);
+void GXSetTevColorS10(GXTevRegID id, GXColorS10 color);
+void GXSetTevKColor(GXTevKColorID id, GXColor color);
+void GXSetTevKColorSel(GXTevStageID stage, GXTevKColorSel sel);
+void GXSetTevKAlphaSel(GXTevStageID stage, GXTevKAlphaSel sel);
+void GXSetTevSwapMode(GXTevStageID stage, GXTevSwapSel ras_sel, GXTevSwapSel tex_sel);
+void GXSetTevSwapModeTable(GXTevSwapSel table, GXTevColorChan red, GXTevColorChan green, GXTevColorChan blue, GXTevColorChan alpha);
+void GXSetTevClampMode(void);
+void GXSetAlphaCompare(GXCompare comp0, u8 ref0, GXAlphaOp op, GXCompare comp1, u8 ref1);
+void GXSetZTexture(GXZTexOp op, GXTexFmt fmt, u32 bias);
+void GXSetTevOrder(GXTevStageID stage, GXTexCoordID coord, GXTexMapID map, GXChannelID color);
+void GXSetNumTevStages(u8 nStages);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/dolphin/dolphin/gx/GXTexture.h
+++ b/include/dolphin/dolphin/gx/GXTexture.h
@@ -1,0 +1,52 @@
+#ifndef _DOLPHIN_GX_GXTEXTURE_H_
+#define _DOLPHIN_GX_GXTEXTURE_H_
+
+#include <dolphin/gx/GXEnum.h>
+#include <dolphin/gx/GXStruct.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef GXTexRegion *(*GXTexRegionCallback)(GXTexObj* t_obj, GXTexMapID id);
+typedef GXTlutRegion *(*GXTlutRegionCallback)(u32 idx);
+
+u32 GXGetTexBufferSize(u16 width, u16 height, u32 format, u8 mipmap, u8 max_lod);
+void GXInitTexObj(GXTexObj* obj, void* image_ptr, u16 width, u16 height, GXTexFmt format, GXTexWrapMode wrap_s, GXTexWrapMode wrap_t, u8 mipmap);
+void GXInitTexObjCI(GXTexObj* obj, void* image_ptr, u16 width, u16 height, GXCITexFmt format, GXTexWrapMode wrap_s, GXTexWrapMode wrap_t, u8 mipmap, u32 tlut_name);
+void GXInitTexObjLOD(GXTexObj* obj, GXTexFilter min_filt, GXTexFilter mag_filt,
+    f32 min_lod, f32 max_lod, f32 lod_bias, GXBool bias_clamp,
+    GXBool do_edge_lod, GXAnisotropy max_aniso);
+void GXInitTexObjData(GXTexObj* obj, void* image_ptr);
+void GXInitTexObjWrapMode(GXTexObj* obj, GXTexWrapMode s, GXTexWrapMode t);
+void GXInitTexObjTlut(GXTexObj* obj, u32 tlut_name);
+void GXInitTexObjUserData(GXTexObj* obj, void* user_data);
+void* GXGetTexObjUserData(const GXTexObj* obj);
+void GXLoadTexObjPreLoaded(GXTexObj* obj, GXTexRegion* region, GXTexMapID id);
+void GXLoadTexObj(GXTexObj* obj, GXTexMapID id);
+void GXInitTlutObj(GXTlutObj* tlut_obj, void* lut, GXTlutFmt fmt, u16 n_entries);
+void GXLoadTlut(GXTlutObj* tlut_obj, u32 tlut_name);
+void GXInitTexCacheRegion(GXTexRegion* region, u8 is_32b_mipmap, u32 tmem_even, GXTexCacheSize size_even, u32 tmem_odd, GXTexCacheSize size_odd);
+void GXInitTexPreLoadRegion(GXTexRegion* region, u32 tmem_even, u32 size_even, u32 tmem_odd, u32 size_odd);
+void GXInitTlutRegion(GXTlutRegion* region, u32 tmem_addr, GXTlutSize tlut_size);
+void GXInvalidateTexRegion(GXTexRegion* region);
+void GXInvalidateTexAll(void);
+GXTexRegionCallback GXSetTexRegionCallback(GXTexRegionCallback f);
+GXTlutRegionCallback GXSetTlutRegionCallback(GXTlutRegionCallback f);
+void GXPreLoadEntireTexture(GXTexObj* tex_obj, GXTexRegion* region);
+void GXSetTexCoordScaleManually(GXTexCoordID coord, u8 enable, u16 ss, u16 ts);
+void GXSetTexCoordCylWrap(GXTexCoordID coord, u8 s_enable, u8 t_enable);
+void GXSetTexCoordBias(GXTexCoordID coord, u8 s_enable, u8 t_enable);
+void GXInitTexObjFilter(GXTexObj* obj, GXTexFilter min_filt, GXTexFilter mag_filt);
+void GXInitTexObjMaxLOD(GXTexObj* obj, f32 max_lod);
+void GXInitTexObjMinLOD(GXTexObj* obj, f32 min_lod);
+void GXInitTexObjLODBias(GXTexObj* obj, f32 lod_bias);
+void GXInitTexObjBiasClamp(GXTexObj* obj, u8 bias_clamp);
+void GXInitTexObjEdgeLOD(GXTexObj* obj, u8 do_edge_lod);
+void GXInitTexObjMaxAniso(GXTexObj* obj, GXAnisotropy max_aniso);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/dolphin/dolphin/gx/GXTransform.h
+++ b/include/dolphin/dolphin/gx/GXTransform.h
@@ -1,0 +1,34 @@
+#ifndef _DOLPHIN_GX_GXTRANSFORM_H_
+#define _DOLPHIN_GX_GXTRANSFORM_H_
+
+#include <dolphin/gx/GXEnum.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define GX_PROJECTION_SZ  7
+#define GX_VIEWPORT_SZ  6
+
+void GXProject(f32 x, f32 y, f32 z, const f32 mtx[3][4], const f32* pm, const f32* vp, f32* sx, f32* sy, f32* sz);
+void GXSetProjection(const f32 mtx[4][4], GXProjectionType type);
+void GXSetProjectionv(const f32* ptr);
+void GXLoadPosMtxImm(const f32 mtx[3][4], u32 id);
+void GXLoadPosMtxIndx(u16 mtx_indx, u32 id);
+void GXLoadNrmMtxImm(const f32 mtx[3][4], u32 id);
+void GXLoadNrmMtxImm3x3(const f32 mtx[3][3], u32 id);
+void GXLoadNrmMtxIndx3x3(u16 mtx_indx, u32 id);
+void GXSetCurrentMtx(u32 id);
+void GXLoadTexMtxImm(const f32 mtx[][4], u32 id, GXTexMtxType type);
+void GXLoadTexMtxIndx(u16 mtx_indx, u32 id, GXTexMtxType type);
+void GXSetViewportJitter(f32 left, f32 top, f32 wd, f32 ht, f32 nearz, f32 farz, u32 field);
+void GXSetViewport(f32 left, f32 top, f32 wd, f32 ht, f32 nearz, f32 farz);
+void GXSetScissorBoxOffset(s32 x_off, s32 y_off);
+void GXSetClipMode(GXClipMode mode);
+void GXSetZScaleOffset(f32 scale, f32 offset);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/dolphin/dolphin/gx/GXVerify.h
+++ b/include/dolphin/dolphin/gx/GXVerify.h
@@ -1,0 +1,29 @@
+#ifndef _DOLPHIN_GX_GXVERIFY_H_
+#define _DOLPHIN_GX_GXVERIFY_H_
+
+#include <dolphin/gx/GXEnum.h>
+#include <dolphin/gx/GXStruct.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    GX_WARN_NONE,
+    GX_WARN_SEVERE,
+    GX_WARN_MEDIUM,
+    GX_WARN_ALL
+} GXWarningLevel;
+
+typedef void (*GXVerifyCallback)(GXWarningLevel level, u32 id, char* msg);
+
+void GXSetVerifyLevel(GXWarningLevel level);
+GXVerifyCallback GXSetVerifyCallback(GXVerifyCallback cb);
+
+void __GXVerifyVATImm(GXAttr attr, GXCompCnt cnt, GXCompType type, u8 frac);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/dolphin/dolphin/gx/GXVert.h
+++ b/include/dolphin/dolphin/gx/GXVert.h
@@ -1,0 +1,162 @@
+#ifndef _DOLPHIN_GX_GXVERT_H_
+#define _DOLPHIN_GX_GXVERT_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define GXFIFO_ADDR 0xCC008000
+
+typedef union
+{
+    u8 u8;
+    u16 u16;
+    u32 u32;
+    u64 u64;
+    s8 s8;
+    s16 s16;
+    s32 s32;
+    s64 s64;
+    f32 f32;
+    f64 f64;
+} PPCWGPipe;
+
+#ifdef __MWERKS__
+volatile PPCWGPipe GXWGFifo : (GXFIFO_ADDR);
+#else
+#define GXWGFifo (*(volatile PPCWGPipe*)GXFIFO_ADDR)
+#endif
+
+#if DEBUG
+
+// external functions
+
+#define FUNC_1PARAM(name, T) void name##1##T(T x);
+#define FUNC_2PARAM(name, T) void name##2##T(T x, T y);
+#define FUNC_3PARAM(name, T) void name##3##T(T x, T y, T z);
+#define FUNC_4PARAM(name, T) void name##4##T(T x, T y, T z, T w);
+#define FUNC_INDEX8(name) void name##1x8(u8 x);
+#define FUNC_INDEX16(name) void name##1x16(u16 x);
+
+#else
+
+// inline functions
+
+#define FUNC_1PARAM(name, T)                                                                       \
+    static inline void name##1##T(T x)                                                             \
+    {                                                                                              \
+        GXWGFifo.T = x;                                                                            \
+    }
+
+#define FUNC_2PARAM(name, T)                                                                       \
+    static inline void name##2##T(T x, T y)                                                        \
+    {                                                                                              \
+        GXWGFifo.T = x;                                                                            \
+        GXWGFifo.T = y;                                                                            \
+    }
+
+#define FUNC_3PARAM(name, T)                                                                       \
+    static inline void name##3##T(T x, T y, T z)                                                   \
+    {                                                                                              \
+        GXWGFifo.T = x;                                                                            \
+        GXWGFifo.T = y;                                                                            \
+        GXWGFifo.T = z;                                                                            \
+    }
+
+#define FUNC_4PARAM(name, T)                                                                       \
+    static inline void name##4##T(T x, T y, T z, T w)                                              \
+    {                                                                                              \
+        GXWGFifo.T = x;                                                                            \
+        GXWGFifo.T = y;                                                                            \
+        GXWGFifo.T = z;                                                                            \
+        GXWGFifo.T = w;                                                                            \
+    }
+
+#define FUNC_INDEX8(name)                                                                          \
+    static inline void name##1x8(u8 x)                                                             \
+    {                                                                                              \
+        GXWGFifo.u8 = x;                                                                           \
+    }
+
+#define FUNC_INDEX16(name)                                                                         \
+    static inline void name##1x16(u16 x)                                                           \
+    {                                                                                              \
+        GXWGFifo.u16 = x;                                                                          \
+    }
+
+#endif
+
+// GXCmd
+FUNC_1PARAM(GXCmd, u8)
+FUNC_1PARAM(GXCmd, u16)
+FUNC_1PARAM(GXCmd, u32)
+
+// GXParam
+FUNC_1PARAM(GXParam, u8)
+FUNC_1PARAM(GXParam, u16)
+FUNC_1PARAM(GXParam, u32)
+FUNC_1PARAM(GXParam, s8)
+FUNC_1PARAM(GXParam, s16)
+FUNC_1PARAM(GXParam, s32)
+FUNC_1PARAM(GXParam, f32)
+FUNC_3PARAM(GXParam, f32)
+FUNC_4PARAM(GXParam, f32)
+
+// GXPosition
+FUNC_3PARAM(GXPosition, f32)
+FUNC_3PARAM(GXPosition, u8)
+FUNC_3PARAM(GXPosition, s8)
+FUNC_3PARAM(GXPosition, u16)
+FUNC_3PARAM(GXPosition, s16)
+FUNC_2PARAM(GXPosition, f32)
+FUNC_2PARAM(GXPosition, u8)
+FUNC_2PARAM(GXPosition, s8)
+FUNC_2PARAM(GXPosition, u16)
+FUNC_2PARAM(GXPosition, s16)
+FUNC_INDEX16(GXPosition)
+FUNC_INDEX8(GXPosition)
+
+// GXNormal
+FUNC_3PARAM(GXNormal, f32)
+FUNC_3PARAM(GXNormal, s16)
+FUNC_3PARAM(GXNormal, s8)
+FUNC_INDEX16(GXNormal)
+FUNC_INDEX8(GXNormal)
+
+// GXColor
+FUNC_4PARAM(GXColor, u8)
+FUNC_1PARAM(GXColor, u32)
+FUNC_3PARAM(GXColor, u8)
+FUNC_1PARAM(GXColor, u16)
+FUNC_INDEX16(GXColor)
+FUNC_INDEX8(GXColor)
+
+// GXTexCoord
+FUNC_2PARAM(GXTexCoord, f32)
+FUNC_2PARAM(GXTexCoord, s16)
+FUNC_2PARAM(GXTexCoord, u16)
+FUNC_2PARAM(GXTexCoord, s8)
+FUNC_2PARAM(GXTexCoord, u8)
+FUNC_1PARAM(GXTexCoord, f32)
+FUNC_1PARAM(GXTexCoord, s16)
+FUNC_1PARAM(GXTexCoord, u16)
+FUNC_1PARAM(GXTexCoord, s8)
+FUNC_1PARAM(GXTexCoord, u8)
+FUNC_INDEX16(GXTexCoord)
+FUNC_INDEX8(GXTexCoord)
+
+// GXMatrixIndex
+FUNC_1PARAM(GXMatrixIndex, u8)
+
+#undef FUNC_1PARAM
+#undef FUNC_2PARAM
+#undef FUNC_3PARAM
+#undef FUNC_4PARAM
+#undef FUNC_INDEX8
+#undef FUNC_INDEX16
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/dolphin/dolphin/mtx.h
+++ b/include/dolphin/dolphin/mtx.h
@@ -1,0 +1,373 @@
+#ifndef _DOLPHIN_MTX_H_
+#define _DOLPHIN_MTX_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+	f32 x, y, z;
+} Vec, *VecPtr, Point3d, *Point3dPtr;
+
+typedef struct {
+    s16 x, y, z;
+} S16Vec, *S16VecPtr;
+
+typedef struct {
+	f32 x, y, z, w;
+} Quaternion, *QuaternionPtr, Qtrn, *QtrnPtr;
+
+typedef f32 Mtx[3][4];
+typedef f32 (*MtxPtr)[4];
+
+typedef f32 Mtx44[4][4];
+typedef f32 (*Mtx44Ptr)[4];
+
+typedef f32 ROMtx[4][3];
+typedef f32 (*ROMtxPtr)[4];
+
+typedef struct {
+    u32 numMtx;
+    MtxPtr stackBase;
+    MtxPtr stackPtr;
+} MTXStack;
+
+#define MTXDegToRad(d) (d * 0.01745329252f)
+#define MTXRadToDeg(r) (r * 57.29577951f)
+
+// MTX
+// C version
+void C_MTXIdentity(Mtx m);
+void C_MTXCopy(const Mtx src, Mtx dst);
+void C_MTXConcat(const Mtx a, const Mtx b, Mtx ab);
+void C_MTXConcatArray(const Mtx a, const Mtx* srcBase, Mtx* dstBase, u32 count);
+void C_MTXTranspose(const Mtx src, Mtx xPose);
+u32 C_MTXInverse(const Mtx src, Mtx inv);
+u32 C_MTXInvXpose(const Mtx src, Mtx invX);
+void C_MTXRotRad(Mtx m, char axis, f32 rad);
+void C_MTXRotTrig(Mtx m, char axis, f32 sinA, f32 cosA);
+void C_MTXRotAxisRad(Mtx m, const Vec* axis, f32 rad);
+void C_MTXTrans(Mtx m, f32 xT, f32 yT, f32 zT);
+void C_MTXTransApply(const Mtx src, Mtx dst, f32 xT, f32 yT, f32 zT);
+void C_MTXScale(Mtx m, f32 xS, f32 yS, f32 zS);
+void C_MTXScaleApply(const Mtx src, Mtx dst, f32 xS, f32 yS, f32 zS);
+void C_MTXQuat(Mtx m, const Quaternion* q);
+void C_MTXReflect(Mtx m, const Vec* p, const Vec* n);
+
+// PS version
+void PSMTXIdentity(Mtx m);
+void PSMTXCopy(const Mtx src, Mtx dst);
+void PSMTXConcat(const Mtx a, const Mtx b, Mtx ab);
+void PSMTXConcatArray(const Mtx a, const Mtx* srcBase, Mtx* dstBase, u32 count);
+void PSMTXTranspose(const Mtx src, Mtx xPose);
+u32 PSMTXInverse(const Mtx src, Mtx inv);
+u32 PSMTXInvXpose(const Mtx src, Mtx invX);
+void PSMTXRotRad(Mtx m, char axis, f32 rad);
+void PSMTXRotTrig(Mtx m, char axis, f32 sinA, f32 cosA);
+void PSMTXRotAxisRad(Mtx m, const Vec* axis, f32 rad);
+void PSMTXTrans(Mtx m, f32 xT, f32 yT, f32 zT);
+void PSMTXTransApply(const Mtx src, Mtx dst, f32 xT, f32 yT, f32 zT);
+void PSMTXScale(Mtx m, f32 xS, f32 yS, f32 zS);
+void PSMTXScaleApply(const Mtx src, Mtx dst, f32 xS, f32 yS, f32 zS);
+void PSMTXQuat(Mtx m, const Quaternion* q);
+void PSMTXReflect(Mtx m, const Vec* p, const Vec* n);
+
+#ifdef DEBUG
+#define MTXIdentity   C_MTXIdentity
+#define MTXCopy       C_MTXCopy
+#define MTXConcat     C_MTXConcat
+#define MTXInverse    C_MTXInverse
+#define MTXTranspose  C_MTXTranspose
+#define MTXInverse    C_MTXInverse
+#define MTXInvXpose   C_MTXInvXpose
+#define MTXRotRad     C_MTXRotRad
+#define MTXRotTrig    C_MTXRotTrig
+#define MTXRotAxisRad C_MTXRotRad
+#define MTXTrans      C_MTXTrans
+#define MTXTransApply C_MTXTransApply
+#define MTXScale      C_MTXScale
+#define MTXScaleApply C_MTXScaleApply
+#define MTXQuat       C_MTXQuat
+#define MTXReflect    C_MTXReflect
+#else
+#define MTXIdentity   PSMTXIdentity
+#define MTXCopy       PSMTXCopy
+#define MTXConcat     PSMTXConcat
+#define MTXInverse    PSMTXInverse
+#define MTXTranspose  PSMTXTranspose
+#define MTXInverse    PSMTXInverse
+#define MTXInvXpose   PSMTXInvXpose
+#define MTXRotRad     PSMTXRotRad
+#define MTXRotTrig    PSMTXRotTrig
+#define MTXRotAxisRad PSMTXRotRad
+#define MTXTrans      PSMTXTrans
+#define MTXTransApply PSMTXTransApply
+#define MTXScale      PSMTXScale
+#define MTXScaleApply PSMTXScaleApply
+#define MTXQuat       PSMTXQuat
+#define MTXReflect    PSMTXReflect
+#endif
+
+// C versions only
+void C_MTXLookAt(Mtx m, const Point3d* camPos, const Vec* camUp, const Point3d* target);
+void C_MTXLightFrustum(Mtx m, f32 t, f32 b, f32 l, f32 r, f32 n, f32 scaleS, f32 scaleT, f32 transS, f32 transT);
+void C_MTXLightPerspective(Mtx m, f32 fovY, f32 aspect, f32 scaleS, f32 scaleT, f32 transS, f32 transT);
+void C_MTXLightOrtho(Mtx m, f32 t, f32 b, f32 l, f32 r, f32 scaleS, f32 scaleT, f32 transS, f32 transT);
+
+#define MTXLookAt           C_MTXLookAt
+#define MTXLightFrustum     C_MTXLightFrustum
+#define MTXLightPerspective C_MTXLightPerspective
+#define MTXLightOrtho       C_MTXLightOrtho
+
+// MTXVEC
+// C versions
+void C_MTXMultVec(const Mtx m, const Vec* src, Vec* dst);
+void C_MTXMultVecArray(const Mtx m, const Vec* srcBase, Vec* dstBase, u32 count);
+void C_MTXMultVecSR(const Mtx m, const Vec* src, Vec* dst);
+void C_MTXMultVecArraySR(const Mtx m, const Vec* srcBase, Vec* dstBase, u32 count);
+
+// PS versions
+void PSMTXMultVec(const Mtx m, const Vec* src, Vec* dst);
+void PSMTXMultVecArray(const Mtx m, const Vec* srcBase, Vec* dstBase, u32 count);
+void PSMTXMultVecSR(const Mtx m, const Vec* src, Vec* dst);
+void PSMTXMultVecArraySR(const Mtx m, const Vec* srcBase, Vec* dstBase, u32 count);
+
+#ifdef DEBUG
+#define MTXMultVec        C_MTXMultVec
+#define MTXMultVecArray   C_MTXMultVecArray
+#define MTXMultVecSR      C_MTXMultVecSR
+#define MTXMultVecArraySR C_MTXMultVecArraySR
+#else
+#define MTXMultVec        PSMTXMultVec
+#define MTXMultVecArray   PSMTXMultVecArray
+#define MTXMultVecSR      PSMTXMultVecSR
+#define MTXMultVecArraySR PSMTXMultVecArraySR
+#endif
+
+// MTX44
+// C versions
+void C_MTX44Identity(Mtx44 m);
+void C_MTX44Copy(const Mtx44 src, Mtx44 dst);
+void C_MTX44Concat(const Mtx44 a, const Mtx44 b, Mtx44 ab);
+void C_MTX44Transpose(const Mtx44 src, Mtx44 xPose);
+void C_MTX44Trans(Mtx44 m, f32 xT, f32 yT, f32 zT);
+void C_MTX44TransApply(const Mtx44 src, Mtx44 dst, f32 xT, f32 yT, f32 zT);
+void C_MTX44Scale(Mtx44 m, f32 xS, f32 yS, f32 zS);
+void C_MTX44ScaleApply(const Mtx44 src, Mtx44 dst, f32 xS, f32 yS, f32 zS);
+void C_MTX44RotRad(Mtx44 m, char axis, f32 rad);
+void C_MTX44RotTrig(Mtx44 m, char axis, f32 sinA, f32 cosA);
+void C_MTX44RotAxisRad(Mtx44 m, const Vec* axis, f32 rad);
+
+// PS versions
+void PSMTX44Identity(Mtx44 m);
+void PSMTX44Copy(const Mtx44 src, Mtx44 dst);
+void PSMTX44Concat(const Mtx44 a, const Mtx44 b, Mtx44 ab);
+void PSMTX44Transpose(const Mtx44 src, Mtx44 xPose);
+void PSMTX44Trans(Mtx44 m, f32 xT, f32 yT, f32 zT);
+void PSMTX44TransApply(const Mtx44 src, Mtx44 dst, f32 xT, f32 yT, f32 zT);
+void PSMTX44Scale(Mtx44 m, f32 xS, f32 yS, f32 zS);
+void PSMTX44ScaleApply(const Mtx44 src, Mtx44 dst, f32 xS, f32 yS, f32 zS);
+void PSMTX44RotRad(Mtx44 m, char axis, f32 rad);
+void PSMTX44RotTrig(Mtx44 m, char axis, f32 sinA, f32 cosA);
+void PSMTX44RotAxisRad(Mtx44 m, const Vec* axis, f32 rad);
+
+#ifdef DEBUG
+#define MTX44Identity   C_MTX44Identity
+#define MTX44Copy       C_MTX44Copy
+#define MTX44Concat     C_MTX44Concat
+#define MTX44Transpose  C_MTX44Transpose
+#define MTX44Trans      C_MTX44Trans
+#define MTX44TransApply C_MTX44TransApply
+#define MTX44Scale      C_MTX44Scale
+#define MTX44ScaleApply C_MTX44ScaleApply
+#define MTX44RotRad     C_MTX44RotRad
+#define MTX44RotTrig    C_MTX44RotTrig
+#define MTX44RotAxisRad C_MTX44RotAxisRad
+#else
+#define MTX44Identity   PSMTX44Identity
+#define MTX44Copy       PSMTX44Copy
+#define MTX44Concat     PSMTX44Concat
+#define MTX44Transpose  PSMTX44Transpose
+#define MTX44Trans      PSMTX44Trans
+#define MTX44TransApply PSMTX44TransApply
+#define MTX44Scale      PSMTX44Scale
+#define MTX44ScaleApply PSMTX44ScaleApply
+#define MTX44RotRad     PSMTX44RotRad
+#define MTX44RotTrig    PSMTX44RotTrig
+#define MTX44RotAxisRad PSMTX44RotAxisRad
+#endif
+
+// C versions only
+void C_MTXFrustum(Mtx44 m, f32 t, f32 b, f32 l, f32 r, f32 n, f32 f);
+void C_MTXPerspective(Mtx44 m, f32 fovY, f32 aspect, f32 n, f32 f);
+void C_MTXOrtho(Mtx44 m, f32 t, f32 b, f32 l, f32 r, f32 n, f32 f);
+u32 C_MTX44Inverse(const Mtx44 src, Mtx44 inv);
+
+#define MTXFrustum     C_MTXFrustum
+#define MTXPerspective C_MTXPerspective
+#define MTXOrtho       C_MTXOrtho
+#define MTX44Inverse   C_MTX44Inverse
+
+// MTX44VEC
+// C versions
+void C_MTX44MultVec(const Mtx44 m, const Vec* src, Vec* dst);
+void C_MTX44MultVecArray(const Mtx44 m, const Vec* srcBase, Vec* dstBase, u32 count);
+void C_MTX44MultVecSR(const Mtx44 m, const Vec* src, Vec* dst);
+void C_MTX44MultVecArraySR(const Mtx44 m, const Vec* srcBase, Vec* dstBase, u32 count);
+
+// PS versions
+void PSMTX44MultVec(const Mtx44 m, const Vec* src, Vec* dst);
+void PSMTX44MultVecArray(const Mtx44 m, const Vec* srcBase, Vec* dstBase, u32 count);
+void PSMTX44MultVecSR(const Mtx44 m, const Vec* src, Vec* dst);
+void PSMTX44MultVecArraySR(const Mtx44 m, const Vec* srcBase, Vec* dstBase, u32 count);
+
+#ifdef DEBUG
+#define MTX44MultVec        C_MTX44MultVec
+#define MTX44MultVecArray   C_MTX44MultVecArray
+#define MTX44MultVecSR      C_MTX44MultVecSR
+#define MTX44MultVecArraySR C_MTX44MultVecArraySR
+#else
+#define MTX44MultVec        PSMTX44MultVec
+#define MTX44MultVecArray   PSMTX44MultVecArray
+#define MTX44MultVecSR      PSMTX44MultVecSR
+#define MTX44MultVecArraySR PSMTX44MultVecArraySR
+#endif
+
+// PSMTX
+void PSMTXReorder(const Mtx src, ROMtx dest);
+void PSMTXROMultVecArray(const ROMtx m, const Vec* srcBase, Vec* dstBase, u32 count);
+void PSMTXROSkin2VecArray(const ROMtx m0, const ROMtx m1, const f32* wtBase, const Vec* srcBase, Vec* dstBase, u32 count);
+void PSMTXROMultS16VecArray(const Mtx m, const S16Vec* srcBase, Vec* dstBase, u32 count);
+void PSMTXMultS16VecArray(const ROMtx* m, const S16Vec* srcBase, Vec* dstBase, u32 count);
+
+// MTXSTACK
+void MTXInitStack(MTXStack* sPtr, u32 numMtx);
+MtxPtr MTXPush(MTXStack* sPtr, const Mtx m);
+MtxPtr MTXPushFwd(MTXStack* sPtr, const Mtx m);
+MtxPtr MTXPushInv(MTXStack* sPtr, const Mtx m);
+MtxPtr MTXPushInvXpose(MTXStack* sPtr, const Mtx m);
+MtxPtr MTXPop(MTXStack* sPtr);
+MtxPtr MTXGetStackPtr(const MTXStack* sPtr);
+
+// VEC
+// C versions
+void C_VECAdd(const Vec* a, const Vec* b, Vec* ab);
+void C_VECSubtract(const Vec* a, const Vec* b, Vec* a_b);
+void C_VECScale(const Vec* src, Vec* dst, f32 scale);
+void C_VECNormalize(const Vec* src, Vec* unit);
+f32 C_VECSquareMag(const Vec* v);
+f32 C_VECMag(const Vec* v);
+f32 C_VECDotProduct(const Vec* a, const Vec* b);
+void C_VECCrossProduct(const Vec* a, const Vec* b, Vec* axb);
+f32 C_VECSquareDistance(const Vec* a, const Vec* b);
+f32 C_VECDistance(const Vec* a, const Vec* b);
+
+// PS versions
+void PSVECAdd(const Vec* a, const Vec* b, Vec* ab);
+void PSVECSubtract(const Vec* a, const Vec* b, Vec* a_b);
+void PSVECScale(const Vec* src, Vec* dst, f32 scale);
+void PSVECNormalize(const Vec* src, Vec* dst);
+f32 PSVECSquareMag(const Vec* v);
+f32 PSVECMag(const Vec* v);
+f32 PSVECDotProduct(const Vec* a, const Vec* b);
+void PSVECCrossProduct(const Vec* a, const Vec* b, Vec* axb);
+f32 PSVECSquareDistance(const Vec* a, const Vec* b);
+f32 PSVECDistance(const Vec* a, const Vec* b);
+
+#ifdef DEBUG
+#define VECAdd            C_VECAdd
+#define VECSubtract       C_VECSubtract
+#define VECScale          C_VECScale
+#define VECNormalize      C_VECNormalize
+#define VECSquareMag      C_VECSquareMag
+#define VECMag            C_VECMag
+#define VECDotProduct     C_VECDotProduct
+#define VECCrossProduct   C_VECCrossProduct
+#define VECSquareDistance C_VECSquareDistance
+#define VECDistance       C_VECDistance
+#else
+#define VECAdd            PSVECAdd
+#define VECSubtract       PSVECSubtract
+#define VECScale          PSVECScale
+#define VECNormalize      PSVECNormalize
+#define VECSquareMag      PSVECSquareMag
+#define VECMag            PSVECMag
+#define VECDotProduct     PSVECDotProduct
+#define VECCrossProduct   PSVECCrossProduct
+#define VECSquareDistance PSVECSquareDistance
+#define VECDistance       PSVECDistance
+#endif
+
+void C_VECHalfAngle(const Vec* a, const Vec* b, Vec* half);
+void C_VECReflect(const Vec* src, const Vec* normal, Vec* dst);
+
+#define VECHalfAngle C_VECHalfAngle
+#define VECReflect   C_VECReflect
+
+// QUAT
+// C versions
+void C_QUATAdd(const Quaternion* p, const Quaternion* q, Quaternion* r);
+void C_QUATSubtract(const Quaternion* p, const Quaternion* q, Quaternion* r);
+void C_QUATMultiply(const Quaternion* p, const Quaternion* q, Quaternion* pq);
+void C_QUATScale(const Quaternion* q, Quaternion* r, f32 scale);
+f32 C_QUATDotProduct(const Quaternion* p, const Quaternion* q);
+void C_QUATNormalize(const Quaternion* src, Quaternion* unit);
+void C_QUATInverse(const Quaternion* src, Quaternion* inv);
+void C_QUATDivide(const Quaternion* p, const Quaternion* q, Quaternion* r);
+
+// PS versions
+void PSQUATAdd(const Quaternion* p, const Quaternion* q, Quaternion* r);
+void PSQUATSubtract(const Quaternion* p, const Quaternion* q, Quaternion* r);
+void PSQUATMultiply(const Quaternion* p, const Quaternion* q, Quaternion* pq);
+void PSQUATScale(const Quaternion* q, Quaternion* r, f32 scale);
+f32 PSQUATDotProduct(const Quaternion* p, const Quaternion* q);
+void PSQUATNormalize(const Quaternion* src, Quaternion* unit);
+void PSQUATInverse(const Quaternion* src, Quaternion* inv);
+void PSQUATDivide(const Quaternion* p, const Quaternion* q, Quaternion* r);
+
+#ifdef DEBUG
+#define QUATAdd        C_QUATAdd
+#define QUATSubtract   C_QUATSubtract
+#define QUATMultiply   C_QUATMultiply
+#define QUATScale      C_QUATScale
+#define QUATDotProduct C_QUATDotProduct
+#define QUATNormalize  C_QUATNormalize
+#define QUATInverse    C_QUATInverse
+#define QUATDivide     C_QUATDivide
+#else
+#define QUATAdd        PSQUATAdd
+#define QUATSubtract   PSQUATSubtract
+#define QUATMultiply   PSQUATMultiply
+#define QUATScale      PSQUATScale
+#define QUATDotProduct PSQUATDotProduct
+#define QUATNormalize  PSQUATNormalize
+#define QUATInverse    PSQUATInverse
+#define QUATDivide     PSQUATDivide
+#endif
+
+// C versions only
+void C_QUATExp(const Quaternion* q, Quaternion* r);
+void C_QUATLogN(const Quaternion* q, Quaternion* r);
+void C_QUATMakeClosest(const Quaternion* q, const Quaternion* qto, Quaternion* r);
+void C_QUATRotAxisRad(Quaternion* r, const Vec* axis, f32 rad);
+void C_QUATMtx(Quaternion* r, const Mtx m);
+void C_QUATLerp(const Quaternion* p, const Quaternion* q, Quaternion* r, f32 t);
+void C_QUATSlerp(const Quaternion* p, const Quaternion* q, Quaternion* r, f32 t);
+void C_QUATSquad(const Quaternion* p, const Quaternion* a, const Quaternion* b, const Quaternion* q, Quaternion* r, f32 t);
+void C_QUATCompA(const Quaternion* qprev, const Quaternion* q, const Quaternion* qnext, Quaternion* a);
+
+#define QUATExp         C_QUATExp
+#define QUATLogN        C_QUATLogN
+#define QUATMakeClosest C_QUATMakeClosest
+#define QUATRotAxisRad  C_QUATRotAxisRad
+#define QUATMtx         C_QUATMtx
+#define QUATLerp        C_QUATLerp
+#define QUATSlerp       C_QUATSlerp
+#define QUATSquad       C_QUATSquad
+#define QUATCompA       C_QUATCompA
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/dolphin/dolphin/vi.h
+++ b/include/dolphin/dolphin/vi.h
@@ -1,0 +1,7 @@
+#ifndef _DOLPHIN_VI_H_
+#define _DOLPHIN_VI_H_
+
+#include <dolphin/vi/vifuncs.h>
+#include <dolphin/vi/vitypes.h>
+
+#endif

--- a/include/dolphin/dolphin/vi/vifuncs.h
+++ b/include/dolphin/dolphin/vi/vifuncs.h
@@ -1,0 +1,35 @@
+#ifndef _DOLPHIN_VIFUNCS_H_
+#define _DOLPHIN_VIFUNCS_H_
+
+#include <dolphin/vi/vitypes.h>
+#include <dolphin/gx/GXStruct.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+VIRetraceCallback VISetPreRetraceCallback(VIRetraceCallback cb);
+VIRetraceCallback VISetPostRetraceCallback(VIRetraceCallback cb);
+void VIInit(void);
+void VIWaitForRetrace(void);
+void VIConfigure(const GXRenderModeObj* rm);
+void VIConfigurePan(u16 xOrg, u16 yOrg, u16 width, u16 height);
+void VIFlush(void);
+void VISetNextFrameBuffer(void* fb);
+void VISetNextRightFrameBuffer(void* fb);
+void VISetBlack(BOOL black);
+void VISet3D(BOOL threeD);
+u32 VIGetRetraceCount(void);
+u32 VIGetNextField(void);
+u32 VIGetCurrentLine(void);
+u32 VIGetTvFormat(void);
+void* VIGetNextFrameBuffer(void);
+void* VIGetCurrentFrameBuffer(void);
+u32 VIGetScanMode(void);
+u32 VIGetDTVStatus(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/dolphin/dolphin/vi/vitypes.h
+++ b/include/dolphin/dolphin/vi/vitypes.h
@@ -1,0 +1,39 @@
+#ifndef _DOLPHIN_VITYPES_H_
+#define _DOLPHIN_VITYPES_H_
+
+#define VI_TVMODE(format, interlace)  (((format) << 2) + (interlace))
+
+#define VI_INTERLACE     0
+#define VI_NON_INTERLACE 1
+#define VI_PROGRESSIVE   2
+
+#define VI_NTSC      0
+#define VI_PAL       1
+#define VI_MPAL      2
+#define VI_DEBUG     3
+#define VI_DEBUG_PAL 4
+#define VI_EURGB60   5
+
+typedef enum {
+    VI_TVMODE_NTSC_INT      = VI_TVMODE(VI_NTSC,        VI_INTERLACE),
+    VI_TVMODE_NTSC_DS       = VI_TVMODE(VI_NTSC,        VI_NON_INTERLACE),
+    VI_TVMODE_NTSC_PROG     = VI_TVMODE(VI_NTSC,        VI_PROGRESSIVE),
+    VI_TVMODE_PAL_INT       = VI_TVMODE(VI_PAL,         VI_INTERLACE),
+    VI_TVMODE_PAL_DS        = VI_TVMODE(VI_PAL,         VI_NON_INTERLACE),
+    VI_TVMODE_EURGB60_INT   = VI_TVMODE(VI_EURGB60,     VI_INTERLACE),
+    VI_TVMODE_EURGB60_DS    = VI_TVMODE(VI_EURGB60,     VI_NON_INTERLACE),
+    VI_TVMODE_MPAL_INT      = VI_TVMODE(VI_MPAL,        VI_INTERLACE),
+    VI_TVMODE_MPAL_DS       = VI_TVMODE(VI_MPAL,        VI_NON_INTERLACE),
+    VI_TVMODE_DEBUG_INT     = VI_TVMODE(VI_DEBUG,       VI_INTERLACE),
+    VI_TVMODE_DEBUG_PAL_INT = VI_TVMODE(VI_DEBUG_PAL,   VI_INTERLACE),
+    VI_TVMODE_DEBUG_PAL_DS  = VI_TVMODE(VI_DEBUG_PAL,   VI_NON_INTERLACE)
+} VITVMode;
+
+typedef enum {
+    VI_XFBMODE_SF = 0,
+    VI_XFBMODE_DF
+} VIXFBMode;
+
+typedef void (*VIRetraceCallback)(u32 retraceCount);
+
+#endif

--- a/include/inline/fastmath.h
+++ b/include/inline/fastmath.h
@@ -17,18 +17,13 @@
 #define W2_XY fp12
 #define W2_Z fp13
 
-typedef struct
-{
-    F32 x, y, z;
-} Vec;
-
 // All this essentially does is do "*dst = *src;"
 #define PSVECCopy(dst, src)                                                                        \
     asm {\
 		psq_l fp0, 0(src), 0, 0; /* Load src->x and src->y into fp0. */ \
 		psq_l fp1, 8(src), 1, 0; /* Load src->z only into fp1. */ \
 		psq_st fp0, 0(dst), 0, 0; /* Store fp0 into dst->x and dst->y. */ \
-		psq_st fp1, 8(dst), 1, 0; /* Store only the first half of fp1 into dst->z. */              \
+		psq_st fp1, 8(dst), 1, 0; /* Store only the first half of fp1 into dst->z. */                  \
     }
 
 // I can't figure out how to get this as a C-style inline function, so use this in an ASM function or block.

--- a/src/SB/Core/gc/iFMV.cpp
+++ b/src/SB/Core/gc/iFMV.cpp
@@ -12,11 +12,7 @@
 #include "zGlobals.h"
 
 #include <types.h>
-// #include <dolphin.h>
-#include <dolphin/gx.h>
-#include <dolphin/ar.h>
-#include <dolphin/mtx.h>
-#include <dolphin/vi.h>
+#include <dolphin.h>
 
 // FIXME: These should be in a RW header somewhere
 extern GXRenderModeObj* _RwDlRenderMode;
@@ -189,7 +185,7 @@ static void* arammalloc(size_t size)
 // Something weird is going on here...
 static void aramfree(void* mem)
 {
-    void* vol;
+    u32 vol;
     ARFree(&vol);
 }
 

--- a/src/SB/Core/gc/iFMV.cpp
+++ b/src/SB/Core/gc/iFMV.cpp
@@ -1,12 +1,50 @@
 #include "iFMV.h"
 
+#include "iCamera.h"
+#include "iFile.h"
+#include "iPad.h"
+#include "iSystem.h"
+#include "iTRC.h"
+
+#include "xFile.h"
 #include "xPar.h"
 
-#include <types.h>
-#include <dolphin.h>
+#include "zGlobals.h"
 
-extern U32 Bink_surface_type[5];
-extern volatile U32 frame_num;
+#include <types.h>
+// #include <dolphin.h>
+#include <dolphin/gx.h>
+#include <dolphin/ar.h>
+#include <dolphin/mtx.h>
+#include <dolphin/vi.h>
+
+// FIXME: These should be in a RW header somewhere
+extern GXRenderModeObj* _RwDlRenderMode;
+extern "C" {
+void RwGameCubeGetXFBs(void*, void*);
+}
+
+// .bss
+static U32 Bink_surface_type[5];
+
+// .sbss
+static S32 frame_num;
+U32 fuckingSurfaceType;
+static HBINK Bink;
+static HRAD3DIMAGE Image;
+static S32 Paused;
+static void* pixels;
+static volatile F32 vol;
+S32 ip;
+s32 oof;
+void* iFMV::mXFBs[2];
+void* iFMV::mCurrentFrameBuffer;
+GXRenderModeObj* iFMV::mRenderMode;
+
+// .sdata
+static float Width_scale = 1.0f;
+static float Height_scale = 1.0f;
+U8 iFMV::mFirstFrame = 1;
 
 void* iFMVmalloc(size_t size)
 {
@@ -18,21 +56,20 @@ void iFMVfree(void* mem)
     RwFree(mem);
 }
 
+static void PlayFMV(char* filename, size_t buttons, F32 time);
 U32 iFMVPlay(char* filename, U32 buttons, F32 time, bool skippable, bool lockController)
 {
     if (filename == NULL)
     {
         return 1;
     }
-    else
+
+    frame_num = 0;
+    while (frame_num >= 0)
     {
-        frame_num = 0;
-        while ((S32)frame_num >= 0)
-        {
-            PlayFMV(filename, buttons, time);
-        }
-        return 0;
+        PlayFMV(filename, buttons, time);
     }
+    return 0;
 }
 
 static void Setup_surface_array()
@@ -44,24 +81,109 @@ static void Setup_surface_array()
     Bink_surface_type[4] = BINKSURFACEYUY2;
 }
 
-#if 0
 // WIP.
-void Decompress_frame(HBINK bnk, HRAD3DIMAGE rad_image, S64 flags)
+void Decompress_frame(HBINK bnk, HRAD3DIMAGE rad_image, long flags)
 {
-    BinkDoFrame(bnk);
-    S32 code = Lock_RAD_3D_image(rad_image, dfgdfgdfgdfg);
-    if (code != 0)
+    struct Result
     {
-        BinkCopyToBuffer(wefwefewfew);
+        S32 unk_0;
+        S32 unk_4;
+        U32 unk_8;
+        U32 unk_c;
+    };
+    Result result;
+    result.unk_4 = BinkDoFrame(bnk);
+    if (Lock_RAD_3D_image(rad_image, &pixels, &result.unk_c, &result.unk_8) != 0)
+    {
+        S32 mask = flags * -1;
+        mask = mask | flags;
+        mask = mask >> 0x1f;
+        mask = mask & 0x80000000;
+        mask |= Bink_surface_type[result.unk_8];
+        result.unk_0 = BinkCopyToBuffer(bnk, pixels, result.unk_c, bnk->unk_4, NULL, NULL, mask);
         Unlock_RAD_3D_image(rad_image);
     }
 }
 
-#endif
-
-void arammalloc(size_t size)
+static void DrawFrame(float arg0, float arg1, float arg2, float arg3)
 {
-    ARAlloc(size);
+    GXRenderModeObj* rm = _RwDlRenderMode;
+    Mtx idt;
+    Mtx44 mtx;
+
+    GXSetViewport(0.0f, 0.0f, rm->fbWidth, rm->efbHeight, 0.0f, 1.0f);
+    GXSetScissor(0, 0, rm->fbWidth, rm->efbHeight);
+    GXSetDispCopySrc(0, 0, rm->fbWidth, rm->efbHeight);
+    GXSetDispCopyDst(rm->fbWidth, rm->xfbHeight);
+    GXSetDispCopyYScale((float)rm->xfbHeight / rm->efbHeight);
+    GXSetCopyFilter(rm->aa, rm->sample_pattern, GX_TRUE, rm->vfilter);
+
+    if (rm->aa)
+    {
+        GXSetPixelFmt(GX_PF_RGB565_Z16, GX_ZC_LINEAR);
+    }
+    else
+    {
+        GXSetPixelFmt(GX_PF_RGB8_Z24, GX_ZC_LINEAR);
+    }
+
+    GXSetDispCopyGamma(GX_GM_1_0);
+    C_MTXOrtho(mtx, 0.0f, 480.0f, 0.0f, 640.0f, 0.0f, 10000.0f);
+    GXSetProjection(mtx, GX_ORTHOGRAPHIC);
+    PSMTXIdentity(idt);
+    GXLoadPosMtxImm(idt, 0);
+
+    GXClearVtxDesc();
+    GXSetVtxDesc(GX_VA_POS, GX_DIRECT);
+    GXSetVtxDesc(GX_VA_CLR0, GX_DIRECT);
+    GXSetVtxDesc(GX_VA_TEX0, GX_DIRECT);
+    GXSetVtxAttrFmt(GX_VTXFMT0, GX_VA_POS, GX_NRM_NBT, GX_S16, 0);
+    GXSetVtxAttrFmt(GX_VTXFMT0, GX_VA_CLR0, GX_NRM_NBT, GX_RGBA8, 0);
+    GXSetVtxAttrFmt(GX_VTXFMT0, GX_VA_TEX0, GX_NRM_NBT, GX_RGBA6, 0);
+
+    GXSetNumTexGens(1);
+    GXSetNumChans(1);
+    GXSetNumTevStages(1);
+    GXSetTexCoordGen(GX_TEXCOORD0, GX_TG_MTX2x4, GX_TG_TEX0, 0x3c);
+    GXSetTevOp(GX_TEVSTAGE0, GX_MODULATE);
+    GXSetTevOrder(GX_TEVSTAGE0, GX_TEXCOORD0, GX_TEXMAP0, GX_COLOR0A0);
+
+    if (rm->field_rendering)
+    {
+        u32 field = VIGetNextField();
+        GXSetViewportJitter(0.0f, 0.0f, rm->fbWidth, rm->efbHeight, 0.0f, 1.0f, field);
+    }
+    else
+    {
+        GXSetViewport(0.0f, 0.0f, rm->fbWidth, rm->efbHeight, 0.0f, 1.0f);
+    }
+
+    GXInvalidateVtxCache();
+    GXInvalidateTexAll();
+    Blit_RAD_3D_image(Image, arg0, arg1, arg2, arg3, 1.0f);
+}
+
+static void xDrawLine2D_LocaliFMVVersion(float, float, float, float);
+static void Show_frame()
+{
+    RwRGBA color = { 0 };
+    RwCamera* cam = iCameraCreate(640, 480, FALSE);
+    RwCameraClear(cam, &color, rwCAMERACLEARIMAGE);
+
+    RwCameraBeginUpdate(cam);
+    Width_scale = 640 / Bink->unk_0;
+    Height_scale = 480 / Bink->unk_4;
+    xDrawLine2D_LocaliFMVVersion(0.0f, 0.0f, 0.0f, 0.0f);
+    DrawFrame(0.0f, 0.0f, Width_scale, Height_scale);
+    RwCameraEndUpdate(cam);
+    RwCameraShowRaster(cam, NULL, 0);
+
+    iCameraDestroy(cam);
+}
+
+static void* arammalloc(size_t size)
+{
+    return (void*)ARAlloc(size);
 }
 
 // Something weird is going on here...
@@ -71,21 +193,197 @@ static void aramfree(void* mem)
     ARFree(&vol);
 }
 
-#if 0
-// WIP.
+static void PlayFMV(char* fname, u32 buttons, F32 time)
+{
+    GXCullMode cull_mode;
+    GXGetCullMode(&cull_mode);
+    iFMV::InitDisplay(_RwDlRenderMode);
+    iPadStopRumble(globals.pad0);
+    RADSetAudioMemory(arammalloc, aramfree);
+    RADSetMemory(iFMVmalloc, iFMVfree);
+    Setup_surface_array();
+
+    for (char* c = fname; *c != NULL; c++)
+    {
+        if (*c == '\\')
+        {
+            *c = '/';
+        }
+    }
+
+    tag_xFile file;
+    DVDFileInfo* pfinfo = &file.ps.fileInfo;
+    do
+    {
+        if (iTRCDisk::IsDiskIDed())
+        {
+            Bink = BinkOpen(fname, NULL);
+            if (Bink == NULL)
+            {
+                BinkGetError();
+            }
+        }
+        if (iTRCDisk::CheckDVDAndResetState() != 0)
+        {
+            break;
+        }
+        if (Bink == NULL)
+        {
+            iFileOpen(fname, 0, &file);
+            DVDSeekAsyncPrio(pfinfo, 0, NULL, 2);
+            if (iTRCDisk::CheckDVDAndResetState())
+            {
+                DVDCancel(&pfinfo->cb);
+                break;
+            }
+            else
+            {
+                DVDCancel(&pfinfo->cb);
+            }
+        }
+    } while (Bink == NULL);
+
+    if (Bink != NULL)
+    {
+        if (Bink->unk_f0 != 0)
+        {
+            for (ip = 0; ip <= Bink->unk_f0; ++ip)
+            {
+                vol = gSnd.categoryVolFader[SND_CAT_CUTSCENE];
+                vol = vol * vol;
+                vol = vol * 32768.0f;
+                BinkSetVolume(Bink, ip, vol);
+            }
+        }
+
+        Image = Open_RAD_3D_image(NULL, Bink->unk_0, Bink->unk_4, fuckingSurfaceType);
+        if (Image != NULL)
+        {
+            if (frame_num != 0)
+            {
+                BinkGoto(Bink, frame_num, 0);
+            }
+            oof = 0;
+
+            do
+            {
+                if (iTRCDisk::CheckDVDAndResetState())
+                {
+                    goto superbreak;
+                }
+                if (BinkWait(Bink) == 0)
+                {
+                    Decompress_frame(Bink, Image, 1);
+                    Show_frame();
+                    BinkNextFrame(Bink);
+                }
+                else if (Paused)
+                {
+                    Show_frame();
+                }
+                xPadUpdate(globals.currentActivePad, 0.0f);
+
+                F32 t = (float)Bink->unk_c / (Bink->unk_14 / Bink->unk_18);
+                if (buttons && t >= time && globals.pad0->pressed & buttons)
+                {
+                    frame_num = -1;
+                    goto superbreak;
+                }
+            } while (Bink->unk_c < Bink->unk_8 - 1);
+            frame_num = -1;
+        }
+    superbreak:
+        if (frame_num != -1)
+        {
+            frame_num = Bink->unk_c;
+        }
+        Close_RAD_3D_image(Image);
+        Image = NULL;
+        BinkClose(Bink);
+        Bink = NULL;
+    }
+
+    GXSetCullMode(cull_mode);
+    iVSync();
+    xPadUpdate(globals.currentActivePad, 0.0f);
+}
+
+void iFMV::InitDisplay(GXRenderModeObj* InRenderMode)
+{
+    GXColor clr = { 0 };
+    Mtx44 mtx;
+    Mtx idt;
+    mRenderMode = InRenderMode;
+    void** xfb = &mXFBs[1];
+    RwGameCubeGetXFBs(&mXFBs[0], &mXFBs[1]);
+    mCurrentFrameBuffer = *xfb;
+
+    InitGX();
+    InitVI();
+
+    GXSetCopyClear(clr, GX_MAX_Z24);
+    C_MTXOrtho(mtx, 0.0f, mRenderMode->efbHeight, 0.0f, mRenderMode->fbWidth, 0.0f, -100.0f);
+    GXSetProjection(mtx, GX_ORTHOGRAPHIC);
+    PSMTXIdentity(idt);
+    GXLoadPosMtxImm(idt, 0);
+    GXSetCurrentMtx(0);
+
+    GXSetZMode(GX_TRUE, GX_ALWAYS, GX_TRUE);
+    GXSetBlendMode(GX_BM_BLEND, GX_BL_ONE, GX_BL_ONE, GX_LO_CLEAR);
+
+    GXClearVtxDesc();
+    GXSetVtxDesc(GX_VA_POS, GX_DIRECT);
+    GXSetVtxDesc(GX_VA_CLR0, GX_DIRECT);
+    GXSetVtxDesc(GX_VA_TEX0, GX_DIRECT);
+    GXSetVtxAttrFmt(GX_VTXFMT0, GX_VA_POS, GX_NRM_NBT, GX_S16, 0);
+    GXSetVtxAttrFmt(GX_VTXFMT0, GX_VA_CLR0, GX_NRM_NBT, GX_RGBA8, 0);
+    GXSetVtxAttrFmt(GX_VTXFMT0, GX_VA_TEX0, GX_NRM_NBT, GX_RGBA6, 0);
+
+    GXSetNumTexGens(1);
+    GXSetNumChans(1);
+    GXSetNumTevStages(1);
+    GXSetTexCoordGen(GX_TEXCOORD0, GX_TG_MTX2x4, GX_TG_TEX0, 0x3c);
+    GXSetTevOp(GX_TEVSTAGE0, GX_MODULATE);
+    GXSetTevOrder(GX_TEVSTAGE0, GX_TEXCOORD0, GX_TEXMAP0, GX_COLOR0A0);
+    mFirstFrame = 1;
+}
+
+void iFMV::InitGX()
+{
+    GXSetViewport(0, 0, mRenderMode->fbWidth, mRenderMode->efbHeight, 0.0f, 1.0f);
+    GXSetScissor(0, 0, mRenderMode->fbWidth, mRenderMode->efbHeight);
+    f32 yScaleFactor = GXGetYScaleFactor(mRenderMode->efbHeight, mRenderMode->xfbHeight);
+    u16 r = GXSetDispCopyYScale(yScaleFactor);
+
+    GXSetDispCopySrc(0, 0, mRenderMode->fbWidth, mRenderMode->efbHeight);
+    GXSetDispCopyDst(mRenderMode->fbWidth, r);
+    GXSetCopyFilter(mRenderMode->aa, mRenderMode->sample_pattern, GX_TRUE, mRenderMode->vfilter);
+
+    if (mRenderMode->aa)
+    {
+        GXSetPixelFmt(GX_PF_RGB565_Z16, GX_ZC_LINEAR);
+    }
+    else
+    {
+        GXSetPixelFmt(GX_PF_RGB8_Z24, GX_ZC_LINEAR);
+    }
+
+    GXCopyDisp(mCurrentFrameBuffer, GX_TRUE);
+    GXSetDispCopyGamma(GX_GM_1_0);
+    GXSetCullMode(GX_CULL_NONE);
+}
+
 void iFMV::InitVI()
 {
-    VISetNextFrameBuffer(FWFWEFEWFWEF);
-    EWDEWDEWDEWD = WEDEDWEWDE;
+    VISetNextFrameBuffer(iFMV::mXFBs[0]);
+    mCurrentFrameBuffer = mXFBs[1];
     VIFlush();
     VIWaitForRetrace();
-    if (*WEFWEFEWEF & 1)
+    if (mRenderMode->viTVmode & 1)
     {
         VIWaitForRetrace();
     }
 }
-
-#endif
 
 void iFMV::Suspend()
 {
@@ -93,4 +391,36 @@ void iFMV::Suspend()
 
 void iFMV::Resume()
 {
+}
+
+static void xDrawLine2D_LocaliFMVVersion(F32 arg0, F32 arg1, F32 arg2, F32 arg3)
+{
+    RwRGBA color = { -1, -1, -1, -1 };
+
+    F32 nearz = RwIm2DGetNearScreenZ();
+    void* texraster_state;
+    RwRenderStateGet(rwRENDERSTATETEXTURERASTER, &texraster_state);
+    void* vtx_alpha_state;
+    RwRenderStateGet(rwRENDERSTATEVERTEXALPHAENABLE, &vtx_alpha_state);
+    RwIm2DVertex verts[2];
+
+    // RwIm2DVertexSetRealRGBA
+
+    RwIm2DVertexSetScreenX(&verts[0], arg0);
+    RwIm2DVertexSetScreenY(&verts[0], arg1);
+    RwIm2DVertexSetScreenZ(&verts[0], nearz);
+    RwIm2DVertexSetIntRGBA(&verts[0], color.red, color.green, color.blue, color.alpha);
+
+    RwIm2DVertexSetScreenX(&verts[1], arg2);
+    RwIm2DVertexSetScreenY(&verts[1], arg3);
+    RwIm2DVertexSetScreenZ(&verts[1], nearz);
+    RwIm2DVertexSetIntRGBA(&verts[1], color.red, color.green, color.blue, color.alpha);
+
+    RwRenderStateSet(rwRENDERSTATETEXTURERASTER, NULL);
+    RwRenderStateSet(rwRENDERSTATEVERTEXALPHAENABLE, NULL);
+
+    // { arg2, arg3, nearz, -1 };
+    RwIm2DRenderLine(verts, 2, 0, 1);
+    RwRenderStateSet(rwRENDERSTATETEXTURERASTER, texraster_state);
+    RwRenderStateSet(rwRENDERSTATEVERTEXALPHAENABLE, vtx_alpha_state);
 }

--- a/src/SB/Core/gc/iFMV.h
+++ b/src/SB/Core/gc/iFMV.h
@@ -2,20 +2,19 @@
 #define IFMV_H
 
 #include <types.h>
-#include <rwcore.h>
 #include <bink.h>
+#include <size_t.h>
 
-#include <dolphin/gx/GXEnum.h>
-#include <dolphin/gx/GXStruct.h>
+struct _GXRenderModeObj;
 
 struct iFMV
 {
     static void* mXFBs[2];
     static void* mCurrentFrameBuffer;
-    static GXRenderModeObj* mRenderMode; 
+    static _GXRenderModeObj* mRenderMode;
     static U8 mFirstFrame;
 
-    static void InitDisplay(GXRenderModeObj*);
+    static void InitDisplay(_GXRenderModeObj*);
     static void InitGX();
     static void InitVI();
     static void Suspend();

--- a/src/SB/Core/gc/iFMV.h
+++ b/src/SB/Core/gc/iFMV.h
@@ -5,21 +5,26 @@
 #include <rwcore.h>
 #include <bink.h>
 
+#include <dolphin/gx/GXEnum.h>
+#include <dolphin/gx/GXStruct.h>
+
 struct iFMV
 {
-    void InitVI();
-    void Suspend();
-    void Resume();
+    static void* mXFBs[2];
+    static void* mCurrentFrameBuffer;
+    static GXRenderModeObj* mRenderMode; 
+    static U8 mFirstFrame;
+
+    static void InitDisplay(GXRenderModeObj*);
+    static void InitGX();
+    static void InitVI();
+    static void Suspend();
+    static void Resume();
 };
 
 void* iFMVmalloc(size_t size);
 void iFMVfree(void* mem);
 U32 iFMVPlay(char* filename, U32 buttons, F32 time, bool skippable, bool lockController);
 static void Setup_surface_array();
-void Decompress_frame(HBINK bnk, HRAD3DIMAGE rad_image, S64 flags);
-
-void arammalloc(size_t size);
-static void aramfree(void* mem);
-void PlayFMV(char* filename, size_t buttons, F32 time);
-
+void Decompress_frame(HBINK bnk, HRAD3DIMAGE rad_image, long flags);
 #endif

--- a/src/SB/Core/gc/iTRC.h
+++ b/src/SB/Core/gc/iTRC.h
@@ -1,6 +1,8 @@
 #ifndef ITRC_H
 #define ITRC_H
 
+#include <types.h>
+
 #include "xPad.h"
 
 struct _tagiTRCPadInfo
@@ -11,8 +13,9 @@ struct _tagiTRCPadInfo
 // Yes, this is a namespace, not a class.
 namespace iTRCDisk
 {
-    void CheckDVDAndResetState();
+    bool CheckDVDAndResetState();
     void Init();
+    bool IsDiskIDed();
 } // namespace iTRCDisk
 
 namespace ResetButton


### PR DESCRIPTION
Partially adds doldecomp/dolsdk2004 headers suggested in #409 

The added dolphin headers were modified to fit our monolithic dolphin.h setup (removed `#include <dolphin/types.h>` and some other minor modifications). They are now meant only to be included transitively by `dolphin.h` and they likely won't work correctly if included individually.