### PR TITLE
Revert '!' back to hex (0x21d)

### DIFF
--- a/src/SB/Core/gc/iSystem.cpp
+++ b/src/SB/Core/gc/iSystem.cpp
@@ -108,7 +108,7 @@ void iSystemExit()
     OSPanic
     (
         "iSystem.cpp",
-        '!',
+        0x21d,
         "(With apologies to Jim Morrison) This the end, my only friend, The End."
     );
 }


### PR DESCRIPTION
Turns out not everything that's hex and *can* be converted to a char, *should*. 0x21 is !, 0x21d is nonsense. Also that argument is called "line" and it's an int, so i was just being dumb thinking this could be converted like the other one that was "HUB2" in hex.

My bad.

I do wonder: How did this `OK` when that was clearly wrong?