### PR TITLE
Restore Partial/Nearly Complete Matches Projectwide

### DIFF
--- a/src/SB/Core/gc/iAnimSKB.cpp
+++ b/src/SB/Core/gc/iAnimSKB.cpp
@@ -5,7 +5,6 @@
 
 #include <limits.h>
 
-#ifdef NON_MATCHING
 void iAnimEvalSKB(iAnimSKBHeader* data, F32 time, U32 flags, xVec3* tran, xQuat* quat)
 {
     U32 i, tidx, bcount, tcount;
@@ -126,7 +125,6 @@ void iAnimEvalSKB(iAnimSKBHeader* data, F32 time, U32 flags, xVec3* tran, xQuat*
         }
     }
 }
-#endif
 
 F32 iAnimDurationSKB(iAnimSKBHeader* data)
 {

--- a/src/SB/Core/gc/iMath3.cpp
+++ b/src/SB/Core/gc/iMath3.cpp
@@ -477,8 +477,7 @@ static U32 ClipPlane(F32 denom, F32 numer, F32* t_in, F32* t_out)
     return (numer <= _557_1);
 }
 
-static U32 ClipBox(const xVec3* r3, const xVec3* r4, const xVec3* r5, F32* t_in,
-                      F32* t_out)
+static U32 ClipBox(const xVec3* r3, const xVec3* r4, const xVec3* r5, F32* t_in, F32* t_out)
 {
     return (ClipPlane(r5->x, -r4->x - r3->x, t_in, t_out) &&
             ClipPlane(-r5->x, r4->x - r3->x, t_in, t_out) &&
@@ -488,7 +487,6 @@ static U32 ClipBox(const xVec3* r3, const xVec3* r4, const xVec3* r5, F32* t_in,
             ClipPlane(-r5->z, r4->z - r3->z, t_in, t_out));
 }
 
-#ifdef NON_MATCHING
 void iBoxIsectRay(const xBox* b, const xRay3* r, xIsect* isx)
 {
     xVec3 var_14, var_20;
@@ -569,9 +567,7 @@ void iBoxIsectRay(const xBox* b, const xRay3* r, xIsect* isx)
         isx->contained = _558_3;
     }
 }
-#endif
 
-#ifdef NON_MATCHING
 void iBoxIsectSphere(const xBox* box, const xSphere* p, xIsect* isx)
 {
     U32 xcode, ycode, zcode;
@@ -722,7 +718,6 @@ void iBoxIsectSphere(const xBox* box, const xSphere* p, xIsect* isx)
         isx->contained = _558_3;
     }
 }
-#endif
 
 void iBoxInitBoundVec(xBox* b, const xVec3* v)
 {

--- a/src/SB/Core/gc/iMemMgr.cpp
+++ b/src/SB/Core/gc/iMemMgr.cpp
@@ -15,7 +15,6 @@ extern U32 HeapSize;
 extern U32 mem_top_alloc;
 extern U32 mem_base_alloc;
 
-#if 0
 // Starts going wrong after the if and else statement, everything else before looks fine.
 void iMemInit()
 {
@@ -39,7 +38,7 @@ void iMemInit()
     gMemInfo.stack.size = 0xffff8000;
     gMemInfo.stack.flags = gMemInfo.DRAM.flags = 0x820;
     HeapSize = 0x384000;
-    gMemInfo.DRAM.addr = (U32)OSAllocFromHeap((void*)__OSCurrHeap, 0x384000);
+    gMemInfo.DRAM.addr = (U32)OSAllocFromHeap(__OSCurrHeap, 0x384000);
     gMemInfo.DRAM.size = HeapSize;
     gMemInfo.DRAM.flags = 0x820;
     gMemInfo.SRAM.addr = 0;
@@ -48,7 +47,6 @@ void iMemInit()
     mem_top_alloc = gMemInfo.DRAM.addr + HeapSize;
     mem_base_alloc = gMemInfo.DRAM.addr;
 }
-#endif
 
 void iMemExit()
 {

--- a/src/SB/Core/gc/iScrFX.cpp
+++ b/src/SB/Core/gc/iScrFX.cpp
@@ -43,7 +43,6 @@ void iCameraMotionBlurActivate(U32 activate)
     sMotionBlurEnabled = activate;
 }
 
-#if 0
 // The instructions regarding the setting of sMotionBlurEnabled and sMBD.motionBlurAlpha are in the wrong order.
 void iCameraSetBlurriness(F32 amount)
 {
@@ -62,9 +61,6 @@ void iCameraSetBlurriness(F32 amount)
     }
 }
 
-#endif
-
-#if 0
 // Instructions in the wrong order.
 void iScrFxCameraCreated(RwCamera* pCamera)
 {
@@ -78,8 +74,6 @@ void iScrFxCameraCreated(RwCamera* pCamera)
     sMBD.index[5] = 3;
     iScrFxMotionBlurOpen(pCamera);
 }
-
-#endif
 
 void iScrFxCameraEndScene(RwCamera* pCamera)
 {
@@ -116,7 +110,6 @@ S32 iScrFxCameraDestroyed(RwCamera* pCamera)
     return 0;
 }
 
-#if 0
 // WIP.
 void iScrFxMotionBlurRender(RwCamera* camera, U32 col)
 {
@@ -127,8 +120,6 @@ void iScrFxMotionBlurRender(RwCamera* camera, U32 col)
         iCameraOverlayRender(camera, (RwRaster*)sMBD.motionBlurFrontBuffer, col);
     }
 }
-
-#endif
 
 void GCMB_MakeFrameBufferCopy(const RwCamera* camera)
 {

--- a/src/SB/Core/gc/iSnd.cpp
+++ b/src/SB/Core/gc/iSnd.cpp
@@ -107,7 +107,6 @@ void iSndStereo(U32 i)
     }
 }
 
-#ifdef NON_MATCHING
 void iSndWaitForDeadSounds()
 {
     fc = 0;
@@ -121,7 +120,6 @@ void iSndWaitForDeadSounds()
         iSndUpdate();
     }
 }
-#endif
 
 void iSndSuspendCD(U32)
 {

--- a/src/SB/Core/gc/iSystem.cpp
+++ b/src/SB/Core/gc/iSystem.cpp
@@ -72,21 +72,18 @@ void MemoryProtectionErrorHandler(U16 last, OSContext* ctx, U64 unk1, U64 unk2)
     }
 }
 
-#if 0
-// WIP.
+// FIXME: Define a bunch of functions :)
 void TRCInit()
 {
     iTRCDisk::Init();
-    iTRCDisk::SetPadStopRumblingFunction(iPadStopRumble);
-    iTRCDisk::SetSndSuspendFunction(iSndSuspend);
-    iTRCDisk::SetSndResumeFunction(iSndResume);
-    iTRCDisk::SetSndKillFunction(iSndDIEDIEDIE);
-    iTRCDisk::SetMovieSuspendFunction(iFMV::Suspend);
-    iTRCDisk::SetMovieResumeFunction(iFMV::Resume);
-    ResetButton::SetSndKillFunction(iSndDIEDIEDIE);
+    // iTRCDisk::SetPadStopRumblingFunction(iPadStopRumble);
+    // iTRCDisk::SetSndSuspendFunction(iSndSuspend);
+    // iTRCDisk::SetSndResumeFunction(iSndResume);
+    // iTRCDisk::SetSndKillFunction(iSndDIEDIEDIE);
+    // iTRCDisk::SetMovieSuspendFunction(iFMV::Suspend);
+    // iTRCDisk::SetMovieResumeFunction(iFMV::Resume);
+    // ResetButton::SetSndKillFunction(iSndDIEDIEDIE);
 }
-
-#endif
 
 S32 RenderWareExit()
 {
@@ -105,12 +102,8 @@ void iSystemExit()
     iFileExit();
     iTimeExit();
     xMemExit();
-    OSPanic
-    (
-        "iSystem.cpp",
-        0x21d,
-        "(With apologies to Jim Morrison) This the end, my only friend, The End."
-    );
+    OSPanic("iSystem.cpp", 0x21d,
+            "(With apologies to Jim Morrison) This the end, my only friend, The End.");
 }
 
 void null_func()
@@ -159,7 +152,7 @@ void _rwDolphinHeapFree(void* __ptr)
     }
     if (__ptr != NULL)
     {
-        if ( *(S32*)((S32)__ptr - 4) == 0xDEADBEEF )
+        if (*(S32*)((S32)__ptr - 4) == 0xDEADBEEF)
         {
             free((void*)((S32)__ptr - 32));
         }
@@ -207,15 +200,12 @@ S32 iGetMonth()
     return td.mon + 1;
 }
 
-#if 0
-// Template for future use.
+// Template for future use. TODO
 char* iGetCurrFormattedDate(char* input)
 {
+    return NULL;
 }
 
-#endif
-
-#if 0
 // WIP.
 char* iGetCurrFormattedTime(char* input)
 {
@@ -243,5 +233,3 @@ char* iGetCurrFormattedTime(char* input)
     ret[12] = '\0';
     return ret + (0xd - (S32)input);
 }
-
-#endif

--- a/src/SB/Core/x/iCamera.cpp
+++ b/src/SB/Core/x/iCamera.cpp
@@ -227,7 +227,6 @@ void iCameraUpdatePos(RwCamera* cam, xMat4x3* pos)
     RwFrameUpdateObjects(f);
 }
 
-#ifdef NON_MATCHING
 void iCameraSetFOV(RwCamera* cam, F32 fov)
 {
     RwV2d vw;
@@ -239,7 +238,6 @@ void iCameraSetFOV(RwCamera* cam, F32 fov)
 
     RwCameraSetViewWindow(cam, &vw);
 }
-#endif
 
 void iCameraAssignEnv(RwCamera* camera, iEnv* env_geom)
 {
@@ -271,7 +269,6 @@ void iCamGetViewMatrix(RwCamera* camera, xMat4x3* view_matrix)
     view_matrix->pos.z = rw_view->pos.z;
 }
 
-#ifdef NON_MATCHING
 void iCameraSetNearFarClip(F32 nearPlane, F32 farPlane)
 {
     if (nearPlane <= *(const F32*)&_742_1)
@@ -290,9 +287,7 @@ void iCameraSetNearFarClip(F32 nearPlane, F32 farPlane)
 
     sCameraFarClip = farPlane;
 }
-#endif
 
-#ifdef NON_MATCHING
 void iCameraSetFogParams(iFogParams* fp, F32 time)
 {
     if (!fp || fp->type == rwFOGTYPENAFOGTYPE)
@@ -314,7 +309,6 @@ void iCameraSetFogParams(iFogParams* fp, F32 time)
         // todo
     }
 }
-#endif
 
 void iCameraSetFogRenderStates()
 {

--- a/src/SB/Core/x/xBehaveMgr.cpp
+++ b/src/SB/Core/x/xBehaveMgr.cpp
@@ -17,7 +17,6 @@ void xBehaveMgr_Startup()
     }
 }
 
-#if 0
 void xBehaveMgr_Shutdown()
 {
     g_modinit_xBehaveMgr--;
@@ -30,7 +29,6 @@ void xBehaveMgr_Shutdown()
         g_behavmgr = NULL;
     }
 }
-#endif
 
 xBehaveMgr* xBehaveMgr_GetSelf()
 {
@@ -115,8 +113,6 @@ void xPsyche::BrainEnd()
     this->psystat = PSY_STAT_THINK;
 }
 
-#ifdef NON_MATCHING
-// Regalloc
 xGoal* xPsyche::AddGoal(S32 gid, void* createData)
 {
     xGoal* goal = (xGoal*)xBehaveMgr_GoalFactory()->CreateItem(gid, createData, NULL);
@@ -139,7 +135,6 @@ xGoal* xPsyche::AddGoal(S32 gid, void* createData)
     }
     return goal;
 }
-#endif
 
 extern F32 _750;
 void xPsyche::FreshWipe()
@@ -198,7 +193,6 @@ void xPsyche::Lobotomy(xFactory* factory)
     }
 }
 
-#if 0
 void xPsyche::Amnesia(S32 i)
 {
     xGoal* g = this->goallist;
@@ -214,4 +208,3 @@ void xPsyche::Amnesia(S32 i)
         }
     }
 }
-#endif

--- a/src/SB/Core/x/xBound.cpp
+++ b/src/SB/Core/x/xBound.cpp
@@ -92,7 +92,6 @@ void xBoundGetSphere(xSphere& o, const xBound& bound)
     }
 }
 
-#ifdef NON_MATCHING
 F32 xsqrt(F32 x)
 {
     const F32 half = _571;
@@ -115,16 +114,12 @@ F32 xsqrt(F32 x)
 
     return _643;
 }
-#endif
 
 U32 xBoundSphereHitsOBB(const xSphere* s, const xBox* b, const xMat4x3* m, xCollis* coll)
 {
     return xSphereHitsOBB_nu(s, b, m, coll);
 }
 
-#ifndef NON_MATCHING
-void xBoundHitsBound(const xBound* a, const xBound* b, xCollis* c);
-#else
 void xBoundHitsBound(const xBound* a, const xBound* b, xCollis* c)
 {
     if (!xQuickCullIsects(&a->qcd, &b->qcd))
@@ -169,11 +164,7 @@ void xBoundHitsBound(const xBound* a, const xBound* b, xCollis* c)
         }
     }
 }
-#endif
 
-#ifndef NON_MATCHING
-static void xBoundOBBIsectRay(const xBox* b, const xMat4x3* m, const xRay3* r, xIsect* isect);
-#else
 static void xBoundOBBIsectRay(const xBox* b, const xMat4x3* m, const xRay3* r, xIsect* isect)
 {
     xRay3 xfr;
@@ -304,7 +295,6 @@ static void xBoundOBBIsectRay(const xBox* b, const xMat4x3* m, const xRay3* r, x
 
     iBoxIsectRay(&sbox, &xfr, isect);
 }
-#endif
 
 void xRayHitsBound(const xRay3* r, const xBound* b, xCollis* c)
 {

--- a/src/SB/Core/x/xCamera.cpp
+++ b/src/SB/Core/x/xCamera.cpp
@@ -202,9 +202,6 @@ void xCameraReset(xCamera* cam, F32 d, F32 h, F32 pitch)
     xcam_collis_owner_disable = 0;
 }
 
-#ifndef NON_MATCHING
-static void xCam_buildbasis(xCamera* cam);
-#else
 static void xCam_buildbasis(xCamera* cam)
 {
     if (cam->tgt_mat)
@@ -270,10 +267,8 @@ static void xCam_buildbasis(xCamera* cam)
         cam->mbasis.right.z = -cam->mbasis.at.x;
     }
 }
-#endif
 
-static void xCam_cyltoworld(xVec3* v, const xMat4x3* tgt_mat, F32 d, F32 h, F32 p,
-                            U32 flags)
+static void xCam_cyltoworld(xVec3* v, const xMat4x3* tgt_mat, F32 d, F32 h, F32 p, U32 flags)
 {
     if (flags & 0x10)
     {
@@ -298,8 +293,8 @@ static void xCam_cyltoworld(xVec3* v, const xMat4x3* tgt_mat, F32 d, F32 h, F32 
     }
 }
 
-static void xCam_worldtocyl(F32& d, F32& h, F32& p, const xMat4x3* tgt_mat,
-                            const xVec3* v, U32 flags)
+static void xCam_worldtocyl(F32& d, F32& h, F32& p, const xMat4x3* tgt_mat, const xVec3* v,
+                            U32 flags)
 {
     F32 lx, lz;
 
@@ -348,9 +343,6 @@ static void xCam_worldtocyl(F32& d, F32& h, F32& p, const xMat4x3* tgt_mat,
     }
 }
 
-#ifndef NON_MATCHING
-static void xCam_CorrectD(xCamera* r3, F32 f1, F32 f2, F32 f3);
-#else
 static void xCam_CorrectD(xCamera* r3, F32 f1, F32 f2, F32 f3)
 {
     // non-matching: incorrect float register
@@ -367,7 +359,6 @@ static void xCam_CorrectD(xCamera* r3, F32 f1, F32 f2, F32 f3)
     r3->mat.pos.x += tmp2;
     r3->mat.pos.z += tmp3;
 }
-#endif
 
 static void xCam_CorrectH(xCamera* r3, F32 f1, F32 f2, F32 f3)
 {
@@ -412,10 +403,6 @@ static void xCam_DampP(xCamera* r3, F32 f1, F32 f2)
     r3->mat.pos.x += tmp1;
     r3->mat.pos.z += tmp2;
 }
-
-#ifndef NON_MATCHING
-static void xCam_CorrectYaw(xCamera* r3, F32 f1, F32 f2, F32 f3);
-#else
 static void xCam_CorrectYaw(xCamera* r3, F32 f1, F32 f2, F32 f3)
 {
     // non-matching: incorrect float registers, slightly out-of-order fmsubs instruction
@@ -431,11 +418,6 @@ static void xCam_CorrectYaw(xCamera* r3, F32 f1, F32 f2, F32 f3)
 
     r3->yaw_cur += tmp2;
 }
-#endif
-
-#ifndef NON_MATCHING
-static void xCam_CorrectPitch(xCamera* r3, F32 f1, F32 f2, F32 f3);
-#else
 static void xCam_CorrectPitch(xCamera* r3, F32 f1, F32 f2, F32 f3)
 {
     // non-matching: same reasons as xCam_CorrectYaw
@@ -451,11 +433,7 @@ static void xCam_CorrectPitch(xCamera* r3, F32 f1, F32 f2, F32 f3)
 
     r3->pitch_cur += tmp2;
 }
-#endif
 
-#ifndef NON_MATCHING
-static void xCam_CorrectRoll(xCamera* r3, F32 f1, F32 f2, F32 f3);
-#else
 static void xCam_CorrectRoll(xCamera* r3, F32 f1, F32 f2, F32 f3)
 {
     // non-matching: same reasons as xCam_CorrectYaw
@@ -471,7 +449,6 @@ static void xCam_CorrectRoll(xCamera* r3, F32 f1, F32 f2, F32 f3)
 
     r3->roll_cur += tmp2;
 }
-#endif
 
 void SweptSphereHitsCameraEnt(xScene*, xRay3* ray, xQCData* qcd, xEnt* ent, void* data)
 {
@@ -573,18 +550,11 @@ void SweptSphereHitsCameraEnt(xScene*, xRay3* ray, xQCData* qcd, xEnt* ent, void
     }
 }
 
-#ifndef NON_MATCHING
-static void _xCameraUpdate(xCamera* cam, F32 dt);
-#else
 static void _xCameraUpdate(xCamera* cam, F32 dt)
 {
     // lol nope
 }
-#endif
 
-#ifndef NON_MATCHING
-void xCameraUpdate(xCamera* cam, F32 dt);
-#else
 void xCameraUpdate(xCamera* cam, F32 dt)
 {
     S32 i;
@@ -603,7 +573,6 @@ void xCameraUpdate(xCamera* cam, F32 dt)
         _xCameraUpdate(cam, sdt);
     }
 }
-#endif
 
 #ifndef INLINE
 float std::ceilf(float x)
@@ -641,9 +610,6 @@ static void xCameraFXInit()
     sCameraFX[9].flags = 0;
 }
 
-#ifndef NON_MATCHING
-cameraFX* xCameraFXAlloc();
-#else
 cameraFX* xCameraFXAlloc()
 {
     S32 i;
@@ -667,11 +633,7 @@ cameraFX* xCameraFXAlloc()
 
     return NULL;
 }
-#endif
 
-#ifndef NON_MATCHING
-void xCameraFXZoomUpdate(cameraFX* f, F32 dt, const xMat4x3*, xMat4x3* m);
-#else
 void xCameraFXZoomUpdate(cameraFX* f, F32 dt, const xMat4x3*, xMat4x3* m)
 {
     switch (f->zoom.mode)
@@ -731,10 +693,9 @@ void xCameraFXZoomUpdate(cameraFX* f, F32 dt, const xMat4x3*, xMat4x3* m)
     }
     }
 }
-#endif
 
-void xCameraFXShake(F32 maxTime, F32 magnitude, F32 cycleMax, F32 rotate_magnitude,
-                    F32 radius, xVec3* epicenter, xVec3* player)
+void xCameraFXShake(F32 maxTime, F32 magnitude, F32 cycleMax, F32 rotate_magnitude, F32 radius,
+                    xVec3* epicenter, xVec3* player)
 {
     cameraFX* f = xCameraFXAlloc();
 
@@ -814,9 +775,6 @@ void xCameraFXShakeUpdate(cameraFX* f, F32 dt, const xMat4x3*, xMat4x3* m)
     xMat3x3Euler(m, &e);
 }
 
-#ifndef NON_MATCHING
-void xCameraFXUpdate(xCamera* cam, F32 dt);
-#else
 void xCameraFXUpdate(xCamera* cam, F32 dt)
 {
     S32 i;
@@ -858,7 +816,6 @@ void xCameraFXUpdate(xCamera* cam, F32 dt)
 
     iCameraUpdatePos(cam->lo_cam, &cam->mat);
 }
-#endif
 
 void xCameraFXEnd(xCamera* cam)
 {
@@ -906,8 +863,8 @@ void xCameraDoCollisions(S32 do_collis, S32 owner)
     xcam_do_collis = (xcam_collis_owner_disable == 0);
 }
 
-void xCameraMove(xCamera* cam, U32 flags, F32 dgoal, F32 hgoal, F32 pgoal,
-                 F32 tm, F32 tm_acc, F32 tm_dec)
+void xCameraMove(xCamera* cam, U32 flags, F32 dgoal, F32 hgoal, F32 pgoal, F32 tm, F32 tm_acc,
+                 F32 tm_dec)
 {
     cam->flags = (cam->flags & ~0x3E) | (flags & 0x3E);
     cam->dgoal = dgoal;
@@ -1002,8 +959,7 @@ void xCameraFOV(xCamera* cam, F32 fov, F32 maxSpeed, F32 dt)
     }
 }
 
-void xCameraLook(xCamera* cam, U32 flags, const xQuat* orn_goal, F32 tm, F32 tm_acc,
-                 F32 tm_dec)
+void xCameraLook(xCamera* cam, U32 flags, const xQuat* orn_goal, F32 tm, F32 tm_acc, F32 tm_dec)
 {
     F32 s; // unused
 
@@ -1032,8 +988,8 @@ void xCameraLook(xCamera* cam, U32 flags, const xQuat* orn_goal, F32 tm, F32 tm_
     }
 }
 
-void xCameraLookYPR(xCamera* cam, U32 flags, F32 yaw, F32 pitch, F32 roll,
-                    F32 tm, F32 tm_acc, F32 tm_dec)
+void xCameraLookYPR(xCamera* cam, U32 flags, F32 yaw, F32 pitch, F32 roll, F32 tm, F32 tm_acc,
+                    F32 tm_dec)
 {
     cam->flags = (cam->flags & ~0xF80) | (flags & 0xF80) | 0x80;
     cam->yaw_goal = yaw;
@@ -1108,8 +1064,7 @@ void xCameraRotate(xCamera* cam, const xMat3x3& m, F32 time, F32 accel, F32 decl
     cam->yaw_epv = cam->pitch_epv = cam->roll_epv = _765;
 }
 
-void xCameraRotate(xCamera* cam, const xVec3& v, F32 roll, F32 time, F32 accel,
-                   F32 decl)
+void xCameraRotate(xCamera* cam, const xVec3& v, F32 roll, F32 time, F32 accel, F32 decl)
 {
     cam->yaw_goal = xatan2(v.x, v.z);
     cam->pitch_goal = -xasin(v.y);
@@ -1157,12 +1112,7 @@ float std::asinf(float x)
 }
 #endif
 
-#ifndef NON_MATCHING
-static void bound_sphere_xz(xVec3& r3, xVec3& r4, const xVec3& r5, F32 f1, const xVec3& r6,
-                            F32 f2);
-#else
-static void bound_sphere_xz(xVec3& r3, xVec3& r4, const xVec3& r5, F32 f1, const xVec3& r6,
-                            F32 f2)
+static void bound_sphere_xz(xVec3& r3, xVec3& r4, const xVec3& r5, F32 f1, const xVec3& r6, F32 f2)
 {
     // non-matching: incorrect registers and out-of-order instructions
     F32 _f31 = f1 / f2;
@@ -1181,7 +1131,6 @@ static void bound_sphere_xz(xVec3& r3, xVec3& r4, const xVec3& r5, F32 f1, const
     r4.y = r5.y;
     r4.z = r5.z + _f6 + _f5_2;
 }
-#endif
 
 void xBinaryCamera::init()
 {
@@ -1204,12 +1153,9 @@ void xBinaryCamera::stop()
     this->camera = NULL;
 }
 
-#ifdef NON_MATCHING
 void xBinaryCamera::update(F32 dt)
 {
-    // lol nope
 }
-#endif
 
 void xCameraSetFOV(xCamera* cam, F32 fov)
 {

--- a/src/SB/Core/x/xClimate.cpp
+++ b/src/SB/Core/x/xClimate.cpp
@@ -37,7 +37,6 @@ void xClimateInit(_tagClimate* climate)
     climate->rain.snow_emitter->emit_flags &= 0xfe;
 }
 
-#ifdef NON_MATCHING
 // Equivalent
 // float ops are being optimized more aggressively
 void xClimateInitAsset(_tagClimate* climate, xEnvAsset* asset)
@@ -65,7 +64,6 @@ void xClimateInitAsset(_tagClimate* climate, xEnvAsset* asset)
         climate->rain.strength += asset->climateStrengthMin;
     }
 }
-#endif
 
 void xClimateSetSnow(F32 stre)
 {
@@ -79,7 +77,6 @@ void xClimateSetRain(F32 stre)
     sClimate->rain.strength = stre;
 }
 
-#ifdef NON_MATCHING
 // Equivalent
 // Float literal is being loaded three separate times in the original code.
 void GetPosBigDogWhattupFool(xVec3* vec)
@@ -89,9 +86,7 @@ void GetPosBigDogWhattupFool(xVec3* vec)
     vec->y = 10.0f * camera->mat.at.y + camera->mat.pos.y;
     vec->z = 10.0f * camera->mat.at.z + camera->mat.pos.z;
 }
-#endif
 
-#ifdef NON_MATCHING
 // NOTE (Square): I think it's equivalent but it's very hard to tell. Our compiler is optimizing the float ops
 // much more aggresively and it's throwing the regalloc off.
 void UpdateRain(_tagClimate* climate, float seconds)
@@ -174,7 +169,6 @@ void UpdateRain(_tagClimate* climate, float seconds)
         }
     }
 }
-#endif
 
 void UpdateWind(_tagClimate* climate, F32 seconds)
 {

--- a/src/SB/Core/x/xClumpColl.cpp
+++ b/src/SB/Core/x/xClumpColl.cpp
@@ -38,12 +38,11 @@ void xClumpColl_InstancePointers(xClumpCollBSPTree* tree, RpClump* clump)
     RpMesh* mesh;
 }
 
-#if 0
 //WIP
-xClumpCollBSPTree*
-xClumpColl_ForAllBoxLeafNodeIntersections(xClumpCollBSPTree* tree, RwBBox* box,
-                                          S32 (*callBack)(xClumpCollBSPTriangle*, void*),
-                                          void* data)
+xClumpCollBSPTree* xClumpColl_ForAllBoxLeafNodeIntersections(xClumpCollBSPTree* tree, RwBBox* box,
+                                                             S32 (*callBack)(xClumpCollBSPTriangle*,
+                                                                             void*),
+                                                             void* data)
 {
     S32 nStack;
     nodeInfo nodeStack[33];
@@ -91,4 +90,3 @@ xClumpColl_ForAllBoxLeafNodeIntersections(xClumpCollBSPTree* tree, RwBBox* box,
     }
     return 0;
 }
-#endif

--- a/src/SB/Core/x/xCutscene.cpp
+++ b/src/SB/Core/x/xCutscene.cpp
@@ -22,7 +22,6 @@ extern F32 _672; // 1.0
 extern F32 lbl_803CCB3C; // 0.0
 extern F32 lbl_803CCB40; // 0.033333335
 
-#ifdef NON_MATCHING
 // Non-matching: scheduling
 void xCutscene_Init(void* toc)
 {
@@ -51,9 +50,7 @@ void xCutscene_Init(void* toc)
         *(volatile float*)&sCutsceneFakeModel[i].Alpha = (volatile float)1.0f;
     }
 }
-#endif
 
-#if 0
 // Damn RwEngineInstance ruining this (as well as the members being accessed incorrectly by Ghidra)
 xCutscene* xCutscene_Create(U32 id)
 {
@@ -78,7 +75,7 @@ xCutscene* xCutscene_Create(U32 id)
     {
         maxload = cnfo->MaxModel;
     }
-    sActiveCutscene.RawBuf = RwFree(maxload + 0x3c);
+    // sActiveCutscene.RawBuf = RwFree(maxload + 0x3c);
     sActiveCutscene.AlignBuf = sActiveCutscene.RawBuf;
     while ((int)sActiveCutscene.AlignBuf & 0x3f != 0)
     {
@@ -94,10 +91,7 @@ xCutscene* xCutscene_Create(U32 id)
     sActiveCutscene.Stream = (xCutsceneTime*)((int)sActiveCutscene.AlignBuf + cnfo->MaxBufEven);
     return &sActiveCutscene;
 }
-#endif
 
-#if 0
-// WIP
 S32 xCutscene_Destroy(xCutscene* csn)
 {
     csn->Ready = 0;
@@ -120,26 +114,24 @@ S32 xCutscene_Destroy(xCutscene* csn)
     }
     for (int i = 0; i < csn->Info->NumData; i++)
     {
-        if ((((U32*)csn->Data->DataType + i) & 0x80000000) &&
-            ((RpAtomic*)((U32*)((U32*)csn->Data->DataType + i) + 3) != NULL))
-        {
-            if ((((U32*)csn->Data->DataType + i) & 0xfffffff) == 6)
-            {
-                RwFree();
-            }
-            else
-            {
-                iModelUnload((RpAtomic*)((U32*)((U32*)csn->Data->DataType + i) + 3));
-            }
-            // (U32)((U32*)csn->Data->DataType + i) =
-            //     (((U32*)csn->Data->DataType + i) & 0xfffffff);
-        }
+        // if ((((U32*)csn->Data->DataType + i) & 0x80000000) &&
+        //     ((RpAtomic*)((U32*)((U32*)csn->Data->DataType + i) + 3) != NULL))
+        // {
+        //     if ((((U32*)csn->Data->DataType + i) & 0xfffffff) == 6)
+        //     {
+        //         RwFree();
+        //     }
+        //     else
+        //     {
+        //         iModelUnload((RpAtomic*)((U32*)((U32*)csn->Data->DataType + i) + 3));
+        //     }
+        //     (U32)((U32*)csn->Data->DataType + i) = (((U32*)csn->Data->DataType + i) & 0xfffffff);
+        // }
     }
     RwFree(csn->RawBuf);
     memset(csn, 0, sizeof(xCutscene));
     return 1;
 }
-#endif
 
 S32 xCutscene_LoadStart(xCutscene* csn)
 {
@@ -156,8 +148,6 @@ S32 xCutscene_LoadStart(xCutscene* csn)
     return 1;
 }
 
-#if 0
-// WIP
 F32 xCutsceneConvertBreak(float param_1, xCutsceneBreak* param_2, U32 param_3, int param_4)
 {
     int i = 0;
@@ -188,7 +178,6 @@ F32 xCutsceneConvertBreak(float param_1, xCutsceneBreak* param_2, U32 param_3, i
     }
     return param_2[i].Time - lbl_803CCB40;
 }
-#endif
 
 xCutscene* xCutscene_CurrentCutscene()
 {

--- a/src/SB/Core/x/xFFX.cpp
+++ b/src/SB/Core/x/xFFX.cpp
@@ -69,7 +69,6 @@ S16 xFFXAddEffect(xEnt* ent, void (*dof)(xEnt*, xScene*, F32, void*), void* fd)
     return effectID;
 }
 
-#if 0
 // WIP.
 U32 xFFXRemoveEffectByFData(xEnt* ent, void* fdata)
 {
@@ -94,8 +93,6 @@ U32 xFFXRemoveEffectByFData(xEnt* ent, void* fdata)
     *found = ffx;
     return 1;
 }
-
-#endif
 
 void xFFXApplyOne(xFFX* ffx, xEnt* ent, xScene* sc, F32 dt)
 {
@@ -138,7 +135,6 @@ void xFFXShakeFree(xFFXShakeState* s)
     shake_alist = s;
 }
 
-#if 0
 // Some instructions are in the wrong order.
 void xFFXRotMatchPoolInit(U32 num)
 {
@@ -156,8 +152,6 @@ void xFFXRotMatchPoolInit(U32 num)
     }
     rot_match_alist = rot_match_pool + (rot_match_psize - 1);
 }
-
-#endif
 
 xFFXRotMatchState* xFFXRotMatchAlloc()
 {

--- a/src/SB/Core/x/xFX.cpp
+++ b/src/SB/Core/x/xFX.cpp
@@ -76,17 +76,11 @@ static void DrawRingSceneExit()
     g_txtr_drawRing = NULL;
 }
 
-#if 1
-static void DrawRing(xFXRing* m);
-
-#else
 static void DrawRing(xFXRing* m)
 {
     // todo: uses int-to-float conversion
 }
-#endif
 
-#ifdef NON_MATCHING
 xFXRing* xFXRingCreate(const xVec3* pos, const xFXRing* params)
 {
     xFXRing* ring = &ringlist[0];
@@ -116,11 +110,7 @@ xFXRing* xFXRingCreate(const xVec3* pos, const xFXRing* params)
 
     return NULL;
 }
-#endif
 
-#ifndef NON_MATCHING
-static void xFXRingUpdate(F32 dt);
-#else
 static void xFXRingUpdate(F32 dt)
 {
     xFXRing* ring = &ringlist[0];
@@ -163,7 +153,6 @@ static void xFXRingUpdate(F32 dt)
         }
     }
 }
-#endif
 
 void xFXRingRender()
 {
@@ -184,7 +173,6 @@ static RpMaterial* MaterialSetBumpMap(RpMaterial* material, void* data);
 static RpMaterial* MaterialSetBumpEnvMap(RpMaterial* material, RwTexture* env, F32 shininess,
                                          RwTexture* bump, F32 bumpiness);
 
-#ifdef NON_MATCHING
 void xFX_SceneEnter(RpWorld* world)
 {
     S32 i;
@@ -296,7 +284,6 @@ void xFX_SceneEnter(RpWorld* world)
 
     num_fx_atomics = 0;
 }
-#endif
 
 void xFX_SceneExit(RpWorld*)
 {
@@ -312,7 +299,6 @@ void xFXUpdate(F32 dt)
 static const RwV3d _1168 = { 1, 0, 0 };
 static const RwV3d _1169 = { 0, 1, 0 };
 
-#ifdef NON_MATCHING
 static void LightResetFrame(RpLight* light)
 {
     // non-matching: lwzu instruction
@@ -325,7 +311,6 @@ static void LightResetFrame(RpLight* light)
     RwFrameRotate(frame, &v1, _1171, rwCOMBINEREPLACE);
     RwFrameRotate(frame, &v2, _1171, rwCOMBINEPOSTCONCAT);
 }
-#endif
 
 static RpMaterial* MaterialDisableMatFX(RpMaterial* material, void*)
 {

--- a/src/SB/Core/x/xFont.cpp
+++ b/src/SB/Core/x/xFont.cpp
@@ -381,9 +381,6 @@ namespace
         RwIm2DVertexSetIntRGBA(&vert, c.r, c.g, c.b, c.a);
     }
 
-#ifndef NON_MATCHING
-    void init_model_cache();
-#else
     void init_model_cache()
     {
         struct model_pool
@@ -416,7 +413,6 @@ namespace
             model.shadowID = 0xDEADBEEF;
         }
     }
-#endif
 
 #ifndef NON_MATCHING
     static U32 next_order_967;
@@ -556,7 +552,6 @@ void xfont::restore_render_state()
     RwRenderStateSet(rwRENDERSTATETEXTUREFILTER, (void*)oldrs.filter);
 }
 
-#ifdef NON_MATCHING
 basic_rect<F32> xfont::bounds(char c) const
 {
     font_data& fd = active_fonts[id];
@@ -572,7 +567,6 @@ basic_rect<F32> xfont::bounds(char c) const
     r.scale(width, height);
     return r;
 }
-#endif
 
 basic_rect<F32> xfont::bounds(const char* text) const
 {
@@ -685,7 +679,6 @@ void xfont::irender(const char* text, F32 x, F32 y) const
 
 static const basic_rect<F32> _1107 = {};
 
-#ifdef NON_MATCHING
 void xfont::irender(const char* text, size_t text_size, F32 x, F32 y) const
 {
     if (!text)
@@ -718,7 +711,6 @@ void xfont::irender(const char* text, size_t text_size, F32 x, F32 y) const
         i++;
     }
 }
-#endif
 
 extern substr text_delims;
 
@@ -1357,7 +1349,6 @@ xtextbox::tag_entry_list xtextbox::read_tag(const substr& s)
 }
 #endif
 
-#ifdef NON_MATCHING
 xtextbox::tag_entry* xtextbox::find_entry(const tag_entry_list& el, const substr& name)
 {
     // non-matching: el.size and el.entries are not cached at the beginning
@@ -1374,9 +1365,7 @@ xtextbox::tag_entry* xtextbox::find_entry(const tag_entry_list& el, const substr
 
     return NULL;
 }
-#endif
 
-#ifdef NON_MATCHING
 size_t xtextbox::read_list(const tag_entry& e, F32* v, size_t vsize)
 {
     size_t total = e.args_size;
@@ -1395,9 +1384,7 @@ size_t xtextbox::read_list(const tag_entry& e, F32* v, size_t vsize)
 
     return total;
 }
-#endif
 
-#ifdef NON_MATCHING
 size_t xtextbox::read_list(const tag_entry& e, S32* v, size_t vsize)
 {
     size_t total = e.args_size;
@@ -1416,7 +1403,6 @@ size_t xtextbox::read_list(const tag_entry& e, S32* v, size_t vsize)
 
     return total;
 }
-#endif
 
 void xtextbox::clear_layout_cache()
 {
@@ -1455,7 +1441,6 @@ void xtextbox::layout::clear()
     tb = xtextbox::create();
 }
 
-#ifdef NON_MATCHING
 void xtextbox::layout::trim_line(jot_line& line)
 {
     // non-matching: mtctr and bdnz not generated
@@ -1491,7 +1476,6 @@ void xtextbox::layout::trim_line(jot_line& line)
         }
     }
 }
-#endif
 
 void xtextbox::layout::erase_jots(size_t begin_jot, size_t end_jot)
 {
@@ -1915,7 +1899,6 @@ void xtextbox::layout::render(const xtextbox& ctb, S32 begin_jot, S32 end_jot)
 // this is different than the one in xMath.h
 #define min(a, b) ((a) >= (b) ? (b) : (a))
 
-#ifdef NON_MATCHING
 F32 xtextbox::layout::yextent(F32 max, S32& size, S32 begin_jot, S32 end_jot) const
 {
     size = 0;
@@ -1996,7 +1979,6 @@ F32 xtextbox::layout::yextent(F32 max, S32& size, S32 begin_jot, S32 end_jot) co
 
     return line.bounds.y + line.bounds.h - top;
 }
-#endif
 
 bool xtextbox::layout::changed(const xtextbox& ctb)
 {

--- a/src/SB/Core/x/xGrid.cpp
+++ b/src/SB/Core/x/xGrid.cpp
@@ -22,8 +22,7 @@ void xGridBoundInit(xGridBound* bound, void* data)
     bound->gpad = 0xea;
 }
 
-#ifdef NON_MATCHING
-// Usual floating point problems, floating point loads get pulled to the start.
+// FIXME: Usual floating point problems, floating point loads get pulled to the start.
 // Also, there's something funny going on with the malloc + memset at the end,
 // I think they may not have used the obvious pattern for it, since changing
 // the multiplication order for the second one generates closer machine code
@@ -64,7 +63,6 @@ void xGridInit(xGrid* grid, xBox* bounds, U16 nx, U16 nz, U8 ingrid_id)
     grid->cells = (xGridBound**)xMemAllocSize(nx * nz * sizeof(xGridBound*));
     memset(grid->cells, 0, sizeof(xGridBound*) * (nz * nx));
 }
-#endif
 
 void xGridKill(xGrid* grid)
 {
@@ -199,7 +197,6 @@ xGridBound** xGridGetCell(xGrid* grid, const xEnt* ent, S32& grx, S32& grz)
     return &grid->cells[grz * grid->nx] + grx;
 }
 
-#ifdef NON_MATCHING
 void xGridGetCell(xGrid* grid, F32 x, F32 y, F32 z, S32& grx, S32& grz)
 {
     F32 pgridx = (x - grid->minx) * grid->inv_csizex;
@@ -208,10 +205,9 @@ void xGridGetCell(xGrid* grid, F32 x, F32 y, F32 z, S32& grx, S32& grz)
     grx = MIN(F32((grid->nx - 1) ^ 0x8000), MAX(0, pgridx));
     grz = MIN(F32((grid->nz - 1) ^ 0x8000), MAX(0, pgridx));
 }
-#endif
 
-xGridBound* xGridIterFirstCell(xGrid* grid, F32 posx, F32 posy, F32 posz, S32& grx,
-                               S32& grz, xGridIterator& iter)
+xGridBound* xGridIterFirstCell(xGrid* grid, F32 posx, F32 posy, F32 posz, S32& grx, S32& grz,
+                               xGridIterator& iter)
 {
     xGridGetCell(grid, posx, posy, posz, grx, grz);
     return xGridIterFirstCell(grid, grx, grz, iter);

--- a/src/SB/Core/x/xJSP.cpp
+++ b/src/SB/Core/x/xJSP.cpp
@@ -32,8 +32,6 @@ static RpMesh* AddMeshCB(RpMesh* mesh, RpMeshHeader* header, void* param_3)
     return mesh;
 }
 
-#if 0
-// ¯\_(ツ)_/¯
 RpAtomic* AddAtomicCB(RpAtomic* atomic, void* data)
 {
     // The dwarf defines this variable but it looks like it isnt used
@@ -44,11 +42,7 @@ RpAtomic* AddAtomicCB(RpAtomic* atomic, void* data)
     _rpMeshHeaderForAllMeshes(atomic->geometry->mesh, (RpMeshCallBack)&AddMeshCB, data);
     return atomic;
 }
-#endif
 
-#if 0
-// not in dwarf data
-// ¯\_(ツ)_/¯
 RpAtomic* AddAtomicPrecalcedVertCB(RpAtomic* atomic, void* data)
 {
     sAtomicStartCount--;
@@ -57,7 +51,6 @@ RpAtomic* AddAtomicPrecalcedVertCB(RpAtomic* atomic, void* data)
 
     return atomic;
 }
-#endif
 
 RpAtomic* ListAtomicCB(RpAtomic* atomic, void* data)
 {

--- a/src/SB/Core/x/xLaserBolt.cpp
+++ b/src/SB/Core/x/xLaserBolt.cpp
@@ -50,15 +50,10 @@ void xLaserBoltEmitter::refresh_config()
     this->ialpha = alpha;
 }
 
-#if 0
-
-// WIP.
 void xLaserBoltEmitter::attach_effects(fx_when_enum when, effect_data* fx, size_t fxsize)
 {
     // TODO!!!
 }
-
-#endif
 
 RxObjSpace3DVertex* xLaserBoltEmitter::get_vert_buffer(S32& dat)
 {
@@ -66,13 +61,9 @@ RxObjSpace3DVertex* xLaserBoltEmitter::get_vert_buffer(S32& dat)
     return gRenderBuffer.m_vertex;
 }
 
-#if 0
-
 // WIP.
 void xLaserBoltEmitter::reset_fx(fx_when_enum when)
 {
     U32* sizePtr = &this->fxsize[when];
     effect_data** effect = &this->fx[when];
 }
-
-#endif

--- a/src/SB/Core/x/xMemMgr.cpp
+++ b/src/SB/Core/x/xMemMgr.cpp
@@ -15,7 +15,6 @@ void xMemDebug_SoakLog(const char*)
 {
 }
 
-#ifdef NON_MATCHING
 // The instructions putting 0/1/2 into registers happen in the wrong order.
 void xMemInit()
 {
@@ -31,7 +30,6 @@ void xMemInit()
     gxHeap[2].opp_heap[1] = 1;
     gActiveHeap = 0;
 }
-#endif
 
 void xMemExit()
 {
@@ -253,7 +251,6 @@ S32 xMemPushBase()
     return xMemPushBase(gActiveHeap);
 }
 
-#ifdef NON_MATCHING
 // Load/Store swap of sMemBaseNotifyFunc and state_idx
 S32 xMemPopBase(U32 heapID, S32 depth)
 {
@@ -271,7 +268,6 @@ S32 xMemPopBase(U32 heapID, S32 depth)
 
     return heap->state_idx;
 }
-#endif
 
 S32 xMemPopBase(S32 depth)
 {
@@ -325,8 +321,8 @@ void xMemPoolAddElements(xMemPool* pool, void* buffer, U32 count)
     pool->Total += count;
 }
 
-void xMemPoolSetup(xMemPool* pool, void* buffer, U32 nextOffset, U32 flags,
-                   xMemPoolInitCB initCB, U32 size, U32 count, U32 numRealloc)
+void xMemPoolSetup(xMemPool* pool, void* buffer, U32 nextOffset, U32 flags, xMemPoolInitCB initCB,
+                   U32 size, U32 count, U32 numRealloc)
 {
     pool->FreeList = NULL;
     pool->NextOffset = nextOffset;

--- a/src/SB/Core/x/xModelBucket.cpp
+++ b/src/SB/Core/x/xModelBucket.cpp
@@ -57,8 +57,6 @@ void xModelBucket_PreCountReset()
     sAlphaList = NULL;
 }
 
-#if 0
-// Idk.
 void xModelBucket_PreCountAlloc(S32 maxAlphaModels)
 {
     sAlphaCount = maxAlphaModels;
@@ -77,8 +75,6 @@ void xModelBucket_PreCountAlloc(S32 maxAlphaModels)
     sBucketDummyCamera = iCameraCreate(0, 0, 0);
     RpWorldAddCamera(sBucketDummyWorld, sBucketDummyCamera);
 }
-
-#endif
 
 void xModelBucket_Init()
 {
@@ -101,7 +97,6 @@ void xModelBucket_Begin()
     xModelBucketEnabled = 1;
 }
 
-#if 0
 // Scheduling!
 void xModelBucket_RenderAlphaBegin()
 {
@@ -112,5 +107,3 @@ void xModelBucket_RenderAlphaBegin()
         qsort(sAlphaList, sAlphaCurr, sizeof(xModelAlphaBucket), CmpAlphaBucket);
     }
 }
-
-#endif

--- a/src/SB/Core/x/xMovePoint.cpp
+++ b/src/SB/Core/x/xMovePoint.cpp
@@ -70,12 +70,14 @@ void xMovePointSplineDestroy(xMovePoint* m)
 
 void xMovePointSplineSetup(xMovePoint* m)
 {
-    xMovePoint* w0, *w1, *w2, *w3;
+    xMovePoint *w0, *w1, *w2, *w3;
     xVec3 points[2];
     xVec3 p1, p2;
 
-    if (m->asset->bezIndex != 1) return;
-    if (m->spl) return;
+    if (m->asset->bezIndex != 1)
+        return;
+    if (m->spl)
+        return;
 
     w0 = m->prev;
     w1 = m;
@@ -91,12 +93,12 @@ void xMovePointSplineSetup(xMovePoint* m)
     }
     else
     {
-        p1.x = (1/3.f) * w0->pos->x + (2/3.f) * w1->pos->x;
-        p1.y = (1/3.f) * w0->pos->y + (2/3.f) * w1->pos->y;
-        p1.z = (1/3.f) * w0->pos->z + (2/3.f) * w1->pos->z;
-        p2.x = (2/3.f) * w1->pos->x + (1/3.f) * w2->pos->x;
-        p2.y = (2/3.f) * w1->pos->y + (1/3.f) * w2->pos->y;
-        p2.z = (2/3.f) * w1->pos->z + (1/3.f) * w2->pos->z;
+        p1.x = (1 / 3.f) * w0->pos->x + (2 / 3.f) * w1->pos->x;
+        p1.y = (1 / 3.f) * w0->pos->y + (2 / 3.f) * w1->pos->y;
+        p1.z = (1 / 3.f) * w0->pos->z + (2 / 3.f) * w1->pos->z;
+        p2.x = (2 / 3.f) * w1->pos->x + (1 / 3.f) * w2->pos->x;
+        p2.y = (2 / 3.f) * w1->pos->y + (1 / 3.f) * w2->pos->y;
+        p2.z = (2 / 3.f) * w1->pos->z + (1 / 3.f) * w2->pos->z;
         points[1] = *w2->pos;
     }
 
@@ -104,7 +106,6 @@ void xMovePointSplineSetup(xMovePoint* m)
     xSpline3_ArcInit(m->spl, 20);
 }
 
-#if 0
 // If you uncomment the numPoints variable then this function is a perfect match
 // minus ordering. In the original assembly some variable fetches are lifted to
 // places earlier in the assembly listing than what this comiles to for some
@@ -127,7 +128,7 @@ F32 xMovePointGetNext(xMovePoint* m, xMovePoint* prev, xMovePoint** next, xVec3*
     // The debug symbols don't show a dedicated numPoints var, but if it isn't
     // present, then getting numPoints isn't lifted outside of the loop, which
     // it is in the original assembly.
-    //U16 numPoints = m->asset->numPoints;
+    U16 numPoints = m->asset->numPoints;
 
     for (U16 idx = 0; idx < m->asset->numPoints; ++idx)
     {
@@ -172,7 +173,6 @@ F32 xMovePointGetNext(xMovePoint* m, xMovePoint* prev, xMovePoint** next, xVec3*
         return xMovePoint_float_0;
     }
 }
-#endif
 
 xVec3* xMovePointGetPos(const xMovePoint* m)
 {

--- a/src/SB/Core/x/xNPCBasic.cpp
+++ b/src/SB/Core/x/xNPCBasic.cpp
@@ -42,9 +42,7 @@ void NPC_entwrap_bupdate(xEnt*, xVec3*);
 void NPC_entwrap_move(xEnt*, xScene*, F32, xEntFrame*);
 void NPC_entwrap_render(xEnt*);
 
-#ifdef NON_MATCHING
 // The order of the function pointer assignment instructions at the end of the
-
 void xNPCBasic::Init(xEntAsset* asset)
 {
     if (xNPCBasic_float_0 == asset->scale.x)
@@ -104,11 +102,7 @@ void xNPCBasic::Init(xEntAsset* asset)
 
     baseFlags &= 0xffef;
 }
-#endif
 
-#ifndef NOT_MATCHING
-
-#else
 // Register assignment in the floating point instructions is slightly wrong.
 void xNPCBasic::Reset()
 {
@@ -136,7 +130,6 @@ void xNPCBasic::Reset()
     RestoreColFlags();
     return;
 }
-#endif
 
 void NPC_alwaysUseSphere(xEnt* ent, xVec3* value)
 {

--- a/src/SB/Core/x/xPad.cpp
+++ b/src/SB/Core/x/xPad.cpp
@@ -16,7 +16,6 @@ S32 xPadInit()
     return 1;
 }
 
-#if 0
 // WIP.
 _tagxPad* xPadEnable(S32 idx)
 {
@@ -27,8 +26,6 @@ _tagxPad* xPadEnable(S32 idx)
     }
     return p;
 }
-
-#endif
 
 void xPadRumbleEnable(S32 idx, S32 enable)
 {
@@ -91,7 +88,6 @@ void xPadKill()
     iPadKill();
 }
 
-#if 0
 // WIP.
 _tagxRumble* xPadGetRumbleSlot()
 {
@@ -107,8 +103,6 @@ _tagxRumble* xPadGetRumbleSlot()
     }
     return NULL;
 }
-
-#endif
 
 void xPadDestroyRumbleChain(_tagxPad* pad)
 {

--- a/src/SB/Core/x/xPar.cpp
+++ b/src/SB/Core/x/xPar.cpp
@@ -9,7 +9,6 @@ extern xPar* gParDead;
 extern F32 lbl_803CCF10; // 0.0f
 extern F32 lbl_803CCF14; // 255f
 
-#if 0
 // For some reason, it does not recompare gParDead and assumes the first comparison is valid for all.
 void xParMemInit()
 {
@@ -26,8 +25,6 @@ void xParMemInit()
         gParDead = curr;
     }
 }
-
-#endif
 
 xPar* xParAlloc()
 {

--- a/src/SB/Core/x/xParCmd.cpp
+++ b/src/SB/Core/x/xParCmd.cpp
@@ -352,7 +352,6 @@ void xParCmdRandomVelocityPar_Update(xParCmd* c, xParGroup* ps, F32 dt)
     }
 }
 
-#ifdef NON_MATCHING
 void xParCmdApplyWind_Update(xParCmd* c, xParGroup* ps, F32 dt)
 {
     xPar* p = ps->m_root;
@@ -369,7 +368,6 @@ void xParCmdApplyWind_Update(xParCmd* c, xParGroup* ps, F32 dt)
         p = p->m_next;
     }
 }
-#endif
 
 void xParCmdRotPar_Update(xParCmd* c, xParGroup* ps, F32 dt)
 {
@@ -404,7 +402,6 @@ void xParCmdVelocityApply_Update(xParCmd* c, xParGroup* ps, F32 dt)
     }
 }
 
-#ifdef NON_MATCHING
 void xParCmdRotateAround_Update(xParCmd* c, xParGroup* ps, F32 dt)
 {
     xPar* p = ps->m_root;
@@ -448,7 +445,6 @@ void xParCmdRotateAround_Update(xParCmd* c, xParGroup* ps, F32 dt)
         p = p->m_next;
     }
 }
-#endif
 
 void xParCmdTex_Update(xParCmd* c, xParGroup* ps, F32 dt)
 {
@@ -739,7 +735,6 @@ void xParCmd_DampenSpeed_Update(xParCmd* c, xParGroup* ps, F32 dt)
     }
 }
 
-#ifdef NON_MATCHING
 void xParCmd_SizeInOut_Update(xParCmd* c, xParGroup* ps, F32 dt)
 {
     xPar* p;
@@ -786,21 +781,16 @@ void xParCmd_SizeInOut_Update(xParCmd* c, xParGroup* ps, F32 dt)
         }
     }
 }
-#endif
 
-#if 0
 void xParCmd_AlphaInOut_Update(xParCmd* c, xParGroup* ps, F32 dt)
 {
     // todo: this is very similar to xParCmd_SizeInOut_Update
 }
-#endif
 
-#if 0
 void xParCmd_Shaper_Update(xParCmd* c, xParGroup* ps, F32 dt)
 {
     // todo: part of this is very similar to xParCmd_SizeInOut_Update
 }
-#endif
 
 WEAK F32 xVec3LengthFast(F32 x, F32 y, F32 z)
 {

--- a/src/SB/Core/x/xParGroup.cpp
+++ b/src/SB/Core/x/xParGroup.cpp
@@ -134,7 +134,6 @@ void xParGroupKillAllParticles(xParGroup* ps)
 
 #define clamp(x, a, b) (((x) < (a)) ? (a) : (((x) > (b)) ? (b) : (x)))
 
-#ifdef NON_MATCHING
 void xParGroupAnimate(xParGroup* ps, F32 dt)
 {
     xPar* i = ps->m_root;
@@ -175,7 +174,6 @@ void xParGroupAnimate(xParGroup* ps, F32 dt)
         }
     }
 }
-#endif
 
 void xParGroupAddParP(xParGroup* ps, xPar* p)
 {

--- a/src/SB/Core/x/xPartition.cpp
+++ b/src/SB/Core/x/xPartition.cpp
@@ -31,14 +31,11 @@ void PartitionSpaceInsert(_tagPartSpace* space, void* data)
     tmp->next->next = NULL;
 }
 
-#if 0
 // Need to figure out the correct order.
 S32 xPartitionGetTrueIdx(_tagPartition* part, S32 x_spaces, S32 y_spaces, S32 z_spaces)
 {
     return part->total_x * z_spaces + part->total_x * y_spaces * part->total_z + x_spaces;
 }
-
-#endif
 
 void xPartitionDump(_tagPartition*, char*)
 {

--- a/src/SB/Core/x/xQuickCull.cpp
+++ b/src/SB/Core/x/xQuickCull.cpp
@@ -2,10 +2,7 @@
 
 #include <types.h>
 
-#if 0
-// WIP.
-void xQuickCullInit(xQCControl* ctrl, F32 xmin, F32 ymin, F32 zmin, F32 xmax,
-                    F32 ymax, F32 zmax)
+void xQuickCullInit(xQCControl* ctrl, F32 xmin, F32 ymin, F32 zmin, F32 xmax, F32 ymax, F32 zmax)
 {
     ctrl->world_xmin = xmin;
     ctrl->world_ymin = ymin;
@@ -16,22 +13,19 @@ void xQuickCullInit(xQCControl* ctrl, F32 xmin, F32 ymin, F32 zmin, F32 xmax,
     ctrl->world_xsz = xmax - xmin;
     ctrl->world_ysz = ymax - ymin;
     ctrl->world_zsz = zmax - zmin;
-    fVar1 = @527;
-    if (((ctrl->world_xsz <= @526) || (ctrl->world_ysz <= @526)) || (ctrl->world_zsz <= @526))
+    if (((ctrl->world_xsz <= 0.0f) || (ctrl->world_ysz <= 0.0f)) || (ctrl->world_zsz <= 0.0f))
     {
-        ctrl->world_zsz = @527;
-        ctrl->world_ysz = fVar1;
-        ctrl->world_xsz = fVar1;
+        ctrl->world_zsz = 1.0f;
+        ctrl->world_ysz = 1.0f;
+        ctrl->world_xsz = 1.0f;
     }
-    ctrl->scale_x = @528 / ctrl->world_xsz;
-    ctrl->scale_y = @528 / ctrl->world_ysz;
-    ctrl->scale_z = @528 / ctrl->world_zsz;
-    ctrl->center_x = @529 * (xmax + xmin) + @529 / ctrl->scale_x;
-    ctrl->center_y = @529 * (ymax + ymin) + @529 / ctrl->scale_y;
-    ctrl->center_z = @529 * (zmax + zmin) + @529 / ctrl->scale_z;
+    ctrl->scale_x = 127.0f / ctrl->world_xsz;
+    ctrl->scale_y = 127.0f / ctrl->world_ysz;
+    ctrl->scale_z = 127.0f / ctrl->world_zsz;
+    ctrl->center_x = 0.5f * (xmax + xmin) + 0.5f / ctrl->scale_x;
+    ctrl->center_y = 0.5f * (ymax + ymin) + 0.5f / ctrl->scale_y;
+    ctrl->center_z = 0.5f * (zmax + zmin) + 0.5f / ctrl->scale_z;
 }
-
-#endif
 
 void xQuickCullInit(xQCControl* ctrl, const xBox* box)
 {
@@ -39,12 +33,9 @@ void xQuickCullInit(xQCControl* ctrl, const xBox* box)
                    box->upper.z);
 }
 
-#if 0
 // WIP.
 S32 xQuickCullIsects(const xQCData* a, const xQCData* b)
 {
     return a->xmin <= b->xmax && a->ymin <= b->ymax && a->zmin <= b->zmax && b->xmin <= a->xmax &&
            b->ymin <= a->ymax && b->zmin <= a->zmax;
 }
-
-#endif

--- a/src/SB/Core/x/xSFX.cpp
+++ b/src/SB/Core/x/xSFX.cpp
@@ -40,7 +40,6 @@ void xSFXInit(void* t, void* asset)
     xSFXInit((xSFX*)t, (xSFXAsset*)asset);
 }
 
-#ifdef NON_MATCHING
 void xSFXInit(xSFX* t, xSFXAsset* asset)
 {
     xBaseInit(t, asset);
@@ -65,7 +64,6 @@ void xSFXInit(xSFX* t, xSFXAsset* asset)
     t->asset->flagsSFX = t->asset->flagsSFX & 0xefff;
     t->cachedOuterDistSquared = (t->asset->outerRadius * t->asset->outerRadius);
 }
-#endif
 
 void xSFXSave(xSFX* ent, xSerial* s)
 {
@@ -82,12 +80,10 @@ void xSFXReset(xSFX* param_1)
     xBaseReset(param_1, param_1->asset);
 }
 
-#if 0
 U32 xSFXConvertFlags(U32 param_1)
 {
     return param_1 & 4 ? 0 : 0x800;
 }
-#endif
 
 void xSFXUpdate(xSFX* param_1)
 {

--- a/src/SB/Core/x/xSkyDome.cpp
+++ b/src/SB/Core/x/xSkyDome.cpp
@@ -22,7 +22,6 @@ void xSkyDome_Setup()
     sSkyCount = 0;
 }
 
-#ifdef NON_MATCHING
 void xSkyDome_AddEntity(xEnt* ent, S32 sortorder, S32 lockY)
 {
     S32 i, j;
@@ -63,7 +62,6 @@ void xSkyDome_AddEntity(xEnt* ent, S32 sortorder, S32 lockY)
     zEntEvent(ent, eEventCollisionOff);
     zEntEvent(ent, eEventCameraCollideOff);
 }
-#endif
 
 void xSkyDome_Render()
 {

--- a/src/SB/Core/x/xSnd.cpp
+++ b/src/SB/Core/x/xSnd.cpp
@@ -15,7 +15,6 @@ extern F32 _598;
 extern F32 _599;
 extern xSndGlobals gSnd;
 
-#ifdef NON_MATCHING
 void xSndInit()
 {
     iSndInit();
@@ -41,7 +40,6 @@ void xSndInit()
     xSndDelayedInit();
     reset_faders();
 }
-#endif
 
 void xSndSceneInit()
 {
@@ -93,7 +91,6 @@ void xSndSetCategoryVol(sound_category category, F32 vol)
     gSnd.categoryVolFader[category] = vol;
 }
 
-#ifdef NON_MATCHING
 void xSndDelayedInit()
 {
     for (int i = 0; i < 16; i++)
@@ -103,7 +100,6 @@ void xSndDelayedInit()
     }
     sDelayedPaused = 0;
 }
-#endif
 
 void xSndCalculateListenerPosition()
 {
@@ -131,7 +127,6 @@ void xSndCalculateListenerPosition()
     }
 }
 
-#ifdef NON_MATCHING
 void xSndInternalUpdateVoicePos(xSndVoiceInfo* pVoice)
 {
     U32 flags = pVoice->flags;
@@ -139,50 +134,50 @@ void xSndInternalUpdateVoicePos(xSndVoiceInfo* pVoice)
 
     if ((flags & 1) != 0)
     {
-        if ((flags & 8) != 0)
-        {
-            if ((flags & 0x10) != 0)
-            {
-                if (pVoice->parentPos == (xVec3*)0x0)
-                {
-                    if (pVoice->parentID == 0)
-                    {
-                        if ((flags & 8) == 0)
-                        {
-                            pVoice->actualPos = gSnd.pos;
-                        }
-                    }
-                    else
-                    {
-                        ent = pVoice->parentID & 0xfffffffc);
-                        if ((flags & 0x800) == 0)
-                        {
-                            if ((? & 1) == 0)
-                            {
-                                pVoice->flags = flags & 0xffffffef;
-                            }
-                            else
-                            {
-                                pxVar2 = (xVec3*)xEntGetPos((xEnt*)ent);
-                                xVec3Copy(pVoice->actualPos, ent);
-                            }
-                        }
-                        else
-                        {
-                            pVoice->actualPos = ent;
-                        }
-                    }
-                }
-                else
-                {
-                    pVoice->actualPos = pVoice->parentPos;
-                }
-            }
-            xSndProcessSoundPos(pVoice->actualPos, pVoice->playPos);
-        }
+        // FIXME: WIP
+        // if ((flags & 8) != 0)
+        // {
+        //     if ((flags & 0x10) != 0)
+        //     {
+        //         if (pVoice->parentPos == (xVec3*)0x0)
+        //         {
+        //             if (pVoice->parentID == 0)
+        //             {
+        //                 if ((flags & 8) == 0)
+        //                 {
+        //                     pVoice->actualPos = gSnd.pos;
+        //                 }
+        //             }
+        //             else
+        //             {
+        //                 ent = pVoice->parentID & 0xfffffffc);
+        //                 if ((flags & 0x800) == 0)
+        //                 {
+        //                     if ((? & 1) == 0)
+        //                     {
+        //                         pVoice->flags = flags & 0xffffffef;
+        //                     }
+        //                     else
+        //                     {
+        //                         pxVar2 = (xVec3*)xEntGetPos((xEnt*)ent);
+        //                         xVec3Copy(pVoice->actualPos, ent);
+        //                     }
+        //                 }
+        //                 else
+        //                 {
+        //                     pVoice->actualPos = ent;
+        //                 }
+        //             }
+        //         }
+        //         else
+        //         {
+        //             pVoice->actualPos = pVoice->parentPos;
+        //         }
+        //     }
+        //     xSndProcessSoundPos(pVoice->actualPos, pVoice->playPos);
+        // }
     }
 }
-#endif
 
 void xSndUpdate()
 {
@@ -216,24 +211,22 @@ void xSndExit()
     reset_faders();
 }
 
-U32 xSndPlay(U32 id, F32 vol, F32 pitch, U32 priority, U32 flags,
-                U32 parentID, sound_category category, F32 delay)
+U32 xSndPlay(U32 id, F32 vol, F32 pitch, U32 priority, U32 flags, U32 parentID,
+             sound_category category, F32 delay)
 {
     return xSndPlayInternal(id, vol, pitch, priority, flags, parentID, NULL, NULL, _598, _598,
                             category, delay);
 }
 
-U32 xSndPlay3D(U32 id, F32 vol, F32 pitch, U32 priority, U32 flags,
-                  xEnt* parent, F32 innerRadius, F32 outerRadius, sound_category category,
-                  F32 delay)
+U32 xSndPlay3D(U32 id, F32 vol, F32 pitch, U32 priority, U32 flags, xEnt* parent, F32 innerRadius,
+               F32 outerRadius, sound_category category, F32 delay)
 {
     return xSndPlayInternal(id, vol, pitch, priority, flags, NULL, parent, NULL, innerRadius,
                             outerRadius, category, delay);
 }
 
-U32 xSndPlay3D(U32 id, F32 vol, F32 pitch, U32 priority, U32 flags,
-                  const xVec3* pos, F32 innerRadius, F32 outerRadius,
-                  sound_category category, F32 delay)
+U32 xSndPlay3D(U32 id, F32 vol, F32 pitch, U32 priority, U32 flags, const xVec3* pos,
+               F32 innerRadius, F32 outerRadius, sound_category category, F32 delay)
 {
     if (flags & 0x800)
     {
@@ -311,7 +304,6 @@ void xSndSetExternalCallback(void (*callback)(U32))
     iSndSetExternalCallback(callback);
 }
 
-#if 0
 U32 xSndStreamReady(U32 owner)
 {
     xSndVoiceInfo* begin = gSnd.voice;
@@ -321,13 +313,12 @@ U32 xSndStreamReady(U32 owner)
     {
         if (v->lock_owner == owner)
         {
-            return (v->flags & 1) >> 5; // Missing cntlzw instruction.
+            return (v->flags & 1) >> 5; // FIXME: Missing cntlzw instruction.
         }
     }
 
     return 0;
 }
-#endif
 
 void xSndStreamUnlock(U32 owner)
 {

--- a/src/SB/Core/x/xordarray.cpp
+++ b/src/SB/Core/x/xordarray.cpp
@@ -57,35 +57,30 @@ void XOrdAppend(st_XORDEREDARRAY* array, void* elt)
     array->list[array->cnt++] = elt;
 }
 
-#if 0
-
 void XOrdInsert(st_XORDEREDARRAY* array, void* elt, XOrdCompareCallback compare)
 {
     if (array->cnt < array->max)
     {
         array->cnt++;
         S32 pos = array->cnt - 1;
-        void* currElement = pos * sizeof(void*);
+        void* currElement = (void*)(pos * sizeof(void*));
         while (pos > 0)
         {
-            S32 score = compare(array->list + currElement - sizeof(void*), elt);
-            if (score <= 0)
-            {
-                array->list[pos] = elt;
-                return;
-            }
-            pos--;
-            void* tmp = (void*)(array->list + currElement);
-            currElement--;
-            *tmp = tmp[-1];
+            // FIXME: currElement
+            // S32 score = compare(array->list + currElement - sizeof(void*), elt);
+            // if (score <= 0)
+            // {
+            //     array->list[pos] = elt;
+            //     return;
+            // }
+            // pos--;
+            // void* tmp = (void*)(array->list + currElement);
+            // currElement--;
+            // *tmp = tmp[-1];
         }
         *array->list = elt;
     }
 }
-
-#endif
-
-
 
 void* XOrdRemove(st_XORDEREDARRAY* array, void* elt, S32 index)
 {
@@ -134,7 +129,6 @@ void* XOrdRemove(st_XORDEREDARRAY* array, void* elt, S32 index)
     return elt;
 }
 
-#if 0
 S32 XOrdLookup(st_XORDEREDARRAY* array, const void* key, XOrdTestCallback test)
 {
     S32 v, index, rightBound, leftBound;
@@ -160,17 +154,15 @@ S32 XOrdLookup(st_XORDEREDARRAY* array, const void* key, XOrdTestCallback test)
     return index;
 }
 
-#endif
-
-#if 0
 void XOrdSort(st_XORDEREDARRAY* array, S32 (*test)(void*, void*))
 {
     void** list = array->list;
     S32 num = 1;
-    while (num <= cnt)
-    {
-        num = num * 3 + 1;
-    }
+    // FIXME: cnt??
+    // while (num <= cnt)
+    // {
+    //     num = num * 3 + 1;
+    // }
     for (;;)
     {
         if (num == 1)
@@ -182,11 +174,10 @@ void XOrdSort(st_XORDEREDARRAY* array, S32 (*test)(void*, void*))
         S32 numPos = num * sizeof(void*);
         void** currItem = list + num;
         S32 i = num;
-        while (i < cnt)
-        {
-            // TODO!!!
-        }
+        // FIXME: cnt??
+        // while (i < cnt)
+        // {
+        //     // TODO!!!
+        // }
     }
 }
-
-#endif

--- a/src/SB/Game/zActionLine.cpp
+++ b/src/SB/Game/zActionLine.cpp
@@ -45,7 +45,6 @@ void zActionLineUpdate(F32 seconds)
     }
 }
 
-#if 0
 void RenderActionLine(_tagActionLine* l)
 {
     static RxObjSpace3DVertex sStripVert[4];
@@ -87,7 +86,6 @@ void RenderActionLine(_tagActionLine* l)
         RwIm3DEnd();
     }
 }
-#endif
 
 void zActionLineRender()
 {

--- a/src/SB/Game/zCamera.cpp
+++ b/src/SB/Game/zCamera.cpp
@@ -111,7 +111,6 @@ extern F32 zCamera_f_3_141; // 3.141593 ~ pi
 extern F32 zCamera_f_20_0; // 20.0
 extern F32 zCamera_f_180_0; // 180.0
 
-#if 0
 void zCameraReset(xCamera* cam)
 {
     // classic multiple float assign non match
@@ -145,7 +144,6 @@ void zCameraReset(xCamera* cam)
     hMultiplier = zCamera_f_1_0;
     hOffset = zCamera_f_0_0;
 }
-#endif
 
 F32 GetCurrentPitch()
 {
@@ -274,7 +272,6 @@ F32 MatrixSpeed(zFlyKey keys[])
     return xacos(m) * zCamera_f_114_592 * zCamera_f_30_0;
 }
 
-#if 0
 void zCameraFlyStart(U32 assetID)
 {
     st_PKR_ASSET_TOCINFO info;
@@ -302,10 +299,9 @@ void zCameraFlyStart(U32 assetID)
         zMusicSetVolume(zCamera_f_0_5, zCamera_f_0_1);
     }
 }
-#endif
 
-void zCameraFreeLookSetGoals(xCamera* cam, F32 pitch_s, F32& dgoal, F32& hgoal,
-                             F32& pitch_goal, F32& lktm, F32 dt)
+void zCameraFreeLookSetGoals(xCamera* cam, F32 pitch_s, F32& dgoal, F32& hgoal, F32& pitch_goal,
+                             F32& lktm, F32 dt)
 {
     if (zcam_bbounce != 0)
     {
@@ -324,8 +320,8 @@ void zCameraFreeLookSetGoals(xCamera* cam, F32 pitch_s, F32& dgoal, F32& hgoal,
         if (zcam_longbounce != 0)
         {
             F32 len = xsqrt(zcam_playervel->x * zcam_playervel->x +
-                                zcam_playervel->y * zcam_playervel->y +
-                                zcam_playervel->z * zcam_playervel->z);
+                            zcam_playervel->y * zcam_playervel->y +
+                            zcam_playervel->z * zcam_playervel->z);
 
             bool lenValid = false;
             if (zcam_playervel != NULL)
@@ -421,7 +417,6 @@ void zCameraSetBbounce(S32 bbouncing)
     zcam_bbounce = bbouncing;
 }
 
-#if 0
 void zCameraSetLongbounce(S32 lbounce)
 {
     if (zcam_highbounce != 0 || zcam_longbounce != lbounce)
@@ -433,9 +428,7 @@ void zCameraSetLongbounce(S32 lbounce)
     // li r0 happens too early
     zcam_highbounce = 0;
 }
-#endif
 
-#if 0
 void zCameraSetHighbounce(S32 lbounce)
 {
     if (zcam_longbounce != 0 || zcam_highbounce != lbounce)
@@ -447,7 +440,6 @@ void zCameraSetHighbounce(S32 lbounce)
     // li r0 happens too early
     zcam_longbounce = 0;
 }
-#endif
 
 void zCameraSetPlayerVel(xVec3* vel)
 {

--- a/src/SB/Game/zCollGeom.cpp
+++ b/src/SB/Game/zCollGeom.cpp
@@ -78,7 +78,6 @@ U32 zCollGeom_EntSetup(xEnt* ent)
     return 0;
 }
 
-#ifdef NON_MATCHING
 void zCollGeom_Init()
 {
     sNumTables = xSTAssetCountByType('COLL');
@@ -133,7 +132,6 @@ void zCollGeom_Init()
         }
     }
 }
-#endif
 
 void zCollGeom_CamEnable(xEnt* ent)
 {

--- a/src/SB/Game/zCombo.cpp
+++ b/src/SB/Game/zCombo.cpp
@@ -109,24 +109,21 @@ void zCombo_Add(S32 arg0)
     }
 }
 
-#if 0
 // Can't get the floating point instructions to go in the right order
 // the zCombo_float32_3 = zCombo_float_minusone always gets lifted to the
 // start regardless of what order the code is in, despite it remaining
 // after the other assignments in the original assembly.
 void zCombo_Setup()
 {
-    zCombo_int32_3 = 0;
-    zCombo_int32_2 = 0;
-    zCombo_int32_1 = 0;
-    zCombo_float32_3 = zCombo_float_minusone;
+    // FIXME: define values
+    // zCombo_int32_3 = 0;
+    // zCombo_int32_2 = 0;
+    // zCombo_int32_1 = 0;
+    // zCombo_float32_3 = zCombo_float_minusone;
 
     // "HUD_TEXT_COMBOMESSAGE"
     U32 id = xStrHash(zCombo_Strings + 0xc1);
     comboHUD = (widget_chunk*)zSceneFindObject(id);
-
-    // Junk to make the size match temporarily, REMOVE THIS
-    zCombo_int32_3 = 6;
 
     if (comboHUD != NULL)
     {
@@ -156,7 +153,8 @@ void zCombo_Setup()
     comboReward[13].reward = globals.player.g.ShinyValueCombo13;
     comboReward[14].reward = globals.player.g.ShinyValueCombo14;
     comboReward[15].reward = globals.player.g.ShinyValueCombo15;
-    zCombo_float32_1 = globals.player.g.ComboTimer;
+    // FIXME: zCombo_float32_1
+    // zCombo_float32_1 = globals.player.g.ComboTimer;
 
     for (int i = 0; i < 16; ++i)
     {
@@ -165,51 +163,28 @@ void zCombo_Setup()
 
     // "TEXTBOX_BUNGEE_HELP"
     id = xStrHash(zCombo_Strings + 0xd7);
-    sHideText[0] = zSceneFindObject(id);
+    sHideText[0] = (ztextbox*)zSceneFindObject(id);
 
     // "DIALOG_TEXTBOX"
     id = xStrHash(zCombo_Strings + 0xeb);
-    sHideText[1] = zSceneFindObject(id);
+    sHideText[1] = (ztextbox*)zSceneFindObject(id);
 
     // "MESSAGE_02_TEXTBOX"
     id = xStrHash(zCombo_Strings + 0xfa);
-    sHideText[2] = zSceneFindObject(id);
+    sHideText[2] = (ztextbox*)zSceneFindObject(id);
 
     // "PROMPT_TEXTBOX"
     id = xStrHash(zCombo_Strings + 0x10d);
-    sHideText[3] = zSceneFindObject(id);
+    sHideText[3] = (ztextbox*)zSceneFindObject(id);
 
     // "QUIT_TEXTBOX"
     id = xStrHash(zCombo_Strings + 0x11c);
-    sHideText[4] = zSceneFindObject(id);
+    sHideText[4] = (ztextbox*)zSceneFindObject(id);
 
     // "MNU4 NPCTALK"
     id = xStrHash(zCombo_Strings + 0x129);
-    sHideUIF[0] = zSceneFindObject(id);
+    sHideUIF = (zUIFont*)zSceneFindObject(id);
 }
-#endif
-
-#if 0
-/* Can't figure out how to get the assignments to happen in the right order */
-void zCombo_Add(S32 points)
-{
-    if (zCombo_float32_3 < zCombo_float_zero)
-    {
-        zCombo_float32_3 = zCombo_float32_1;
-        zCombo_int32_1 = points - 1;
-    }
-    else
-    {
-        zCombo_float32_3 = zCombo_float32_1;
-        zCombo_int32_3 += points;
-        if (zCombo_int32_1 != 0)
-        {
-            zCombo_int32_3 += zCombo_int32_1;
-            zCombo_int32_1 = 0;
-        }
-    }
-}
-#endif
 
 void zComboHideMessage(xhud::widget& w, xhud::motive& motive)
 {
@@ -280,46 +255,47 @@ void zCombo_Update(F32 dt)
         comboTimer = temp_f0;
 
         temp_r0 = &comboReward[0];
-        
+
         if (comboTimer < 0.0f && temp_r0->reward > 0)
         {
-            zEntPickup_SpawnNRewards(comboReward->rewardList, comboReward->rewardNum, &sUnderCamPos);
+            zEntPickup_SpawnNRewards(comboReward->rewardList, comboReward->rewardNum,
+                                     &sUnderCamPos);
 
             switch (var_r31)
             {
             case 5:
-                zEntPlayer_SNDPlayStreamRandom(0, 1, ePlayerStreamSnd_Combo1, ePlayerStreamSnd_Combo2,
-                                            0.1f);
+                zEntPlayer_SNDPlayStreamRandom(0, 1, ePlayerStreamSnd_Combo1,
+                                               ePlayerStreamSnd_Combo2, 0.1f);
                 break;
             case 6:
             case 7:
-                zEntPlayer_SNDPlayStreamRandom(0, 2, ePlayerStreamSnd_Combo1, ePlayerStreamSnd_Combo2,
-                                            0.1f);
+                zEntPlayer_SNDPlayStreamRandom(0, 2, ePlayerStreamSnd_Combo1,
+                                               ePlayerStreamSnd_Combo2, 0.1f);
                 break;
             case 8:
             case 9:
-                zEntPlayer_SNDPlayStreamRandom(0, 3, ePlayerStreamSnd_Combo1, ePlayerStreamSnd_Combo2,
-                                            0.1f);
+                zEntPlayer_SNDPlayStreamRandom(0, 3, ePlayerStreamSnd_Combo1,
+                                               ePlayerStreamSnd_Combo2, 0.1f);
                 break;
             case 10:
-                zEntPlayer_SNDPlayStreamRandom(0, 4, ePlayerStreamSnd_Combo1, ePlayerStreamSnd_Combo2,
-                                            0.1f);
+                zEntPlayer_SNDPlayStreamRandom(0, 4, ePlayerStreamSnd_Combo1,
+                                               ePlayerStreamSnd_Combo2, 0.1f);
                 break;
             case 11:
             case 12:
-                zEntPlayer_SNDPlayStreamRandom(0, 5, ePlayerStreamSnd_Combo1, ePlayerStreamSnd_Combo2,
-                                            0.1f);
-                zEntPlayer_SNDPlayStreamRandom(6, 50, ePlayerStreamSnd_Combo1, ePlayerStreamSnd_Combo5,
-                                            0.1f);
+                zEntPlayer_SNDPlayStreamRandom(0, 5, ePlayerStreamSnd_Combo1,
+                                               ePlayerStreamSnd_Combo2, 0.1f);
+                zEntPlayer_SNDPlayStreamRandom(6, 50, ePlayerStreamSnd_Combo1,
+                                               ePlayerStreamSnd_Combo5, 0.1f);
                 break;
             case 13:
                 zEntPlayer_SNDPlayStreamRandom(0, 10, ePlayerStreamSnd_BigCombo1,
-                                            ePlayerStreamSnd_BigCombo2, 0.1f);
+                                               ePlayerStreamSnd_BigCombo2, 0.1f);
                 zEntPlayer_SNDPlayStream(11, 100, ePlayerStreamSnd_BigCombo1, 0x0);
                 break;
             case 14:
                 zEntPlayer_SNDPlayStreamRandom(0, 10, ePlayerStreamSnd_BigCombo1,
-                                            ePlayerStreamSnd_BigCombo2, 0.1f);
+                                               ePlayerStreamSnd_BigCombo2, 0.1f);
                 zEntPlayer_SNDPlayStream(21, 100, ePlayerStreamSnd_BigCombo1, 0x0);
                 break;
             case 15:
@@ -330,14 +306,14 @@ void zCombo_Update(F32 dt)
             if (comboHUD != NULL)
             {
                 comboHUD->w.add_motive(xhud::motive(NULL, comboDisplayTime, (F32)0.0f, (F32)0.0f,
-                                                    xhud::delay_motive_update, (void*)zComboHideMessage));
+                                                    xhud::delay_motive_update,
+                                                    (void*)zComboHideMessage));
             }
 
             comboTimer = -1.0f;
             comboCounter = 0;
             comboLastCounter = 0;
         }
-
     }
 }
 

--- a/src/SB/Game/zCutsceneMgr.cpp
+++ b/src/SB/Game/zCutsceneMgr.cpp
@@ -158,7 +158,6 @@ void zCutSceneNamesTable_clearAll()
     }
 }
 
-#ifdef NON_MATCHING
 void zCutsceneMgrPlayStart(zCutsceneMgr* t)
 {
     gCutsceneSkipOK = 1;
@@ -222,7 +221,6 @@ void zCutsceneMgrPlayStart(zCutsceneMgr* t)
         }
     }
 }
-#endif
 
 S32 zCutsceneMgrEventCB(xBase*, xBase* to, U32 toEvent, const F32*, xBase*)
 {
@@ -262,7 +260,6 @@ S32 zCutsceneMgrEventCB(xBase*, xBase* to, U32 toEvent, const F32*, xBase*)
     return 1;
 }
 
-#ifdef NON_MATCHING
 void zCutsceneMgrFinishLoad(xBase* to)
 {
     zCutsceneMgr* t = (zCutsceneMgr*)to;
@@ -285,9 +282,7 @@ void zCutsceneMgrFinishLoad(xBase* to)
     zEntEvent(&globals.player.ent, 4);
     return;
 }
-#endif
 
-#ifdef NON_MATCHING
 void zCutsceneMgrFinishExit(xBase* to)
 {
     zCutsceneMgr* t;
@@ -316,7 +311,6 @@ void zCutsceneMgrFinishExit(xBase* to)
     t->csn = NULL;
     globals.cmgr = NULL;
 }
-#endif
 
 void zCutsceneMgrKillFX(zCutsceneMgr* t)
 {

--- a/src/SB/Game/zDiscoFloor.cpp
+++ b/src/SB/Game/zDiscoFloor.cpp
@@ -55,9 +55,6 @@ namespace
         xLightKitLight light[1];
     } glow_light;
 
-#ifndef NON_MATCHING
-    void create_glow_light();
-#else
     void create_glow_light()
     {
         memset(&glow_light, 0, sizeof(glow_light));
@@ -75,7 +72,6 @@ namespace
 
         xLightKit_Prepare(&glow_light.kit);
     }
-#endif
 
     void destroy_glow_light()
     {
@@ -272,7 +268,8 @@ namespace
                 df.curr_note = 5.0f * -xurand() - 5.0f;
             }
 
-            F32 pitch = (df.curr_note >= 0) ? close_encounters[df.curr_note] : blues_scale[(S32)(6.0f * xurand() - 0.01f)];
+            F32 pitch = (df.curr_note >= 0) ? close_encounters[df.curr_note] :
+                                              blues_scale[(S32)(6.0f * xurand() - 0.01f)];
             F32 pitch_offset = pitch;
 
             if (df.transition_delay < 0.05f)
@@ -1033,7 +1030,6 @@ void z_disco_floor::render(S32 group)
     }
 }
 
-#ifdef NON_MATCHING
 void z_disco_floor::effects_render(S32 group)
 {
     F32 glow = pulse_glow[group];
@@ -1090,7 +1086,6 @@ void z_disco_floor::effects_render(S32 group)
         yoffset += dyoffset;
     }
 }
-#endif
 
 S32 z_disco_floor::event_handler(xBase*, xBase* to, U32 event, const F32* argf, xBase*)
 {

--- a/src/SB/Game/zDispatcher.cpp
+++ b/src/SB/Game/zDispatcher.cpp
@@ -70,7 +70,6 @@ void zDispatcher_sceneFinish()
     }
 }
 
-#ifdef NON_MATCHING
 // Compiler is optimizng the size calcuation and moving parameters for memset differently.
 st_ZDISPATCH_DATA* zDispatcher_memPool(S32 cnt)
 {
@@ -89,7 +88,6 @@ st_ZDISPATCH_DATA* zDispatcher_memPool(S32 cnt)
         return pool;
     }
 }
-#endif
 
 st_ZDISPATCH_DATA* zDispatcher_getInst(st_ZDISPATCH_DATA* pool, S32 idx)
 {
@@ -353,7 +351,6 @@ void zDispatcherStoreOptions()
     oldSFXVolume = zVarEntryCB_SndFXVol(NULL);
 }
 
-#ifdef NON_MATCHING
 // This is actually stupid. Loading parameter before assignment.
 void zDispatcherRestoreOptions()
 {
@@ -363,13 +360,10 @@ void zDispatcherRestoreOptions()
     WRAP_xsnd_setMusicVolume(oldMusicVolume);
     WRAP_xsnd_setSFXVolume(oldSFXVolume);
 }
-#endif
 
-#if 0
 // WIP
-// This switch is a mess, good luck.
-S32 ZDSP_elcb_event(xBase*, xBase* xb, U32 toEvent, const F32* toParam,
-                      xBase* toParamWidget)
+// FIXME: This switch is a mess, good luck.
+S32 ZDSP_elcb_event(xBase*, xBase* xb, U32 toEvent, const F32* toParam, xBase* toParamWidget)
 {
     st_ZDISPATCH_DATA* dspdata = (st_ZDISPATCH_DATA*)xb;
     switch (toEvent)
@@ -523,9 +517,7 @@ S32 ZDSP_elcb_event(xBase*, xBase* xb, U32 toEvent, const F32* toParam,
     }
     return 1;
 }
-#endif
 
-#if 0
 void WRAP_xsnd_setMusicVolume(S32 i)
 {
     float f1 = _1181 * i;
@@ -542,9 +534,7 @@ void WRAP_xsnd_setMusicVolume(S32 i)
     xSndSetCategoryVol(SND_CAT_MUSIC, f2);
     zMusicRefreshVolume();
 }
-#endif
 
-#if 0
 void WRAP_xsnd_setSFXVolume(S32 i)
 {
     F32 fcmp = _1181 * i; // - _1199;
@@ -562,4 +552,3 @@ void WRAP_xsnd_setSFXVolume(S32 i)
     xSndSetCategoryVol(SND_CAT_DIALOG, f);
     xSndSetCategoryVol(SND_CAT_UI, f);
 }
-#endif

--- a/src/SB/Game/zEGenerator.cpp
+++ b/src/SB/Game/zEGenerator.cpp
@@ -15,41 +15,39 @@ void zEGenerator_Init(void* egen, void* asset)
     zEGenerator_Init((zEGenerator*)egen, (xEntAsset*)asset);
 }
 
-#if 0
 // I can't figure out the 2nd parameter for the find asset function call.
+// FIXME: struct access offsets and callback definitions with suspect parameter typing
 void zEGenerator_Init(zEGenerator* egen, xEntAsset* asset)
 {
     zEntInit((zEnt*)egen, (xEntAsset*)asset, 'EGEN');
-    egen->zasset = asset;
+    // egen->zasset = asset;
     if (egen->linkCount != 0)
     {
-        egen->link = asset + 1;
+        // egen->link = asset + 1;
     }
     else
     {
         egen->link = NULL;
     }
-    egen->update = zEGenerator_Update;
-    egen->move = zEGenerator_Move;
-    egen->eventFunc = zEGenerator_EventCB;
-    egen->render = zEGenerator_Render;
+    // egen->update = zEGenerator_Update;
+    // egen->move = zEGenerator_Move;
+    // egen->eventFunc = zEGenerator_EventCB;
+    // egen->render = zEGenerator_Render;
     egen->afile = NULL;
-    if (asset->onAnimID)
-    {
-        void* buf = xSTFindAsset(asset->onAnimID, FREFREFRF);
-        if (buf != NULL)
-        {
-            egen->afile = xAnimFileNew(buf, &zEGeneratorStringBase[0], 0, NULL);
-            egen->atbl = xAnimTableNew(&zEGeneratorStringBase[0], NULL, 0);
-            xAnimTableNewState(egen->atbl, &zEGeneratorStringBase[1], 0x10, 0, lbl_803CD290, NULL,
-                               NULL, lbl_803CD294, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-            xAnimTableAddFile(egen->atbl, egen->afile, &zEGeneratorStringBase[1]);
-            xAnimPoolAlloc(globals.scenePreload->mempool, egen, egen->atbl, egen->model);
-        }
-    }
+    // if (asset->onAnimID)
+    // {
+    //     void* buf = xSTFindAsset(asset->onAnimID, FREFREFRF);
+    //     if (buf != NULL)
+    //     {
+    //         egen->afile = xAnimFileNew(buf, &zEGeneratorStringBase[0], 0, NULL);
+    //         egen->atbl = xAnimTableNew(&zEGeneratorStringBase[0], NULL, 0);
+    //         xAnimTableNewState(egen->atbl, &zEGeneratorStringBase[1], 0x10, 0, lbl_803CD290, NULL,
+    //                            NULL, lbl_803CD294, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
+    //         xAnimTableAddFile(egen->atbl, egen->afile, &zEGeneratorStringBase[1]);
+    //         xAnimPoolAlloc(globals.scenePreload->mempool, egen, egen->atbl, egen->model);
+    //     }
+    // }
 }
-
-#endif
 
 void zEGenerator_Setup(zEGenerator* egen, xScene* sc)
 {
@@ -116,7 +114,6 @@ void zEGenerator_Render(zEGenerator* egen)
     xEntRender((xEnt*)egen);
 }
 
-#if 0
 // WIP.
 void zEGenerator_TurnOn(zEGenerator* egen)
 {
@@ -124,17 +121,18 @@ void zEGenerator_TurnOn(zEGenerator* egen)
     zEGenAsset* zasset = (zEGenAsset*)egen->asset;
     if (egen->afile != NULL)
     {
-        egen->model->Anim->Single->CurrentSpeed = @679;
+        egen->model->Anim->Single->CurrentSpeed = 1.0f;
     }
     egen->tmr = zasset->ontime;
-    xMat4x3Toworld(&egen->src_pos, &egen->model->Mat, &egen->zasset->src_dpos);
+    xMat4x3Toworld(&egen->src_pos, (const xMat4x3*)&egen->model->Mat, &egen->zasset->src_dpos);
     if (egen->num_dsts)
     {
         // TODO!!!
     }
     else
     {
-        xDrawSphere(&egen->dst_pos, @856, 0xc006);
+        // FIXME: Find correct definition
+        // xDrawSphere(&egen->dst_pos, @856, 0xc006);
     }
     for (S32 i = 0; i < 2; i++)
     {
@@ -146,8 +144,6 @@ void zEGenerator_TurnOn(zEGenerator* egen)
     }
     // TODO!!!
 }
-
-#endif
 
 void zEGenerator_TurnOff(zEGenerator* egen)
 {
@@ -178,10 +174,9 @@ void zEGenerator_ToggleOn(zEGenerator* egen)
     }
 }
 
-#if 0
 // Need to figure out how to call the link function. Everything else should be in order as long as the case labels are correct.
 S32 zEGeneratorEventCB(xBase* to, xBase* from, U32 toEvent, const F32* toParam,
-                         xBase* toParamWidget)
+                       xBase* toParamWidget)
 {
     zEGenerator* egen = (zEGenerator*)from;
     switch (toEvent)
@@ -224,10 +219,10 @@ S32 zEGeneratorEventCB(xBase* to, xBase* from, U32 toEvent, const F32* toParam,
             break;
         if (toParamWidget->link == NULL)
             break;
-        toParamWidget->link(toParamWidget, egen->model, 0, 0);
+
+        // FIXME: xLinkAsset isn't a function call :(
+        // toParamWidget->link(toParamWidget, egen->model, 0, 0);
         break;
     }
     return eEventEnable;
 }
-
-#endif

--- a/src/SB/Game/zEntCruiseBubble.cpp
+++ b/src/SB/Game/zEntCruiseBubble.cpp
@@ -468,26 +468,19 @@ namespace cruise_bubble
 
                 if (s->streamed != 0)
                 {
-                   zEntPlayer_SNDPlayStream((_tagePlayerStreamSnd) i);
+                    zEntPlayer_SNDPlayStream((_tagePlayerStreamSnd)i);
                 }
                 else
                 {
-                    zEntPlayer_SNDPlay((_tagePlayerSnd) i, 0.0f);
+                    zEntPlayer_SNDPlay((_tagePlayerSnd)i, 0.0f);
                 }
 
                 s->handle = 0;
             }
             else
             {
-                s->handle = xSndPlay(
-                        (U32) s->id,
-                        s->volume * volFactor,
-                        0.0f,
-                        (U32) 128,
-                        (U32) 0,
-                        (U32) 0,
-                        SND_CAT_GAME,
-                        0.0f);
+                s->handle = xSndPlay((U32)s->id, s->volume * volFactor, 0.0f, (U32)128, (U32)0,
+                                     (U32)0, SND_CAT_GAME, 0.0f);
             }
 
             if (s->rumble != SDR_None)
@@ -505,17 +498,8 @@ namespace cruise_bubble
             {
                 // using float literals only the TOC address doesnt match
                 // -> will match when file is complete
-                s->handle = xSndPlay3D(
-                        s->id,
-                        s->volume * volFactor,
-                        0.0f,
-                        (U32) 128,
-                        (U32) 2048,
-                        pos,
-                        s->radius_inner,
-                        s->radius_outer,
-                        SND_CAT_GAME,
-                        0.0f);
+                s->handle = xSndPlay3D(s->id, s->volume * volFactor, 0.0f, (U32)128, (U32)2048, pos,
+                                       s->radius_inner, s->radius_outer, SND_CAT_GAME, 0.0f);
             }
 
             if (s->rumble != SDR_None)
@@ -882,7 +866,8 @@ namespace cruise_bubble
 
         void init_shrapnel()
         {
-            shared.droplet_shrapnel = (zShrapnelAsset*)xSTFindAsset(xStrHash("cruise_bubble_droplet_shrapnel"), NULL);
+            shared.droplet_shrapnel =
+                (zShrapnelAsset*)xSTFindAsset(xStrHash("cruise_bubble_droplet_shrapnel"), NULL);
         }
 
         void init_wake_ribbons()
@@ -895,12 +880,9 @@ namespace cruise_bubble
         bool check_launch()
         {
             bool can_cruise_bubble =
-            (
-                !(globals.player.ControlOff || globals.player.cheat_mode) &&
-                 globals.player.g.PowerUp[1] &&
-                (globals.player.s->pcType == ePlayer_SB) &&
-                (globals.pad0->pressed & 0x100)
-            );
+                (!(globals.player.ControlOff || globals.player.cheat_mode) &&
+                 globals.player.g.PowerUp[1] && (globals.player.s->pcType == ePlayer_SB) &&
+                 (globals.pad0->pressed & 0x100));
 
             if (!can_cruise_bubble)
             {
@@ -963,7 +945,8 @@ namespace cruise_bubble
             {
                 xAnimPlayStartTransition(
                     globals.player.ent.model->Anim,
-                    shared.atran.player.end); // [xAnimPlayStartTransition__FP9xAnimPlayP15xAnimTransition]
+                    shared.atran.player
+                        .end); // [xAnimPlayStartTransition__FP9xAnimPlayP15xAnimTransition]
             }
             exit_triggers(*globals.sceneCur);
         }
@@ -989,7 +972,8 @@ namespace cruise_bubble
         void load_settings()
         {
             U32 params_size;
-            xModelAssetParam* params = zEntGetModelParams(xStrHash("cruise_bubble_bind.MINF"), &params_size);
+            xModelAssetParam* params =
+                zEntGetModelParams(xStrHash("cruise_bubble_bind.MINF"), &params_size);
 
             if (params == NULL)
             {
@@ -1031,7 +1015,6 @@ namespace cruise_bubble
 
         void refresh_missle_model()
         {
-
         }
 
         void render_hud()
@@ -1209,10 +1192,6 @@ namespace cruise_bubble
             return screen_loc;
         }
 
-#ifndef NON_MATCHING
-        void damage_entity(xEnt& ent, const xVec3& loc, const xVec3& dir, const xVec3& hit_norm,
-                           F32 radius, bool explosive);
-#else
         void damage_entity(xEnt& ent, const xVec3& loc, const xVec3& dir, const xVec3& hit_norm,
                            F32 radius, bool explosive)
         {
@@ -1299,7 +1278,6 @@ namespace cruise_bubble
 
             zEntEvent(&ent, 0x1c7);
         }
-#endif
 
         void init_missle_model()
         {
@@ -1320,7 +1298,6 @@ namespace cruise_bubble
     } // namespace
 } // namespace cruise_bubble
 
-#ifdef NON_MATCHING
 void cruise_bubble::start_trail()
 {
     if (shared.flags & 0x80)
@@ -1332,9 +1309,8 @@ void cruise_bubble::start_trail()
     shared.fov_default = zEntCruiseBubble_f_0_0;
     shared.dialog_freq = zEntCruiseBubble_f_0_0;
 
-    refresh_trail(shared.trail.mat, shared.trail.dir);
+    cruise_bubble::refresh_trail(shared.trail.mat, shared.trail.dir);
 }
-#endif
 
 void cruise_bubble::state_type::start()
 {
@@ -1351,11 +1327,10 @@ void cruise_bubble::state_type::abort()
     // empty
 }
 
-#ifdef NON_MATCHING
 void cruise_bubble::update_player(xScene& s, F32 dt)
 {
     // register usage and stack scheduling differing
-    xVec3 pre_update_loc = get_player_loc();
+    xVec3 pre_update_loc = cruise_bubble::get_player_loc();
     xVec3 drive_motion;
 
     bool stop = zEntPlayer_MinimalUpdate(&globals.player.ent, &s, dt, drive_motion) ||
@@ -1363,7 +1338,7 @@ void cruise_bubble::update_player(xScene& s, F32 dt)
 
     if (!stop)
     {
-        shared.player_motion += get_player_loc() - pre_update_loc - drive_motion;
+        shared.player_motion += cruise_bubble::get_player_loc() - pre_update_loc - drive_motion;
 
         if (shared.player_motion.length2() > zEntCruiseBubble_f_0_25)
         {
@@ -1373,10 +1348,9 @@ void cruise_bubble::update_player(xScene& s, F32 dt)
 
     if (stop)
     {
-        kill(true, false);
+        cruise_bubble::kill(true, false);
     }
 }
-#endif
 
 void cruise_bubble::state_type::render()
 {
@@ -1436,7 +1410,6 @@ cruise_bubble::state_player_halt::state_player_halt() : state_type(STATE_PLAYER_
 {
 }
 
-#ifdef NON_MATCHING
 void cruise_bubble::reset_wake_ribbons()
 {
     wake_ribbon[0].set_default_config();
@@ -1467,9 +1440,7 @@ void cruise_bubble::reset_wake_ribbons()
     wake_ribbon[0].refresh_config();
     wake_ribbon[1].refresh_config();
 }
-#endif
 
-#ifdef NON_MATCHING
 void cruise_bubble::init_explode_decal()
 {
     explode_decal.init(1, "Cruise Bubble Explosion");
@@ -1486,9 +1457,7 @@ void cruise_bubble::init_explode_decal()
     explode_decal.set_texture("par_cruise_explosion");
     explode_decal.refresh_config();
 }
-#endif
 
-#ifdef NON_MATCHING
 void cruise_bubble::update_trail(F32 dt)
 {
     // will match once file complete
@@ -1515,7 +1484,7 @@ void cruise_bubble::update_trail(F32 dt)
 
     xMat4x3 end_mat;
     xQuat end_dir;
-    refresh_trail(end_mat, end_dir);
+    cruise_bubble::refresh_trail(end_mat, end_dir);
 
     // float cast
     F32 ds = zEntCruiseBubble_f_1_0 / (F32)samples;
@@ -1545,27 +1514,26 @@ void cruise_bubble::update_trail(F32 dt)
     shared.trail.dir = end_dir;
     shared.flags = shared.flags & 0xfffffeff;
 }
-#endif
 
-#ifdef NON_MATCHING
 void init_hud()
 {
     // should use stbu here and save an addi instruction
     // which should also fix the rest of the function by correcting offsets
-    hud.hiding = false;
-    hud.alpha = zEntCruiseBubble_f_0_0;
-    hud.alpha_vel = zEntCruiseBubble_f_0_0;
-    hud.glow = zEntCruiseBubble_f_0_0;
-    hud.gizmos_used = 0;
 
-    hud.model.reticle = load_model(xStrHash("ui_3dicon_reticle"));
-    hud.model.target = load_model(xStrHash("ui_3dicon_target_lock"));
-    hud.model.wind = load_model(xStrHash("ui_3dicon_missile_frame02"));
+    //FIXME: HUD is undefined
+    // hud.hiding = false;
+    // hud.alpha = zEntCruiseBubble_f_0_0;
+    // hud.alpha_vel = zEntCruiseBubble_f_0_0;
+    // hud.glow = zEntCruiseBubble_f_0_0;
+    // hud.gizmos_used = 0;
 
-    hud.uv_wind.init(hud.model.wind->Data);
-    hud.uv_wind.offset_vel.assign(current_tweak->hud.wind.du, current_tweak->hud.wind.dv);
+    // hud.model.reticle = load_model(xStrHash("ui_3dicon_reticle"));
+    // hud.model.target = load_model(xStrHash("ui_3dicon_target_lock"));
+    // hud.model.wind = load_model(xStrHash("ui_3dicon_missile_frame02"));
+
+    // hud.uv_wind.init(hud.model.wind->Data);
+    // hud.uv_wind.offset_vel.assign(current_tweak->hud.wind.du, current_tweak->hud.wind.dv);
 }
-#endif
 
 bool cruise_bubble::uv_animated_model::init(RpAtomic* m)
 {
@@ -1645,16 +1613,13 @@ void cruise_bubble::update_gizmo(cruise_bubble::hud_gizmo& gizmo, F32 dt)
                                   zEntCruiseBubble_f_1_0);
 }
 
-#ifdef NON_MATCHING
 void cruise_bubble::flash_hud()
 {
     // nice meme
     hud.glow = zEntCruiseBubble_f_1_0;
     hud.glow_vel = zEntCruiseBubble_f_n1_0 / current_tweak->hud.time_glow;
 }
-#endif
 
-#ifdef NON_MATCHING
 void cruise_bubble::render_timer(F32 alpha, F32 glow)
 {
     state_missle_fly* state = (state_missle_fly*)shared.state[THREAD_MISSLE];
@@ -1676,7 +1641,8 @@ void cruise_bubble::render_timer(F32 alpha, F32 glow)
                       screen_bounds);
     // register use for copying fields into font off, also causes a larger stack frame
     // also the color tags are loaded too early, should be just before the call
-    lerp(font.color, glow, zEntCruiseBubble_color_80_00_00_FF, zEntCruiseBubble_color_FF_14_14_FF);
+    cruise_bubble::lerp(font.color, glow, zEntCruiseBubble_color_80_00_00_FF,
+                        zEntCruiseBubble_color_FF_14_14_FF);
     font.color.a = (S32)(zEntCruiseBubble_f_255_0 * alpha + zEntCruiseBubble_f_0_5);
 
     basic_rect<F32> bound = font.bounds(buffer);
@@ -1685,9 +1651,7 @@ void cruise_bubble::render_timer(F32 alpha, F32 glow)
 
     font.render(buffer, x, y);
 }
-#endif
 
-#ifdef NON_MATCHING
 void cruise_bubble::update_hud(F32 dt)
 {
     if (hud.gizmos_used == 0)
@@ -1738,7 +1702,6 @@ void cruise_bubble::update_hud(F32 dt)
         hud.gizmo[i].flags &= 0xfffffffe;
     }
 }
-#endif
 
 void cruise_bubble::uv_animated_model::update(F32 dt)
 {
@@ -1754,7 +1717,6 @@ void cruise_bubble::uv_animated_model::update(F32 dt)
     this->refresh();
 }
 
-#ifdef NON_MATCHING
 void cruise_bubble::show_hud()
 {
     // scheduling and register usage off
@@ -1773,30 +1735,27 @@ void cruise_bubble::show_hud()
 
     flash_hud();
 }
-#endif
 
-#ifdef NON_MATCHING
 void cruise_bubble::hide_hud()
 {
     hud.gizmos_used = 0;
     // float scheduling ...
     hud.model.wind->Alpha = zEntCruiseBubble_f_0_0;
 }
-#endif
 
 void cruise_bubble::tweak_group::load(xModelAssetParam* params, U32 size)
 {
     this->register_tweaks(true, params, size, NULL);
 }
 
-void cruise_bubble::tweak_group::register_tweaks(bool init, xModelAssetParam* ap, U32 apsize, const char*)
+void cruise_bubble::tweak_group::register_tweaks(bool init, xModelAssetParam* ap, U32 apsize,
+                                                 const char*)
 {
     if (init)
     {
         this->aim_delay = zEntCruiseBubble_f_0_2;
-        auto_tweak::load_param<F32, F32>(this->aim_delay, 1.0f,
-                                         zEntCruiseBubble_f_0_0, 1.0f, ap, apsize,
-                                         "aim_delay");
+        auto_tweak::load_param<F32, F32>(this->aim_delay, 1.0f, zEntCruiseBubble_f_0_0, 1.0f, ap,
+                                         apsize, "aim_delay");
     }
 
     if (init)
@@ -1923,7 +1882,8 @@ void cruise_bubble::tweak_group::register_tweaks(bool init, xModelAssetParam* ap
         this->missle.fly.engine_pitch_sensitivity = zEntCruiseBubble_f_0_005;
         auto_tweak::load_param<F32, F32>(this->missle.fly.engine_pitch_sensitivity,
                                          zEntCruiseBubble_f_1_0, zEntCruiseBubble_f_0_0,
-                                         zEntCruiseBubble_f_1_0, ap, apsize, "missle.fly.engine_pitch_sensitivity");
+                                         zEntCruiseBubble_f_1_0, ap, apsize,
+                                         "missle.fly.engine_pitch_sensitivity");
     }
 
     if (init)
@@ -2289,8 +2249,7 @@ void cruise_bubble::tweak_group::register_tweaks(bool init, xModelAssetParam* ap
     if (init)
     {
         this->blast.emit = 300;
-        auto_tweak::load_param<U32, S32>(this->blast.emit, 1, 0, 0x3e8, ap, apsize,
-                                         "blast.emit");
+        auto_tweak::load_param<U32, S32>(this->blast.emit, 1, 0, 0x3e8, ap, apsize, "blast.emit");
     }
 
     if (init)
@@ -2531,7 +2490,6 @@ void cruise_bubble::tweak_group::register_tweaks(bool init, xModelAssetParam* ap
     }
 }
 
-#ifdef NON_MATCHING
 void cruise_bubble::init()
 {
     if ((shared.flags & 0x1) != 0x1)
@@ -2539,24 +2497,23 @@ void cruise_bubble::init()
         return;
     }
 
-    init_sound();
+    cruise_bubble::init_sound();
 
     shared.flags = shared.flags | 0x2;
 
-    load_settings();
-    init_states();
-    init_missle_model();
-    init_wake_ribbons();
-    init_explode_decal();
-    init_shrapnel();
-    init_hud();
-    init_debug();
+    cruise_bubble::load_settings();
+    cruise_bubble::init_states();
+    cruise_bubble::init_missle_model();
+    cruise_bubble::init_wake_ribbons();
+    cruise_bubble::init_explode_decal();
+    cruise_bubble::init_shrapnel();
+    cruise_bubble::init_hud();
+    cruise_bubble::init_debug();
 
     // scheduling off
     shared.fov_default = xCameraGetFOV(&globals.camera);
     shared.dialog_freq = current_tweak->dialog.freq;
 }
-#endif
 
 void cruise_bubble::reset()
 {
@@ -2567,7 +2524,6 @@ void cruise_bubble::reset()
     cruise_bubble::kill(true, false);
 }
 
-#ifdef NON_MATCHING
 void cruise_bubble::launch()
 {
     if ((shared.flags & 0x13) != 0x3)
@@ -2586,8 +2542,8 @@ void cruise_bubble::launch()
         current_tweak = &normal_tweak;
     }
 
-    reset_wake_ribbons();
-    reset_explode_decal();
+    cruise_bubble::reset_wake_ribbons();
+    cruise_bubble::reset_explode_decal();
 
     shared.flags = shared.flags | 0x14;
     shared.last_sp = shared.sp = globals.pad0->analog[0].offset;
@@ -2597,9 +2553,8 @@ void cruise_bubble::launch()
     shared.fov_default = xCameraGetFOV(&globals.camera);
 
     ztalkbox::permit(0x0, 0xffffffff);
-    set_state(THREAD_PLAYER, BEGIN_STATE_PLAYER);
+    cruise_bubble::set_state(THREAD_PLAYER, BEGIN_STATE_PLAYER);
 }
-#endif
 
 bool cruise_bubble::update(xScene* s, F32 dt)
 {
@@ -2664,7 +2619,6 @@ void cruise_bubble::render_screen()
     cruise_bubble::render_hud();
 }
 
-#ifdef NON_MATCHING
 void cruise_bubble::insert_player_animations(xAnimTable& table)
 {
     // not matching for different reasons
@@ -2683,12 +2637,14 @@ void cruise_bubble::insert_player_animations(xAnimTable& table)
                            zEntCruiseBubble_f_0_0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
 
     shared.astate.player.fire =
-        xAnimTableNewState(&table, "cruise_bubble_fire", 0x20, 0, zEntCruiseBubble_f_1_0, NULL, NULL,
-                           zEntCruiseBubble_f_0_0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
+        xAnimTableNewState(&table, "cruise_bubble_fire", 0x20, 0, zEntCruiseBubble_f_1_0, NULL,
+                           NULL, zEntCruiseBubble_f_0_0, NULL, NULL, xAnimDefaultBeforeEnter, NULL,
+                           NULL);
 
     shared.astate.player.idle =
-        xAnimTableNewState(&table, "cruise_bubble_idle", 0x10, 0, zEntCruiseBubble_f_1_0, NULL, NULL,
-                           zEntCruiseBubble_f_0_0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
+        xAnimTableNewState(&table, "cruise_bubble_idle", 0x10, 0, zEntCruiseBubble_f_1_0, NULL,
+                           NULL, zEntCruiseBubble_f_0_0, NULL, NULL, xAnimDefaultBeforeEnter, NULL,
+                           NULL);
 
     char* start_from = (char*)xMemPushTemp(0x250);
     memset(start_from, 0, 0x250);
@@ -2714,18 +2670,17 @@ void cruise_bubble::insert_player_animations(xAnimTable& table)
                                 zEntCruiseBubble_f_0_15, NULL);
 
     shared.atran.player.idle =
-        xAnimTableNewTransition(&table, "cruise_bubble_fire", "cruise_bubble_idle", NULL, NULL, 0x10,
-                                0, zEntCruiseBubble_f_0_0, zEntCruiseBubble_f_0_0, 0, 0,
+        xAnimTableNewTransition(&table, "cruise_bubble_fire", "cruise_bubble_idle", NULL, NULL,
+                                0x10, 0, zEntCruiseBubble_f_0_0, zEntCruiseBubble_f_0_0, 0, 0,
                                 zEntCruiseBubble_f_0_15, NULL);
 
     shared.atran.player.end =
-        xAnimTableNewTransition(&table, "cruise_bubble_aim cruise_bubble_fire cruise_bubble_idle", "Idle01", NULL, NULL, 0, 0,
-                                zEntCruiseBubble_f_0_0, zEntCruiseBubble_f_0_0, 0, 0,
-                                zEntCruiseBubble_f_0_15, NULL);
+        xAnimTableNewTransition(&table, "cruise_bubble_aim cruise_bubble_fire cruise_bubble_idle",
+                                "Idle01", NULL, NULL, 0, 0, zEntCruiseBubble_f_0_0,
+                                zEntCruiseBubble_f_0_0, 0, 0, zEntCruiseBubble_f_0_15, NULL);
 
     xMemPopTemp(start_from);
 }
-#endif
 
 bool cruise_bubble::active()
 {
@@ -2879,7 +2834,8 @@ cruise_bubble::state_enum cruise_bubble::state_player_halt::update(F32 dt)
     }
 
     xVec3 dmotion = shared.player_motion - this->last_motion;
-    if (dmotion.length2() < zEntCruiseBubble_f_0_0001) {
+    if (dmotion.length2() < zEntCruiseBubble_f_0_0001)
+    {
         return STATE_PLAYER_AIM;
     }
 
@@ -2913,7 +2869,8 @@ cruise_bubble::state_enum cruise_bubble::state_player_aim::update(F32 dt)
 {
     this->turn_delay += dt;
 
-    if (this->turn_delay >= current_tweak->aim_delay) {
+    if (this->turn_delay >= current_tweak->aim_delay)
+    {
         this->face_camera(dt);
     }
     this->apply_yaw();
@@ -2991,7 +2948,8 @@ void cruise_bubble::state_player_fire::start()
         play_sound(3, zEntCruiseBubble_f_1_0);
         shared.dialog_freq *= current_tweak->dialog.decay;
 
-        if (shared.dialog_freq < current_tweak->dialog.min_freq) {
+        if (shared.dialog_freq < current_tweak->dialog.min_freq)
+        {
             shared.dialog_freq = current_tweak->dialog.min_freq;
         }
     }
@@ -3050,7 +3008,8 @@ void cruise_bubble::state_missle_appear::start()
     cruise_bubble::show_missle();
     shared.missle_model->Flags = shared.missle_model->Flags & 0xfffe;
     shared.missle_model->Alpha = zEntCruiseBubble_f_1_0;
-    xAnimPlaySetState(shared.missle_model->Anim->Single, shared.astate.missle.fire, zEntCruiseBubble_f_0_0);
+    xAnimPlaySetState(shared.missle_model->Anim->Single, shared.astate.missle.fire,
+                      zEntCruiseBubble_f_0_0);
     this->move();
 }
 
@@ -3082,7 +3041,8 @@ cruise_bubble::state_enum cruise_bubble::state_missle_appear::update(F32 dt)
     }
     move();
 
-    if (time >= current_tweak->missle.appear.delay_fly) {
+    if (time >= current_tweak->missle.appear.delay_fly)
+    {
         return STATE_MISSLE_FLY;
     }
 
@@ -3095,7 +3055,6 @@ void cruise_bubble::state_missle_appear::update_effects(F32 dt)
     //empty
 }
 
-#ifdef NON_MATCHING
 void cruise_bubble::state_missle_fly::start()
 {
     // lwzu
@@ -3121,7 +3080,6 @@ void cruise_bubble::state_missle_fly::start()
     play_sound(2, zEntCruiseBubble_f_1_0, &cruise_bubble::get_missle_mat()->pos);
     signal_event(0x203);
 }
-#endif
 
 cruise_bubble::missle_record_data::missle_record_data(const xVec3& loc, F32 roll)
     : loc(loc), roll(roll)
@@ -3150,7 +3108,7 @@ void cruise_bubble::state_missle_fly::abort()
 
     xSphere o;
     o.center = zEntCruiseBubble_f_1_0e38;
-    o.r =zEntCruiseBubble_f_0_0;
+    o.r = zEntCruiseBubble_f_0_0;
     notify_triggers(*globals.sceneCur, o, xVec3::create(zEntCruiseBubble_f_0_0));
 }
 
@@ -3211,10 +3169,10 @@ void cruise_bubble::state_missle_fly::update_flash(F32 dt)
 void cruise_bubble::state_missle_fly::update_engine_sound(F32 dt)
 {
     F32 tmp = current_tweak->missle.fly.engine_pitch_max *
-    (iabs(shared.last_sp.x) + iabs(shared.last_sp.y));
+              (iabs(shared.last_sp.x) + iabs(shared.last_sp.y));
 
-    this->engine_pitch += (tmp - this->engine_pitch) *
-    current_tweak->missle.fly.engine_pitch_sensitivity;
+    this->engine_pitch +=
+        (tmp - this->engine_pitch) * current_tweak->missle.fly.engine_pitch_sensitivity;
 
     set_pitch(2, this->engine_pitch, 0);
 }
@@ -3238,7 +3196,6 @@ U8 cruise_bubble::state_missle_fly::collide_hazards()
     return true;
 }
 
-#ifdef NON_MATCHING
 bool cruise_bubble::state_missle_fly::hazard_check(NPCHazard& haz, void* context)
 {
     // get_missle_mat()->pos uses one more instruction for no apparent reason
@@ -3254,7 +3211,6 @@ bool cruise_bubble::state_missle_fly::hazard_check(NPCHazard& haz, void* context
 
     return true;
 }
-#endif
 
 U8 cruise_bubble::state_missle_fly::collide()
 {
@@ -3323,7 +3279,6 @@ U8 cruise_bubble::state_missle_fly::collide()
     return this->hit_test(*hit_loc, *hit_norm, hit_depen, hit_ent);
 }
 
-#ifdef NON_MATCHING
 U8 cruise_bubble::state_missle_fly::hit_test(xVec3& hit_loc, xVec3& hit_norm, xVec3& hit_depen,
                                              xEnt*& hit_ent) const
 {
@@ -3351,7 +3306,6 @@ U8 cruise_bubble::state_missle_fly::hit_test(xVec3& hit_loc, xVec3& hit_norm, xV
 
     return true;
 }
-#endif
 
 void cruise_bubble::state_missle_fly::update_move(F32 dt)
 {
@@ -3365,7 +3319,6 @@ void cruise_bubble::state_missle_fly::update_move(F32 dt)
     mat->pos += mat->at * move;
 }
 
-#ifdef NON_MATCHING
 void cruise_bubble::state_missle_explode::start()
 {
     shared.flags |= 0x40;
@@ -3383,7 +3336,6 @@ void cruise_bubble::state_missle_explode::start()
     play_sound(1, 1.0f, &get_missle_mat()->pos);
     this->start_effects();
 }
-#endif
 
 void cruise_bubble::state_missle_explode::stop()
 {
@@ -3403,7 +3355,6 @@ cruise_bubble::state_enum cruise_bubble::state_missle_explode::update(F32 dt)
     return STATE_MISSLE_EXPLODE;
 }
 
-#ifdef NON_MATCHING
 void cruise_bubble::state_camera_aim::start()
 {
     capture_camera();
@@ -3434,7 +3385,6 @@ void cruise_bubble::state_camera_aim::start()
     start_cam_mat = *mat;
     start_cam_mat.pos -= ploc;
 }
-#endif
 
 void cruise_bubble::state_camera_aim::stop()
 {
@@ -3545,7 +3495,8 @@ void cruise_bubble::state_camera_attach::start()
     capture_camera();
     xMat4x3* mat = get_missle_mat();
     xCameraMove(&globals.camera, mat->pos);
-    xCameraRotate(&globals.camera, *mat, zEntCruiseBubble_f_0_0, zEntCruiseBubble_f_0_0, zEntCruiseBubble_f_0_0);
+    xCameraRotate(&globals.camera, *mat, zEntCruiseBubble_f_0_0, zEntCruiseBubble_f_0_0,
+                  zEntCruiseBubble_f_0_0);
     xCameraSetFOV(&globals.camera, current_tweak->camera.seize.fov);
     distort_screen(zEntCruiseBubble_f_1_0);
 }
@@ -3568,7 +3519,8 @@ cruise_bubble::state_enum cruise_bubble::state_camera_attach::update(F32 dt)
 {
     xMat4x3* mat = get_missle_mat();
     xCameraMove(&globals.camera, mat->pos);
-    xCameraRotate(&globals.camera, *mat, zEntCruiseBubble_f_0_0, zEntCruiseBubble_f_0_0, zEntCruiseBubble_f_0_0);
+    xCameraRotate(&globals.camera, *mat, zEntCruiseBubble_f_0_0, zEntCruiseBubble_f_0_0,
+                  zEntCruiseBubble_f_0_0);
     this->lock_targets();
 
     return STATE_CAMERA_ATTACH;
@@ -3622,7 +3574,7 @@ cruise_bubble::state_enum cruise_bubble::state_camera_survey::update(F32 dt)
     }
 
     if (this->time >= current_tweak->camera.survey.min_duration &&
-            ((globals.pad0->pressed & 0x100) != 0 || this->control_jerked()))
+        ((globals.pad0->pressed & 0x100) != 0 || this->control_jerked()))
     {
         return STATE_CAMERA_RESTORE;
     }
@@ -3640,7 +3592,8 @@ void cruise_bubble::state_camera_restore::start()
     {
         xVec3 loc = get_player_loc() + start_cam_mat.pos;
         xCameraMove(&globals.camera, loc);
-        xCameraRotate(&globals.camera, start_cam_mat, zEntCruiseBubble_f_0_0, zEntCruiseBubble_f_0_0, zEntCruiseBubble_f_0_0);
+        xCameraRotate(&globals.camera, start_cam_mat, zEntCruiseBubble_f_0_0,
+                      zEntCruiseBubble_f_0_0, zEntCruiseBubble_f_0_0);
     }
 
     if (camera_taken())

--- a/src/SB/Game/zEntPlayer.cpp
+++ b/src/SB/Game/zEntPlayer.cpp
@@ -3515,15 +3515,14 @@ S32 zEntPlayer_IsSneaking()
     }
 }
 
-#if 0
 // The cmpw instruction used in `if ((S32)non_choices[j] - 1 == i)` has its
 // operands in the wrong order.
 S32 load_talk_filter(U8* filter, xModelAssetParam* params, U32 params_size, S32 max_size)
 {
     S32 found = 0;
     F32* non_choices = (F32*)xMemPushTemp(max_size * 4);
-    S32 size = zParamGetFloatList(params, params_size, zEntPlayer_Strings + 0x29ec, max_size,
-                                    non_choices, non_choices);
+    S32 size =
+        20; // FIXME Define zEntPlayer_Strings for line: zParamGetFloatList(params, params_size, zEntPlayer_Strings + 0x29ec, max_size, non_choices, non_choices);
 
     for (S32 i = 0; i < max_size; i++)
     {
@@ -3551,7 +3550,6 @@ S32 load_talk_filter(U8* filter, xModelAssetParam* params, U32 params_size, S32 
     xMemPopTemp(non_choices);
     return found;
 }
-#endif
 
 static U32 count_talk_anims(xAnimTable* anims)
 {
@@ -3580,13 +3578,10 @@ U8 BubbleBounceContrails(xAnimSingle* anim)
 {
     S32 ret = 0;
     xAnimState* state = anim->State;
-    if
-    (
+    if (
 
-        ((strcmp(state->Name, "BbounceStart01") == 0) && (anim->Time >= 0.9f))
-        ||
-        (strcmp(state->Name, "BbounceAttack01") == 0)
-    )
+        ((strcmp(state->Name, "BbounceStart01") == 0) && (anim->Time >= 0.9f)) ||
+        (strcmp(state->Name, "BbounceAttack01") == 0))
     {
         ret = 1;
     }
@@ -3597,14 +3592,9 @@ U8 BubbleBashContrails(xAnimSingle* anim)
 {
     S32 ret = 0;
     xAnimState* state = anim->State;
-    if
-    (
-        ((strcmp(state->Name, "BbashStart01") == 0) && (anim->Time >= 0.6f))
-        ||
+    if (((strcmp(state->Name, "BbashStart01") == 0) && (anim->Time >= 0.6f)) ||
         (strcmp(state->Name, "BbashAttack01") == 0) ||
-        (strcmp(state->Name, "BbashMiss01") == 0) &&
-        (anim->Time <= 0.125f)
-    )
+        (strcmp(state->Name, "BbashMiss01") == 0) && (anim->Time <= 0.125f))
     {
         ret = 1;
     }
@@ -3615,25 +3605,18 @@ U8 StunBubbleTrail(xAnimSingle* anim)
 {
     S32 ret = 0;
     xAnimState* state = anim->State;
-    if
-    (
-        (strcmp(state->Name, "StunFall") == 0)
-        ||
-        (
-        (strcmp(state->Name, "StunJump") == 0) &&
-        (anim->Time >= 0.6f) && (anim->Time <= 1.0f)
-        )
-    )
+    if ((strcmp(state->Name, "StunFall") == 0) ||
+        ((strcmp(state->Name, "StunJump") == 0) && (anim->Time >= 0.6f) && (anim->Time <= 1.0f)))
     {
         ret = 1;
     }
     return ret;
 }
-  
+
 F32 det3x3top1(float a, float b, float c, float d, float e, float f)
 {
-    F32 ret = -((a * f)  - ((b * f) -  (e * c)));
-    return    -((d * b)  - ((a * e) + ((d * c) + ret)));
+    F32 ret = -((a * f) - ((b * f) - (e * c)));
+    return -((d * b) - ((a * e) + ((d * c) + ret)));
 }
 
 void zEntPlayerExit(xEnt* ent)
@@ -3750,21 +3733,18 @@ S32 zEntPlayer_MoveInfo()
         flags |= 4;
     }
 
-    if (globals.player.IsBubbleSpinning || strcmp(animName,"Bspin01") == 0)
+    if (globals.player.IsBubbleSpinning || strcmp(animName, "Bspin01") == 0)
     {
         flags |= 0x20;
     }
 
-    if (strcmp(animName,"BbashStart01") == 0)
+    if (strcmp(animName, "BbashStart01") == 0)
     {
         flags |= 8;
     }
 
-    if 
-	(
-        (strcmp(animName,"BbounceStrike01") == 0) ||
-        (strcmp(animName,"BbounceStart01") == 0) ||
-        (strcmp(animName,"BbounceAttack01") == 0))
+    if ((strcmp(animName, "BbounceStrike01") == 0) || (strcmp(animName, "BbounceStart01") == 0) ||
+        (strcmp(animName, "BbounceAttack01") == 0))
     {
         flags |= 0x10;
     }
@@ -3893,22 +3873,22 @@ xVec3* GetPosVec(xBase* base)
 
     switch (base->baseType)
     {
-        case eBaseTypeMovePoint:
-            vec = ((xMovePoint*)(base))->pos;
-            break;
-        case eBaseTypeVillain:
-        case eBaseTypePlayer:
-        case eBaseTypePickup:
-        case eBaseTypePlatform:
-        case eBaseTypeDoor:
-        case eBaseTypeStatic:
-        case eBaseTypeDynamic:
-        case eBaseTypePendulum:
-        case eBaseTypeHangable:
-        case eBaseTypeButton:
-        case eBaseTypeDestructObj:
-            vec = (xVec3*)&(((xEnt*)(base))->model->Mat->pos);
-            break;
+    case eBaseTypeMovePoint:
+        vec = ((xMovePoint*)(base))->pos;
+        break;
+    case eBaseTypeVillain:
+    case eBaseTypePlayer:
+    case eBaseTypePickup:
+    case eBaseTypePlatform:
+    case eBaseTypeDoor:
+    case eBaseTypeStatic:
+    case eBaseTypeDynamic:
+    case eBaseTypePendulum:
+    case eBaseTypeHangable:
+    case eBaseTypeButton:
+    case eBaseTypeDestructObj:
+        vec = (xVec3*)&(((xEnt*)(base))->model->Mat->pos);
+        break;
     }
 
     return vec;
@@ -4849,237 +4829,504 @@ void xMat3x3RMulVec(xVec3* o, const xMat3x3* m, const xVec3* v)
 
 xAnimTable* zSandy_AnimTable()
 {
-	xAnimTable *animTable = xAnimTableNew("Sandy", NULL, 0);
-	
-    xAnimTableNewState(animTable, "Idle01",               0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Idle01b",              0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Idle01c",              0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Idle02",               0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Idle04",               0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Idle05",               0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Inactive_sleep",       0x20, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "SlipIdle01",           0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Inactive01",           0x20, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Inactive02",           0x20, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Hit01",                0x20, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Defeat01",             0x00, 0x0480, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Defeat02",             0x00, 0x0480, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Defeat03",             0x00, 0x0480, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Defeat04",             0x00, 0x0480, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "DefeatGoo",            0x00, 0x0480, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Walk01",               0x10, 0x0044, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Run01",                0x10, 0x0046, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "RunOutOfWorld01",      0x10, 0x0046, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "SlipRun01",            0x10, 0x0046, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "JumpStart01",          0x20, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "JumpLift01",           0x20, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "JumpApex01",           0x20, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Fall01",               0x10, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Land01",               0x20, 0x0000, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "LandRun01",            0x20, 0x0006, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "BounceStart01",        0x20, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "BounceLift01",         0x10, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "BounceApex01",         0x20, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "DJumpApex01",          0x20, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "FallHigh01",           0x10, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "LandHigh01",           0x20, 0x0000, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "LCopterHeadUp01",      0x20, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "LCopter01",            0x10, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "LedgeGrab01",          0x20, 0x0080, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "TailSlide01",          0x10, 0x1840, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "TailSlideJumpStart01", 0x20, 0x100a, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "TailSlideJumpApex01",  0x20, 0x100a, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "TailSlideFall01",      0x10, 0x100a, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "TailSlideLand01",      0x20, 0x100a, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "TailSlideDJumpApex01", 0x20, 0x100a, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Talk04",               0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Talk03",               0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Talk02",               0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Talk01",               0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "LassoSwingCatch01",    0x20, 0x0000, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "LassoSwingCatch02",    0x20, 0x0000, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "LassoSwing",           0x10, 0x0040, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "LassoSwingRelease",    0x20, 0x0000, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "SpatulaGrab01",        0x20, 0x0080, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "JumpMelee01",          0x20, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Melee01",              0x20, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "LassoWindup",          0x20, 0x0080, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "LassoThrow",           0x20, 0x0080, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "LassoFly",             0x10, 0x0080, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "LassoDestroy",         0x20, 0x0080, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "LassoAboutToDestroy",  0x10, 0x0080, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "LassoEnemyRope",       0x20, 0x0000, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "LassoEnemyFight",      0x10, 0x0000, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "LassoEnemyWin",        0x20, 0x0000, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "LassoEnemyLose",       0x20, 0x0000, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-	
-    xAnimTableNewTransition(animTable, "LandRun01", "Run01", NULL, NULL, 0x10, 0, 0.0, 0.0, 0, 0, 0.1, NULL);
-	
-    xAnimTableNewTransition(animTable, "Idle01b Idle01c Idle02 Idle04 Idle05 Inactive_sleep Inactive01 Inactive02 Land01 LandHigh01", "Idle01", NULL, IdleCB, 0x10, 0, 0.0, 0.0, 0, 0, 0.1, NULL);
-    xAnimTableNewTransition(animTable, "Idle01 Idle01b Idle01c Idle02 Idle04 Idle05 SlipIdle01 Inactive01 Inactive02 Inactive_sleep Walk01 LandRun01 Run01 SlipRun01", "LassoSwingCatch01", LassoSwingGroundedBeginCheck, LassoSwingGroundedBeginCB, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "JumpStart01 JumpApex01 Fall01 DJumpStart01 DJumpApex01 TailSlideJumpStart01 TailSlideJumpApex01 TailSlideFall01 TailSlideDJumpApex01 LCopter01 LCopterHeadUp01 BounceStart01 BounceLift01 BounceApex01", "LassoSwingCatch01", LassoSwingBeginCheck, LassoSwingBeginCB, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-	
-    xAnimTableNewTransition(animTable, "LassoSwingCatch01", "LassoSwingCatch02", NULL, LassoSwingTossCB, 0x10, 0, 0.0, 0.0, 0, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "LassoSwingCatch02",        "LassoSwing", NULL,     LassoSwingCB, 0x10, 0, 0.0, 0.0, 0, 0, 0.15, NULL);
-	
-    xAnimTableNewTransition(animTable, "LassoSwingCatch01 LassoSwingCatch02 LassoSwing", "SlipIdle01",            IdleSlipCheck, LassoSwingGroundedCB, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "LassoSwingCatch01 LassoSwingCatch02 LassoSwing", "Idle01",                    IdleCheck, LassoSwingGroundedCB, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "LassoSwingCatch01 LassoSwingCatch02 LassoSwing", "Walk01",                    WalkCheck, LassoSwingGroundedCB, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "LassoSwingCatch01 LassoSwingCatch02 LassoSwing", "Run01",                   RunAnyCheck, LassoSwingGroundedCB, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "LassoSwingCatch01 LassoSwingCatch02 LassoSwing", "RunOutOfWorld01",  RunOutOfWorldCheck, LassoSwingGroundedCB, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "LassoSwingCatch01 LassoSwingCatch02 LassoSwing", "SlipRun01",              RunSlipCheck, LassoSwingGroundedCB, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "LassoSwingCatch01 LassoSwingCatch02 LassoSwing", "Fall01",       LassoSwingReleaseCheck,  LassoSwingReleaseCB, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-	
-    xAnimTableNewTransition(animTable, "LassoWindup", "LassoThrow", NULL,  LassoThrowCB, 0x10, 0, 0.0, 0.0, 0, 0, 0.0, NULL);
-    xAnimTableNewTransition(animTable, "LassoThrow",  "LassoFly",   NULL,    LassoFlyCB, 0x10, 0, 0.0, 0.0, 0, 0, 0.0, NULL);
-	
-    xAnimTableNewTransition(animTable, "LassoEnemyRope", "LassoEnemyFight", NULL, NULL, 0x10, 0, 0.0, 0.0, 0, 0, 0.0, NULL);
-									   
-    xAnimTableNewTransition(animTable, "Melee01 JumpMelee01", "SlipIdle01",           IdleSlipCheck, MeleeStopCB, 0x10, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Melee01 JumpMelee01", "Idle01",                   IdleCheck, MeleeStopCB, 0x10, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Melee01 JumpMelee01", "Walk01",                   WalkCheck, MeleeStopCB, 0x10, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Melee01 JumpMelee01", "Run01",                  RunAnyCheck, MeleeStopCB, 0x10, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Melee01 JumpMelee01", "RunOutOfWorld01", RunOutOfWorldCheck, MeleeStopCB, 0x10, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Melee01 JumpMelee01", "SlipRun01",             RunSlipCheck, MeleeStopCB, 0x10, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-	
-    xAnimTableNewTransition(animTable, "JumpMelee01", "Fall01", NULL, NULL, 0x10, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-									   
-    xAnimTableNewTransition(animTable, "Idle01 Idle01b Idle01c Idle02 Idle04 Idle05 Inactive_sleep SlipIdle01 Inactive01 Inactive02 Walk01 Run01 Land01 LandRun01 ", "SpatulaGrab01", SpatulaGrabCheck, SpatulaGrabCB, 0, 0, 0.0, 0.0, 5, 0, 0.15, NULL);
-									   
-    xAnimTableNewTransition(animTable, "Melee01", "SpatulaGrab01", SpatulaGrabCheck, SpatulaMeleeStopCB, 0x00, 0, 0.0, 0.0, 5, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "SpatulaGrab01",  "Idle01",             NULL,  SpatulaGrabStopCB, 0x10, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-									   
-    xAnimTableNewTransition(animTable, "LassoEnemyWin LassoEnemyLose LassoDestroy", "SlipIdle01",           IdleSlipCheck,  LassoStopCB, 0x10, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "LassoEnemyWin LassoEnemyLose LassoDestroy", "Idle01",                   IdleCheck,  LassoStopCB, 0x10, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "LassoEnemyWin LassoEnemyLose LassoDestroy", "Walk01",                   WalkCheck,  LassoStopCB, 0x10, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "LassoEnemyWin LassoEnemyLose LassoDestroy", "Run01",                  RunAnyCheck,  LassoStopCB, 0x10, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "LassoEnemyWin LassoEnemyLose LassoDestroy", "RunOutOfWorld01", RunOutOfWorldCheck,  LassoStopCB, 0x10, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "LassoEnemyWin LassoEnemyLose LassoDestroy", "SlipRun01",             RunSlipCheck,  LassoStopCB, 0x10, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-									   
-    xAnimTableNewTransition(animTable, "DJumpApex01", "Fall01",     NULL, NULL, 0x10, 0, 0.0, 0.0, 0, 0, 0.20, NULL);
-    xAnimTableNewTransition(animTable, "JumpApex01",  "Fall01",     NULL, NULL, 0x10, 0, 0.0, 0.0, 0, 0, 0.08,  NULL);
-    xAnimTableNewTransition(animTable, "JumpStart01", "JumpApex01", NULL, NULL, 0x10, 0, 0.0, 0.0, 0, 0, 0.08,  NULL);
-									   
-    xAnimTableNewTransition(animTable, "Idle01 SlipIdle01 Walk01 Run01 RunOutOfWorld01 SlipRun01 Land01 LandHigh01 LandRun01 JumpStart01 JumpApex01 DJumpApex01 Fall01", "BounceStart01", BounceCheck, BounceCB, 0, 0, 0.0, 0.0, 0x0f, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "LCopterHeadUp01 LCopter01", "BounceStart01",   BounceCheck, BounceStopLCopterCB, 0x00, 0, 0.0, 0.0, 0x0f, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "BounceStart01",              "BounceLift01",          NULL,                NULL, 0x10, 0, 0.0, 0.0, 0x00, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "BounceLift01",               "BounceApex01", JumpApexCheck,                NULL, 0x00, 0, 0.0, 0.0, 0x01, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "BounceApex01",                     "Fall01",          NULL,                NULL, 0x10, 0, 0.0, 0.0, 0x00, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01 Idle01b Idle01c Idle02 Idle04 Idle05 SlipIdle01 Inactive01 Inactive02 Inactive_sleep Walk01 LandRun01 Run01 SlipRun01", "LassoWindup", LassoStartCheck, LassoStartCB, 0, 0, 0.0, 0.0, 2, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "JumpStart01 JumpLift01 JumpApex01 DJumpApex01 Fall01 BounceStart01 BounceLift01 BounceApex01", "JumpMelee01", MeleeCheck, JumpMeleeCB, 0, 0, 0.0, 0.0, 2, 0, 0.06, NULL);
-    xAnimTableNewTransition(animTable, "DJumpApex01", "JumpMelee01", MeleeCheck, JumpMeleeCB, 0, 0, 0.0, 0.0,2, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01 Idle01b Idle01c Idle02 Idle04 Idle05 SlipIdle01 Inactive01 Inactive02 Inactive_sleep Walk01 LandRun01 Land01 Run01 SlipRun01", "Melee01",           MeleeCheck,     MeleeCB, 0, 0, 0.0, 0.0, 2, 0, 0.00, NULL);
-    xAnimTableNewTransition(animTable, "LassoWindup LassoThrow LassoFly LassoDestroy LassoAboutToDestroy LassoEnemyRope LassoEnemyFight LassoEnemyWin LassoEnemyLose",         "Idle01", LassoLostTargetCheck, LassoStopCB, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-    
-	xAnimTableNewTransition(animTable, "LassoFly", "LassoDestroy",                 LassoStraightToDestroyCheck, LassoDestroyCB, 0, 0, 0.0, 0.0, 0, 0, 0.08, NULL);
-    xAnimTableNewTransition(animTable, "LassoDestroy", "LassoDestroy",                        LassoReyankCheck,    LassoYankCB, 0, 0, 0.0, 0.0, 0, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "LassoFly", "LassoAboutToDestroy",             LassoAboutToDestroyCheck, LassoDestroyCB, 0, 0, 0.0, 0.0, 0, 0, 0.08, NULL);
-    xAnimTableNewTransition(animTable, "LassoAboutToDestroy", "LassoDestroy",                LassoDestroyCheck,    LassoYankCB, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "LassoAboutToDestroy", "SlipIdle01",             LassoFailIdleSlipCheck,    LassoStopCB, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "LassoAboutToDestroy", "Idle01",                     LassoFailIdleCheck,    LassoStopCB, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "LassoAboutToDestroy", "Walk01",                     LassoFailWalkCheck,    LassoStopCB, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "LassoAboutToDestroy", "Run01",                       LassoFailRunCheck,    LassoStopCB, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "LassoAboutToDestroy", "RunOutOfWorld01",   LassoFailRunOutOfWorldCheck,    LassoStopCB, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "LassoAboutToDestroy", "SlipRun01",               LassoFailRunSlipCheck,    LassoStopCB, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-									   
-    xAnimTableNewTransition(animTable, "LCopter01 LCopterHeadUp01", "SlipIdle01",           IdleSlipCheck, StopLCopterCB, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "LCopter01 LCopterHeadUp01", "Idle01",                   IdleCheck, StopLCopterCB, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "LCopter01 LCopterHeadUp01", "Walk01",                   WalkCheck, StopLCopterCB, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "LCopter01 LCopterHeadUp01", "Run01",                  RunAnyCheck, StopLCopterCB, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "LCopter01 LCopterHeadUp01", "RunOutOfWorld01", RunOutOfWorldCheck, StopLCopterCB, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "LCopter01 LCopterHeadUp01", "SlipRun01",             RunSlipCheck, StopLCopterCB, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-									   
-    xAnimTableNewTransition(animTable, "Walk01 Run01 RunOutOfWorld01 LandRun01 Idle01 SlipRun01", "SlipIdle01", IdleSlipCheck, IdleCB, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Walk01 Run01 RunOutOfWorld01 LandRun01 SlipIdle01 SlipRun01", "Idle01", IdleCheck,     IdleCB, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-									   
-    xAnimTableNewTransition(animTable, "Idle01 Idle01b Idle01c Idle02 Idle04 Idle05 SlipIdle01 Inactive01 Inactive02 Inactive_sleep Run01 RunOutOfWorld01 SlipRun01 LandRun01 Land01 LandHigh01",   "Walk01",          WalkCheck, NULL, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01 Idle01b Idle01c Idle02 Idle04 Idle05 SlipIdle01 Inactive01 Inactive02 Inactive_sleep RunOutOfWorld01 SlipRun01 Walk01 Land01 LandHigh01",             "Run01",        RunAnyCheck, NULL, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01 Idle01b Idle01c Idle02 Idle04 Idle05 SlipIdle01 Inactive01 Inactive02 Inactive_sleep Run01 SlipRun01 Walk01 Land01 LandHigh01",             "RunOutOfWorld01", RunOutOfWorldCheck, NULL, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01 Idle01b Idle01c Idle02 Idle04 Idle05 SlipIdle01 Inactive01 Inactive02 Inactive_sleep Run01 RunOutOfWorld01 Walk01 Land01 LandHigh01",             "SlipRun01",       RunSlipCheck, NULL, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-									   
-    xAnimTableNewTransition(animTable, "Idle01 Idle01b Idle01c Idle02 Idle04 Idle05 SlipIdle01 Inactive01 Inactive02 Inactive_sleep Walk01 LandRun01 Run01 RunOutOfWorld01 SlipRun01 Land01 LandHigh01", "JumpStart01", JumpCheck, JumpCB, 0, 0, 0.0, 0.0, 0x0A, 0, 0.0, NULL);
-									   
-    xAnimTableNewTransition(animTable, "JumpStart01", "JumpApex01", JumpApexCheck, NULL, 0, 0, 0.0, 0.0, 1, 0, 0.1, NULL);
-    xAnimTableNewTransition(animTable, "JumpStart01 JumpApex01 Fall01 BounceStart01 BounceLift01 BounceApex01", "DJumpApex01", DblJumpCheck, DblJumpCB, 0, 0, 0.0, 0.0, 0x0A, 0, 0.1, NULL);
-    xAnimTableNewTransition(animTable, "LCopter01 LCopterHeadUp01", "Fall01", FallCheck, StopLCopterCB, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01 Idle01b Idle01c Idle02 Idle04 Idle05 SlipIdle01 Inactive01 Inactive02 Inactive_sleep Walk01 LandRun01 RunOutOfWorld01 Run01 SlipRun01 Land01 LandHigh01", "Fall01", FallCheck, NULL, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-    
-	xAnimTableNewTransition(animTable, "JumpApex01 DJumpApex01 Fall01", "Land01",             LandCheck, SandyLandCB, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "JumpApex01 DJumpApex01 Fall01", "SlipIdle01", LandSlipIdleCheck, SandyLandCB, 0, 0, 0.0, 0.0, 2, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "JumpApex01 DJumpApex01 Fall01", "LandRun01",      LandFastCheck, SandyLandCB, 0, 0, 0.0, 0.0, 3, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "JumpApex01 DJumpApex01 Fall01", "Walk01",         LandWalkCheck, SandyLandCB, 0, 0, 0.0, 0.0, 3, 0, 0.15, NULL);
-	xAnimTableNewTransition(animTable, "JumpApex01 DJumpApex01 Fall01", "SlipRun01",   LandSlipRunCheck, SandyLandCB, 0, 0, 0.0, 0.0, 4, 0, 0.15, NULL);
-	
-    xAnimTableNewTransition(animTable, "Fall01 DJumpApex01 TailSlideFall01 TailSlideDJumpApex01", "LCopterHeadUp01", LCopterCheck, LCopterCB, 0, 0, 0.0, 0.0, 8, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "LCopterHeadUp01", "LCopter01", NULL, NULL, 0x10, 0, 0.0, 0.0, 0, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "JumpStart01 JumpLift01 JumpApex01 Fall01 DJumpApex01 TailSlideJumpStart01 TailSlideJumpApex01 TailSlideFall01 TailSlideDJumpApex01 LCopter01 LCopterHeadUp01", "LedgeGrab01", LedgeGrabCheck, LedgeGrabCB, 0, 0, 0.0, 0.0, 0x0B, 0, 0.1, NULL);
-    xAnimTableNewTransition(animTable, "LedgeGrab01", "Idle01", NULL,LedgeFinishCB, 0x10, 0, 0.0, 0.0, 0, 0, 0.1, NULL);
-    xAnimTableNewTransition(animTable, "Idle01 Idle01b Idle01c Idle02 Idle04 Idle05 SlipIdle01 Inactive01 Inactive02 Inactive_sleep Walk01 LandRun01 Run01 RunOutOfWorld01 SlipRun01 JumpLift01 JumpApex01 Fall01 Land01 DJumpApex01 FallHigh01 LandHigh01 LCopter01 LCopterHeadUp01", "TailSlide01", SlideTrackCheck, SlideTrackCB, 0, 0, 0.0, 0.0, 9, 0, 0.15, NULL);
-    
-	xAnimTableNewTransition(animTable, "TailSlide01",                                                           "Idle01",  NoslideTrackCheck, NoslideTrackCB, 0x00, 0, 0.0, 0.0, 0x09, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "TailSlide01",                                                   "TailSlideFall01", TrackFallCheck,       TrackFallCB, 0x00, 0, 0.0, 0.0, 0x09, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "TailSlideDJumpApex01",                                          "TailSlideFall01", NULL,                        NULL, 0x10, 0, 0.0, 0.0, 0x00, 0, 0.20, NULL);
-    xAnimTableNewTransition(animTable, "TailSlideJumpApex01",                                           "TailSlideFall01", NULL,                        NULL, 0x10, 0, 0.0, 0.0, 0x00, 0, 0.08, NULL);
-    xAnimTableNewTransition(animTable, "TailSlideLand01",                                                   "TailSlide01", NULL,                        NULL, 0x10, 0, 0.0, 0.0, 0x00, 0, 0.08, NULL);
-    xAnimTableNewTransition(animTable, "TailSlideJumpStart01",                                      "TailSlideJumpApex01", NULL,                        NULL, 0x10, 0, 0.0, 0.0, 0x00, 0, 0.08, NULL);
-    xAnimTableNewTransition(animTable, "TailSlide01 TailSlideLand01",                              "TailSlideJumpStart01", JumpCheck,                 JumpCB, 0x00, 0, 0.0, 0.0, 0x0A, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "TailSlideJumpStart01 TailSlideJumpApex01 TailSlideFall01", "TailSlideJumpStart01", TrackPrefallJumpCheck,     JumpCB, 0x00, 0, 0.0, 0.0, 0x0F, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "TailSlideJumpStart01",                                      "TailSlideJumpApex01", JumpApexCheck,               NULL, 0x00, 0, 0.0, 0.0, 0x01, 0, 0.10, NULL);
-    xAnimTableNewTransition(animTable, "TailSlideJumpStart01 TailSlideJumpApex01 TailSlideFall01", "TailSlideDJumpApex01", DblJumpCheck,           DblJumpCB, 0x00, 0, 0.0, 0.0, 0x0A, 0, 0.10, NULL);
-									   
-    xAnimTableNewTransition(animTable, "TailSlideJumpStart01 TailSlideJumpApex01 TailSlideDJumpApex01 TailSlideFall01", "TailSlideLand01",      LandTrackCheck,   SlideTrackCB, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "TailSlideJumpStart01 TailSlideJumpApex01 TailSlideDJumpApex01 TailSlideFall01", "Land01",             LandNoTrackCheck, NoslideTrackCB, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "TailSlideJumpStart01 TailSlideJumpApex01 TailSlideDJumpApex01 TailSlideFall01", "LandRun01",      LandNoTrackFastCheck, NoslideTrackCB, 0, 0, 0.0, 0.0, 3, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "TailSlideJumpStart01 TailSlideJumpApex01 TailSlideDJumpApex01 TailSlideFall01", "Walk01",         LandNoTrackWalkCheck, NoslideTrackCB, 0, 0, 0.0, 0.0, 3, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "TailSlideJumpStart01 TailSlideJumpApex01 TailSlideDJumpApex01 TailSlideFall01", "SlipIdle01", LandNoTrackSlipIdleCheck, NoslideTrackCB, 0, 0, 0.0, 0.0, 4, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "TailSlideJumpStart01 TailSlideJumpApex01 TailSlideDJumpApex01 TailSlideFall01", "SlipRun01",   LandNoTrackSlipRunCheck, NoslideTrackCB, 0, 0, 0.0, 0.0, 4, 0, 0.15, NULL);
-									   
-	xAnimTableNewTransition(animTable, "Idle01 Idle01b Idle01c Idle02 Idle04 Idle05 SlipIdle01 Inactive01 Inactive02 Inactive_sleep Walk01 LandRun01 Run01 RunOutOfWorld01 SlipRun01 JumpLift01 JumpApex01 Fall01 Land01 DJumpApex01 FallHigh01 LandHigh01 LCopter01 LCopterHeadUp01 TailSlide01 TailSlideJumpStart01 TailSlideJumpApex01 TailSlideDJumpApex01 TailSlideFall01 TailSlideLand01", "Defeat01", Defeated01Check, DefeatedCB, 0, 4, 0.0, 0.0, 0x09, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01 Idle01b Idle01c Idle02 Idle04 Idle05 SlipIdle01 Inactive01 Inactive02 Inactive_sleep Walk01 LandRun01 Run01 RunOutOfWorld01 SlipRun01 JumpLift01 JumpApex01 Fall01 Land01 DJumpApex01 FallHigh01 LandHigh01 LCopter01 LCopterHeadUp01 TailSlide01 TailSlideJumpStart01 TailSlideJumpApex01 TailSlideDJumpApex01 TailSlideFall01 TailSlideLand01", "Defeat02", Defeated02Check, DefeatedCB, 0, 4, 0.0, 0.0, 0x09, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01 Idle01b Idle01c Idle02 Idle04 Idle05 SlipIdle01 Inactive01 Inactive02 Inactive_sleep Walk01 LandRun01 Run01 RunOutOfWorld01 SlipRun01 JumpLift01 JumpApex01 Fall01 Land01 DJumpApex01 FallHigh01 LandHigh01 LCopter01 LCopterHeadUp01 TailSlide01 TailSlideJumpStart01 TailSlideJumpApex01 TailSlideDJumpApex01 TailSlideFall01 TailSlideLand01", "Defeat03", Defeated03Check, DefeatedCB, 0, 4, 0.0, 0.0, 0x09, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01 Idle01b Idle01c Idle02 Idle04 Idle05 SlipIdle01 Inactive01 Inactive02 Inactive_sleep Walk01 LandRun01 Run01 RunOutOfWorld01 SlipRun01 JumpLift01 JumpApex01 Fall01 Land01 DJumpApex01 FallHigh01 LandHigh01 LCopter01 LCopterHeadUp01 TailSlide01 TailSlideJumpStart01 TailSlideJumpApex01 TailSlideDJumpApex01 TailSlideFall01 TailSlideLand01", "Defeat04", Defeated04Check, DefeatedCB, 0, 4, 0.0, 0.0, 0x09, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01 Idle01b Idle01c Idle02 Idle04 Idle05 SlipIdle01 Inactive01 Inactive02 Inactive_sleep Walk01 LandRun01 Run01 RunOutOfWorld01 SlipRun01 JumpLift01 JumpApex01 Fall01 Land01 DJumpApex01 FallHigh01 LandHigh01 LCopter01 LCopterHeadUp01 TailSlide01 TailSlideJumpStart01 TailSlideJumpApex01 TailSlideDJumpApex01 TailSlideFall01 TailSlideLand01", "DefeatGoo",       GooCheck, GooDeathCB, 0, 0, 0.0, 0.0, 0x1e, 0, 0.15, NULL);
-									   
-	xAnimTableNewTransition(animTable, "Idle01 Idle01b Idle01c Idle02 Idle04 Idle05 SlipIdle01 Inactive_sleep Inactive01 Inactive02 ", "Talk01", TalkCheck, NULL, 0, 0, 0.0, 0.0, 0x14, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01 Idle01b Idle01c Idle02 Idle04 Idle05 SlipIdle01 Inactive_sleep Inactive01 Inactive02 ", "Talk02", TalkCheck, NULL, 0, 1, 0.0, 0.0, 0x14, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01 Idle01b Idle01c Idle02 Idle04 Idle05 SlipIdle01 Inactive_sleep Inactive01 Inactive02 ", "Talk03", TalkCheck, NULL, 0, 2, 0.0, 0.0, 0x14, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01 Idle01b Idle01c Idle02 Idle04 Idle05 SlipIdle01 Inactive_sleep Inactive01 Inactive02 ", "Talk04", TalkCheck, NULL, 0, 3, 0.0, 0.0, 0x14, 0, 0.15, NULL);
-									   
-	xAnimTableNewTransition(animTable, "Talk01",     "Idle01",                TalkDoneCheck,      IdleCB, 0x00, 0x00000, 0.0, 0.0, 0x14, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Talk02",     "Idle01",                TalkDoneCheck,      IdleCB, 0x00, 0x00001, 0.0, 0.0, 0x14, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Talk03",     "Idle01",                TalkDoneCheck,      IdleCB, 0x00, 0x00002, 0.0, 0.0, 0x14, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Talk04",     "Idle01",                TalkDoneCheck,      IdleCB, 0x00, 0x00003, 0.0, 0.0, 0x14, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01",     "Idle01b",               InactiveCheck,  InactiveCB, 0x00, 0x80000, 0.0, 0.0, 0x01, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01",     "Idle01c",               InactiveCheck,  InactiveCB, 0x00, 0x80001, 0.0, 0.0, 0x01, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01",     "Idle02",                InactiveCheck,  InactiveCB, 0x00, 0x80002, 0.0, 0.0, 0x01, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01",     "Idle04",                InactiveCheck,  InactiveCB, 0x00, 0x80003, 0.0, 0.0, 0x01, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01",     "Idle05",                InactiveCheck,  InactiveCB, 0x00, 0x80004, 0.0, 0.0, 0x01, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01",     "Inactive_sleep",        InactiveCheck,  InactiveCB, 0x00, 0x80005, 0.0, 0.0, 0x01, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01",     "Inactive01",            InactiveCheck,  InactiveCB, 0x00, 0x80006, 0.0, 0.0, 0x01, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01",     "Inactive02",            InactiveCheck,  InactiveCB, 0x00, 0x80007, 0.0, 0.0, 0x01, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01b",    "Idle01",        InactiveFinishedCheck,      IdleCB, 0x00, 0x00000, 0.0, 0.0, 0x00, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01c",    "Idle01",        InactiveFinishedCheck,      IdleCB, 0x00, 0x00000, 0.0, 0.0, 0x00, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle02",     "Idle01",        InactiveFinishedCheck,      IdleCB, 0x00, 0x00000, 0.0, 0.0, 0x00, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle04",     "Idle01",        InactiveFinishedCheck,      IdleCB, 0x00, 0x00000, 0.0, 0.0, 0x00, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle05",     "Idle01",        InactiveFinishedCheck,      IdleCB, 0x00, 0x00000, 0.0, 0.0, 0x00, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Inactive01", "Idle01",                         NULL,      IdleCB, 0x10, 0x00000, 0.0, 0.0, 0x00, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Inactive02", "Idle01",                         NULL,      IdleCB, 0x10, 0x00000, 0.0, 0.0, 0x00, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Hit01",      "Idle01",                         NULL,      IdleCB, 0x10, 0x00000, 0.0, 0.0, 0x00, 0, 0.15, NULL);
-	
-	return animTable;
+    xAnimTable* animTable = xAnimTableNew("Sandy", NULL, 0);
+
+    xAnimTableNewState(animTable, "Idle01", 0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Idle01b", 0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Idle01c", 0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Idle02", 0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Idle04", 0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Idle05", 0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Inactive_sleep", 0x20, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "SlipIdle01", 0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Inactive01", 0x20, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Inactive02", 0x20, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Hit01", 0x20, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Defeat01", 0x00, 0x0480, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Defeat02", 0x00, 0x0480, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Defeat03", 0x00, 0x0480, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Defeat04", 0x00, 0x0480, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "DefeatGoo", 0x00, 0x0480, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Walk01", 0x10, 0x0044, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Run01", 0x10, 0x0046, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "RunOutOfWorld01", 0x10, 0x0046, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "SlipRun01", 0x10, 0x0046, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "JumpStart01", 0x20, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "JumpLift01", 0x20, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "JumpApex01", 0x20, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Fall01", 0x10, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Land01", 0x20, 0x0000, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "LandRun01", 0x20, 0x0006, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "BounceStart01", 0x20, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "BounceLift01", 0x10, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "BounceApex01", 0x20, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "DJumpApex01", 0x20, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "FallHigh01", 0x10, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "LandHigh01", 0x20, 0x0000, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "LCopterHeadUp01", 0x20, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "LCopter01", 0x10, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "LedgeGrab01", 0x20, 0x0080, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "TailSlide01", 0x10, 0x1840, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "TailSlideJumpStart01", 0x20, 0x100a, 1.0, NULL, NULL, 0.0, NULL,
+                       NULL, xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "TailSlideJumpApex01", 0x20, 0x100a, 1.0, NULL, NULL, 0.0, NULL,
+                       NULL, xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "TailSlideFall01", 0x10, 0x100a, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "TailSlideLand01", 0x20, 0x100a, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "TailSlideDJumpApex01", 0x20, 0x100a, 1.0, NULL, NULL, 0.0, NULL,
+                       NULL, xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Talk04", 0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Talk03", 0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Talk02", 0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Talk01", 0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "LassoSwingCatch01", 0x20, 0x0000, 1.0, NULL, NULL, 0.0, NULL,
+                       NULL, xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "LassoSwingCatch02", 0x20, 0x0000, 1.0, NULL, NULL, 0.0, NULL,
+                       NULL, xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "LassoSwing", 0x10, 0x0040, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "LassoSwingRelease", 0x20, 0x0000, 1.0, NULL, NULL, 0.0, NULL,
+                       NULL, xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "SpatulaGrab01", 0x20, 0x0080, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "JumpMelee01", 0x20, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Melee01", 0x20, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "LassoWindup", 0x20, 0x0080, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "LassoThrow", 0x20, 0x0080, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "LassoFly", 0x10, 0x0080, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "LassoDestroy", 0x20, 0x0080, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "LassoAboutToDestroy", 0x10, 0x0080, 1.0, NULL, NULL, 0.0, NULL,
+                       NULL, xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "LassoEnemyRope", 0x20, 0x0000, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "LassoEnemyFight", 0x10, 0x0000, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "LassoEnemyWin", 0x20, 0x0000, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "LassoEnemyLose", 0x20, 0x0000, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+
+    xAnimTableNewTransition(animTable, "LandRun01", "Run01", NULL, NULL, 0x10, 0, 0.0, 0.0, 0, 0,
+                            0.1, NULL);
+
+    xAnimTableNewTransition(
+        animTable,
+        "Idle01b Idle01c Idle02 Idle04 Idle05 Inactive_sleep Inactive01 Inactive02 Land01 LandHigh01",
+        "Idle01", NULL, IdleCB, 0x10, 0, 0.0, 0.0, 0, 0, 0.1, NULL);
+    xAnimTableNewTransition(
+        animTable,
+        "Idle01 Idle01b Idle01c Idle02 Idle04 Idle05 SlipIdle01 Inactive01 Inactive02 Inactive_sleep Walk01 LandRun01 Run01 SlipRun01",
+        "LassoSwingCatch01", LassoSwingGroundedBeginCheck, LassoSwingGroundedBeginCB, 0, 0, 0.0,
+        0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(
+        animTable,
+        "JumpStart01 JumpApex01 Fall01 DJumpStart01 DJumpApex01 TailSlideJumpStart01 TailSlideJumpApex01 TailSlideFall01 TailSlideDJumpApex01 LCopter01 LCopterHeadUp01 BounceStart01 BounceLift01 BounceApex01",
+        "LassoSwingCatch01", LassoSwingBeginCheck, LassoSwingBeginCB, 0, 0, 0.0, 0.0, 1, 0, 0.15,
+        NULL);
+
+    xAnimTableNewTransition(animTable, "LassoSwingCatch01", "LassoSwingCatch02", NULL,
+                            LassoSwingTossCB, 0x10, 0, 0.0, 0.0, 0, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "LassoSwingCatch02", "LassoSwing", NULL, LassoSwingCB, 0x10,
+                            0, 0.0, 0.0, 0, 0, 0.15, NULL);
+
+    xAnimTableNewTransition(animTable, "LassoSwingCatch01 LassoSwingCatch02 LassoSwing",
+                            "SlipIdle01", IdleSlipCheck, LassoSwingGroundedCB, 0, 0, 0.0, 0.0, 1, 0,
+                            0.15, NULL);
+    xAnimTableNewTransition(animTable, "LassoSwingCatch01 LassoSwingCatch02 LassoSwing", "Idle01",
+                            IdleCheck, LassoSwingGroundedCB, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "LassoSwingCatch01 LassoSwingCatch02 LassoSwing", "Walk01",
+                            WalkCheck, LassoSwingGroundedCB, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "LassoSwingCatch01 LassoSwingCatch02 LassoSwing", "Run01",
+                            RunAnyCheck, LassoSwingGroundedCB, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "LassoSwingCatch01 LassoSwingCatch02 LassoSwing",
+                            "RunOutOfWorld01", RunOutOfWorldCheck, LassoSwingGroundedCB, 0, 0, 0.0,
+                            0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "LassoSwingCatch01 LassoSwingCatch02 LassoSwing",
+                            "SlipRun01", RunSlipCheck, LassoSwingGroundedCB, 0, 0, 0.0, 0.0, 1, 0,
+                            0.15, NULL);
+    xAnimTableNewTransition(animTable, "LassoSwingCatch01 LassoSwingCatch02 LassoSwing", "Fall01",
+                            LassoSwingReleaseCheck, LassoSwingReleaseCB, 0, 0, 0.0, 0.0, 1, 0, 0.15,
+                            NULL);
+
+    xAnimTableNewTransition(animTable, "LassoWindup", "LassoThrow", NULL, LassoThrowCB, 0x10, 0,
+                            0.0, 0.0, 0, 0, 0.0, NULL);
+    xAnimTableNewTransition(animTable, "LassoThrow", "LassoFly", NULL, LassoFlyCB, 0x10, 0, 0.0,
+                            0.0, 0, 0, 0.0, NULL);
+
+    xAnimTableNewTransition(animTable, "LassoEnemyRope", "LassoEnemyFight", NULL, NULL, 0x10, 0,
+                            0.0, 0.0, 0, 0, 0.0, NULL);
+
+    xAnimTableNewTransition(animTable, "Melee01 JumpMelee01", "SlipIdle01", IdleSlipCheck,
+                            MeleeStopCB, 0x10, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Melee01 JumpMelee01", "Idle01", IdleCheck, MeleeStopCB,
+                            0x10, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Melee01 JumpMelee01", "Walk01", WalkCheck, MeleeStopCB,
+                            0x10, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Melee01 JumpMelee01", "Run01", RunAnyCheck, MeleeStopCB,
+                            0x10, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Melee01 JumpMelee01", "RunOutOfWorld01", RunOutOfWorldCheck,
+                            MeleeStopCB, 0x10, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Melee01 JumpMelee01", "SlipRun01", RunSlipCheck,
+                            MeleeStopCB, 0x10, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
+
+    xAnimTableNewTransition(animTable, "JumpMelee01", "Fall01", NULL, NULL, 0x10, 0, 0.0, 0.0, 1, 0,
+                            0.15, NULL);
+
+    xAnimTableNewTransition(
+        animTable,
+        "Idle01 Idle01b Idle01c Idle02 Idle04 Idle05 Inactive_sleep SlipIdle01 Inactive01 Inactive02 Walk01 Run01 Land01 LandRun01 ",
+        "SpatulaGrab01", SpatulaGrabCheck, SpatulaGrabCB, 0, 0, 0.0, 0.0, 5, 0, 0.15, NULL);
+
+    xAnimTableNewTransition(animTable, "Melee01", "SpatulaGrab01", SpatulaGrabCheck,
+                            SpatulaMeleeStopCB, 0x00, 0, 0.0, 0.0, 5, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "SpatulaGrab01", "Idle01", NULL, SpatulaGrabStopCB, 0x10, 0,
+                            0.0, 0.0, 1, 0, 0.15, NULL);
+
+    xAnimTableNewTransition(animTable, "LassoEnemyWin LassoEnemyLose LassoDestroy", "SlipIdle01",
+                            IdleSlipCheck, LassoStopCB, 0x10, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "LassoEnemyWin LassoEnemyLose LassoDestroy", "Idle01",
+                            IdleCheck, LassoStopCB, 0x10, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "LassoEnemyWin LassoEnemyLose LassoDestroy", "Walk01",
+                            WalkCheck, LassoStopCB, 0x10, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "LassoEnemyWin LassoEnemyLose LassoDestroy", "Run01",
+                            RunAnyCheck, LassoStopCB, 0x10, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "LassoEnemyWin LassoEnemyLose LassoDestroy",
+                            "RunOutOfWorld01", RunOutOfWorldCheck, LassoStopCB, 0x10, 0, 0.0, 0.0,
+                            1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "LassoEnemyWin LassoEnemyLose LassoDestroy", "SlipRun01",
+                            RunSlipCheck, LassoStopCB, 0x10, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
+
+    xAnimTableNewTransition(animTable, "DJumpApex01", "Fall01", NULL, NULL, 0x10, 0, 0.0, 0.0, 0, 0,
+                            0.20, NULL);
+    xAnimTableNewTransition(animTable, "JumpApex01", "Fall01", NULL, NULL, 0x10, 0, 0.0, 0.0, 0, 0,
+                            0.08, NULL);
+    xAnimTableNewTransition(animTable, "JumpStart01", "JumpApex01", NULL, NULL, 0x10, 0, 0.0, 0.0,
+                            0, 0, 0.08, NULL);
+
+    xAnimTableNewTransition(
+        animTable,
+        "Idle01 SlipIdle01 Walk01 Run01 RunOutOfWorld01 SlipRun01 Land01 LandHigh01 LandRun01 JumpStart01 JumpApex01 DJumpApex01 Fall01",
+        "BounceStart01", BounceCheck, BounceCB, 0, 0, 0.0, 0.0, 0x0f, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "LCopterHeadUp01 LCopter01", "BounceStart01", BounceCheck,
+                            BounceStopLCopterCB, 0x00, 0, 0.0, 0.0, 0x0f, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "BounceStart01", "BounceLift01", NULL, NULL, 0x10, 0, 0.0,
+                            0.0, 0x00, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "BounceLift01", "BounceApex01", JumpApexCheck, NULL, 0x00, 0,
+                            0.0, 0.0, 0x01, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "BounceApex01", "Fall01", NULL, NULL, 0x10, 0, 0.0, 0.0,
+                            0x00, 0, 0.15, NULL);
+    xAnimTableNewTransition(
+        animTable,
+        "Idle01 Idle01b Idle01c Idle02 Idle04 Idle05 SlipIdle01 Inactive01 Inactive02 Inactive_sleep Walk01 LandRun01 Run01 SlipRun01",
+        "LassoWindup", LassoStartCheck, LassoStartCB, 0, 0, 0.0, 0.0, 2, 0, 0.15, NULL);
+    xAnimTableNewTransition(
+        animTable,
+        "JumpStart01 JumpLift01 JumpApex01 DJumpApex01 Fall01 BounceStart01 BounceLift01 BounceApex01",
+        "JumpMelee01", MeleeCheck, JumpMeleeCB, 0, 0, 0.0, 0.0, 2, 0, 0.06, NULL);
+    xAnimTableNewTransition(animTable, "DJumpApex01", "JumpMelee01", MeleeCheck, JumpMeleeCB, 0, 0,
+                            0.0, 0.0, 2, 0, 0.15, NULL);
+    xAnimTableNewTransition(
+        animTable,
+        "Idle01 Idle01b Idle01c Idle02 Idle04 Idle05 SlipIdle01 Inactive01 Inactive02 Inactive_sleep Walk01 LandRun01 Land01 Run01 SlipRun01",
+        "Melee01", MeleeCheck, MeleeCB, 0, 0, 0.0, 0.0, 2, 0, 0.00, NULL);
+    xAnimTableNewTransition(
+        animTable,
+        "LassoWindup LassoThrow LassoFly LassoDestroy LassoAboutToDestroy LassoEnemyRope LassoEnemyFight LassoEnemyWin LassoEnemyLose",
+        "Idle01", LassoLostTargetCheck, LassoStopCB, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
+
+    xAnimTableNewTransition(animTable, "LassoFly", "LassoDestroy", LassoStraightToDestroyCheck,
+                            LassoDestroyCB, 0, 0, 0.0, 0.0, 0, 0, 0.08, NULL);
+    xAnimTableNewTransition(animTable, "LassoDestroy", "LassoDestroy", LassoReyankCheck,
+                            LassoYankCB, 0, 0, 0.0, 0.0, 0, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "LassoFly", "LassoAboutToDestroy", LassoAboutToDestroyCheck,
+                            LassoDestroyCB, 0, 0, 0.0, 0.0, 0, 0, 0.08, NULL);
+    xAnimTableNewTransition(animTable, "LassoAboutToDestroy", "LassoDestroy", LassoDestroyCheck,
+                            LassoYankCB, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "LassoAboutToDestroy", "SlipIdle01", LassoFailIdleSlipCheck,
+                            LassoStopCB, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "LassoAboutToDestroy", "Idle01", LassoFailIdleCheck,
+                            LassoStopCB, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "LassoAboutToDestroy", "Walk01", LassoFailWalkCheck,
+                            LassoStopCB, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "LassoAboutToDestroy", "Run01", LassoFailRunCheck,
+                            LassoStopCB, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "LassoAboutToDestroy", "RunOutOfWorld01",
+                            LassoFailRunOutOfWorldCheck, LassoStopCB, 0, 0, 0.0, 0.0, 1, 0, 0.15,
+                            NULL);
+    xAnimTableNewTransition(animTable, "LassoAboutToDestroy", "SlipRun01", LassoFailRunSlipCheck,
+                            LassoStopCB, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
+
+    xAnimTableNewTransition(animTable, "LCopter01 LCopterHeadUp01", "SlipIdle01", IdleSlipCheck,
+                            StopLCopterCB, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "LCopter01 LCopterHeadUp01", "Idle01", IdleCheck,
+                            StopLCopterCB, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "LCopter01 LCopterHeadUp01", "Walk01", WalkCheck,
+                            StopLCopterCB, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "LCopter01 LCopterHeadUp01", "Run01", RunAnyCheck,
+                            StopLCopterCB, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "LCopter01 LCopterHeadUp01", "RunOutOfWorld01",
+                            RunOutOfWorldCheck, StopLCopterCB, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "LCopter01 LCopterHeadUp01", "SlipRun01", RunSlipCheck,
+                            StopLCopterCB, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
+
+    xAnimTableNewTransition(animTable, "Walk01 Run01 RunOutOfWorld01 LandRun01 Idle01 SlipRun01",
+                            "SlipIdle01", IdleSlipCheck, IdleCB, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable,
+                            "Walk01 Run01 RunOutOfWorld01 LandRun01 SlipIdle01 SlipRun01", "Idle01",
+                            IdleCheck, IdleCB, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
+
+    xAnimTableNewTransition(
+        animTable,
+        "Idle01 Idle01b Idle01c Idle02 Idle04 Idle05 SlipIdle01 Inactive01 Inactive02 Inactive_sleep Run01 RunOutOfWorld01 SlipRun01 LandRun01 Land01 LandHigh01",
+        "Walk01", WalkCheck, NULL, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(
+        animTable,
+        "Idle01 Idle01b Idle01c Idle02 Idle04 Idle05 SlipIdle01 Inactive01 Inactive02 Inactive_sleep RunOutOfWorld01 SlipRun01 Walk01 Land01 LandHigh01",
+        "Run01", RunAnyCheck, NULL, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(
+        animTable,
+        "Idle01 Idle01b Idle01c Idle02 Idle04 Idle05 SlipIdle01 Inactive01 Inactive02 Inactive_sleep Run01 SlipRun01 Walk01 Land01 LandHigh01",
+        "RunOutOfWorld01", RunOutOfWorldCheck, NULL, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(
+        animTable,
+        "Idle01 Idle01b Idle01c Idle02 Idle04 Idle05 SlipIdle01 Inactive01 Inactive02 Inactive_sleep Run01 RunOutOfWorld01 Walk01 Land01 LandHigh01",
+        "SlipRun01", RunSlipCheck, NULL, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
+
+    xAnimTableNewTransition(
+        animTable,
+        "Idle01 Idle01b Idle01c Idle02 Idle04 Idle05 SlipIdle01 Inactive01 Inactive02 Inactive_sleep Walk01 LandRun01 Run01 RunOutOfWorld01 SlipRun01 Land01 LandHigh01",
+        "JumpStart01", JumpCheck, JumpCB, 0, 0, 0.0, 0.0, 0x0A, 0, 0.0, NULL);
+
+    xAnimTableNewTransition(animTable, "JumpStart01", "JumpApex01", JumpApexCheck, NULL, 0, 0, 0.0,
+                            0.0, 1, 0, 0.1, NULL);
+    xAnimTableNewTransition(animTable,
+                            "JumpStart01 JumpApex01 Fall01 BounceStart01 BounceLift01 BounceApex01",
+                            "DJumpApex01", DblJumpCheck, DblJumpCB, 0, 0, 0.0, 0.0, 0x0A, 0, 0.1,
+                            NULL);
+    xAnimTableNewTransition(animTable, "LCopter01 LCopterHeadUp01", "Fall01", FallCheck,
+                            StopLCopterCB, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(
+        animTable,
+        "Idle01 Idle01b Idle01c Idle02 Idle04 Idle05 SlipIdle01 Inactive01 Inactive02 Inactive_sleep Walk01 LandRun01 RunOutOfWorld01 Run01 SlipRun01 Land01 LandHigh01",
+        "Fall01", FallCheck, NULL, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
+
+    xAnimTableNewTransition(animTable, "JumpApex01 DJumpApex01 Fall01", "Land01", LandCheck,
+                            SandyLandCB, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "JumpApex01 DJumpApex01 Fall01", "SlipIdle01",
+                            LandSlipIdleCheck, SandyLandCB, 0, 0, 0.0, 0.0, 2, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "JumpApex01 DJumpApex01 Fall01", "LandRun01", LandFastCheck,
+                            SandyLandCB, 0, 0, 0.0, 0.0, 3, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "JumpApex01 DJumpApex01 Fall01", "Walk01", LandWalkCheck,
+                            SandyLandCB, 0, 0, 0.0, 0.0, 3, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "JumpApex01 DJumpApex01 Fall01", "SlipRun01",
+                            LandSlipRunCheck, SandyLandCB, 0, 0, 0.0, 0.0, 4, 0, 0.15, NULL);
+
+    xAnimTableNewTransition(animTable, "Fall01 DJumpApex01 TailSlideFall01 TailSlideDJumpApex01",
+                            "LCopterHeadUp01", LCopterCheck, LCopterCB, 0, 0, 0.0, 0.0, 8, 0, 0.15,
+                            NULL);
+    xAnimTableNewTransition(animTable, "LCopterHeadUp01", "LCopter01", NULL, NULL, 0x10, 0, 0.0,
+                            0.0, 0, 0, 0.15, NULL);
+    xAnimTableNewTransition(
+        animTable,
+        "JumpStart01 JumpLift01 JumpApex01 Fall01 DJumpApex01 TailSlideJumpStart01 TailSlideJumpApex01 TailSlideFall01 TailSlideDJumpApex01 LCopter01 LCopterHeadUp01",
+        "LedgeGrab01", LedgeGrabCheck, LedgeGrabCB, 0, 0, 0.0, 0.0, 0x0B, 0, 0.1, NULL);
+    xAnimTableNewTransition(animTable, "LedgeGrab01", "Idle01", NULL, LedgeFinishCB, 0x10, 0, 0.0,
+                            0.0, 0, 0, 0.1, NULL);
+    xAnimTableNewTransition(
+        animTable,
+        "Idle01 Idle01b Idle01c Idle02 Idle04 Idle05 SlipIdle01 Inactive01 Inactive02 Inactive_sleep Walk01 LandRun01 Run01 RunOutOfWorld01 SlipRun01 JumpLift01 JumpApex01 Fall01 Land01 DJumpApex01 FallHigh01 LandHigh01 LCopter01 LCopterHeadUp01",
+        "TailSlide01", SlideTrackCheck, SlideTrackCB, 0, 0, 0.0, 0.0, 9, 0, 0.15, NULL);
+
+    xAnimTableNewTransition(animTable, "TailSlide01", "Idle01", NoslideTrackCheck, NoslideTrackCB,
+                            0x00, 0, 0.0, 0.0, 0x09, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "TailSlide01", "TailSlideFall01", TrackFallCheck,
+                            TrackFallCB, 0x00, 0, 0.0, 0.0, 0x09, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "TailSlideDJumpApex01", "TailSlideFall01", NULL, NULL, 0x10,
+                            0, 0.0, 0.0, 0x00, 0, 0.20, NULL);
+    xAnimTableNewTransition(animTable, "TailSlideJumpApex01", "TailSlideFall01", NULL, NULL, 0x10,
+                            0, 0.0, 0.0, 0x00, 0, 0.08, NULL);
+    xAnimTableNewTransition(animTable, "TailSlideLand01", "TailSlide01", NULL, NULL, 0x10, 0, 0.0,
+                            0.0, 0x00, 0, 0.08, NULL);
+    xAnimTableNewTransition(animTable, "TailSlideJumpStart01", "TailSlideJumpApex01", NULL, NULL,
+                            0x10, 0, 0.0, 0.0, 0x00, 0, 0.08, NULL);
+    xAnimTableNewTransition(animTable, "TailSlide01 TailSlideLand01", "TailSlideJumpStart01",
+                            JumpCheck, JumpCB, 0x00, 0, 0.0, 0.0, 0x0A, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "TailSlideJumpStart01 TailSlideJumpApex01 TailSlideFall01",
+                            "TailSlideJumpStart01", TrackPrefallJumpCheck, JumpCB, 0x00, 0, 0.0,
+                            0.0, 0x0F, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "TailSlideJumpStart01", "TailSlideJumpApex01", JumpApexCheck,
+                            NULL, 0x00, 0, 0.0, 0.0, 0x01, 0, 0.10, NULL);
+    xAnimTableNewTransition(animTable, "TailSlideJumpStart01 TailSlideJumpApex01 TailSlideFall01",
+                            "TailSlideDJumpApex01", DblJumpCheck, DblJumpCB, 0x00, 0, 0.0, 0.0,
+                            0x0A, 0, 0.10, NULL);
+
+    xAnimTableNewTransition(
+        animTable, "TailSlideJumpStart01 TailSlideJumpApex01 TailSlideDJumpApex01 TailSlideFall01",
+        "TailSlideLand01", LandTrackCheck, SlideTrackCB, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(
+        animTable, "TailSlideJumpStart01 TailSlideJumpApex01 TailSlideDJumpApex01 TailSlideFall01",
+        "Land01", LandNoTrackCheck, NoslideTrackCB, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(
+        animTable, "TailSlideJumpStart01 TailSlideJumpApex01 TailSlideDJumpApex01 TailSlideFall01",
+        "LandRun01", LandNoTrackFastCheck, NoslideTrackCB, 0, 0, 0.0, 0.0, 3, 0, 0.15, NULL);
+    xAnimTableNewTransition(
+        animTable, "TailSlideJumpStart01 TailSlideJumpApex01 TailSlideDJumpApex01 TailSlideFall01",
+        "Walk01", LandNoTrackWalkCheck, NoslideTrackCB, 0, 0, 0.0, 0.0, 3, 0, 0.15, NULL);
+    xAnimTableNewTransition(
+        animTable, "TailSlideJumpStart01 TailSlideJumpApex01 TailSlideDJumpApex01 TailSlideFall01",
+        "SlipIdle01", LandNoTrackSlipIdleCheck, NoslideTrackCB, 0, 0, 0.0, 0.0, 4, 0, 0.15, NULL);
+    xAnimTableNewTransition(
+        animTable, "TailSlideJumpStart01 TailSlideJumpApex01 TailSlideDJumpApex01 TailSlideFall01",
+        "SlipRun01", LandNoTrackSlipRunCheck, NoslideTrackCB, 0, 0, 0.0, 0.0, 4, 0, 0.15, NULL);
+
+    xAnimTableNewTransition(
+        animTable,
+        "Idle01 Idle01b Idle01c Idle02 Idle04 Idle05 SlipIdle01 Inactive01 Inactive02 Inactive_sleep Walk01 LandRun01 Run01 RunOutOfWorld01 SlipRun01 JumpLift01 JumpApex01 Fall01 Land01 DJumpApex01 FallHigh01 LandHigh01 LCopter01 LCopterHeadUp01 TailSlide01 TailSlideJumpStart01 TailSlideJumpApex01 TailSlideDJumpApex01 TailSlideFall01 TailSlideLand01",
+        "Defeat01", Defeated01Check, DefeatedCB, 0, 4, 0.0, 0.0, 0x09, 0, 0.15, NULL);
+    xAnimTableNewTransition(
+        animTable,
+        "Idle01 Idle01b Idle01c Idle02 Idle04 Idle05 SlipIdle01 Inactive01 Inactive02 Inactive_sleep Walk01 LandRun01 Run01 RunOutOfWorld01 SlipRun01 JumpLift01 JumpApex01 Fall01 Land01 DJumpApex01 FallHigh01 LandHigh01 LCopter01 LCopterHeadUp01 TailSlide01 TailSlideJumpStart01 TailSlideJumpApex01 TailSlideDJumpApex01 TailSlideFall01 TailSlideLand01",
+        "Defeat02", Defeated02Check, DefeatedCB, 0, 4, 0.0, 0.0, 0x09, 0, 0.15, NULL);
+    xAnimTableNewTransition(
+        animTable,
+        "Idle01 Idle01b Idle01c Idle02 Idle04 Idle05 SlipIdle01 Inactive01 Inactive02 Inactive_sleep Walk01 LandRun01 Run01 RunOutOfWorld01 SlipRun01 JumpLift01 JumpApex01 Fall01 Land01 DJumpApex01 FallHigh01 LandHigh01 LCopter01 LCopterHeadUp01 TailSlide01 TailSlideJumpStart01 TailSlideJumpApex01 TailSlideDJumpApex01 TailSlideFall01 TailSlideLand01",
+        "Defeat03", Defeated03Check, DefeatedCB, 0, 4, 0.0, 0.0, 0x09, 0, 0.15, NULL);
+    xAnimTableNewTransition(
+        animTable,
+        "Idle01 Idle01b Idle01c Idle02 Idle04 Idle05 SlipIdle01 Inactive01 Inactive02 Inactive_sleep Walk01 LandRun01 Run01 RunOutOfWorld01 SlipRun01 JumpLift01 JumpApex01 Fall01 Land01 DJumpApex01 FallHigh01 LandHigh01 LCopter01 LCopterHeadUp01 TailSlide01 TailSlideJumpStart01 TailSlideJumpApex01 TailSlideDJumpApex01 TailSlideFall01 TailSlideLand01",
+        "Defeat04", Defeated04Check, DefeatedCB, 0, 4, 0.0, 0.0, 0x09, 0, 0.15, NULL);
+    xAnimTableNewTransition(
+        animTable,
+        "Idle01 Idle01b Idle01c Idle02 Idle04 Idle05 SlipIdle01 Inactive01 Inactive02 Inactive_sleep Walk01 LandRun01 Run01 RunOutOfWorld01 SlipRun01 JumpLift01 JumpApex01 Fall01 Land01 DJumpApex01 FallHigh01 LandHigh01 LCopter01 LCopterHeadUp01 TailSlide01 TailSlideJumpStart01 TailSlideJumpApex01 TailSlideDJumpApex01 TailSlideFall01 TailSlideLand01",
+        "DefeatGoo", GooCheck, GooDeathCB, 0, 0, 0.0, 0.0, 0x1e, 0, 0.15, NULL);
+
+    xAnimTableNewTransition(
+        animTable,
+        "Idle01 Idle01b Idle01c Idle02 Idle04 Idle05 SlipIdle01 Inactive_sleep Inactive01 Inactive02 ",
+        "Talk01", TalkCheck, NULL, 0, 0, 0.0, 0.0, 0x14, 0, 0.15, NULL);
+    xAnimTableNewTransition(
+        animTable,
+        "Idle01 Idle01b Idle01c Idle02 Idle04 Idle05 SlipIdle01 Inactive_sleep Inactive01 Inactive02 ",
+        "Talk02", TalkCheck, NULL, 0, 1, 0.0, 0.0, 0x14, 0, 0.15, NULL);
+    xAnimTableNewTransition(
+        animTable,
+        "Idle01 Idle01b Idle01c Idle02 Idle04 Idle05 SlipIdle01 Inactive_sleep Inactive01 Inactive02 ",
+        "Talk03", TalkCheck, NULL, 0, 2, 0.0, 0.0, 0x14, 0, 0.15, NULL);
+    xAnimTableNewTransition(
+        animTable,
+        "Idle01 Idle01b Idle01c Idle02 Idle04 Idle05 SlipIdle01 Inactive_sleep Inactive01 Inactive02 ",
+        "Talk04", TalkCheck, NULL, 0, 3, 0.0, 0.0, 0x14, 0, 0.15, NULL);
+
+    xAnimTableNewTransition(animTable, "Talk01", "Idle01", TalkDoneCheck, IdleCB, 0x00, 0x00000,
+                            0.0, 0.0, 0x14, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Talk02", "Idle01", TalkDoneCheck, IdleCB, 0x00, 0x00001,
+                            0.0, 0.0, 0x14, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Talk03", "Idle01", TalkDoneCheck, IdleCB, 0x00, 0x00002,
+                            0.0, 0.0, 0x14, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Talk04", "Idle01", TalkDoneCheck, IdleCB, 0x00, 0x00003,
+                            0.0, 0.0, 0x14, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Idle01", "Idle01b", InactiveCheck, InactiveCB, 0x00,
+                            0x80000, 0.0, 0.0, 0x01, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Idle01", "Idle01c", InactiveCheck, InactiveCB, 0x00,
+                            0x80001, 0.0, 0.0, 0x01, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Idle01", "Idle02", InactiveCheck, InactiveCB, 0x00, 0x80002,
+                            0.0, 0.0, 0x01, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Idle01", "Idle04", InactiveCheck, InactiveCB, 0x00, 0x80003,
+                            0.0, 0.0, 0x01, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Idle01", "Idle05", InactiveCheck, InactiveCB, 0x00, 0x80004,
+                            0.0, 0.0, 0x01, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Idle01", "Inactive_sleep", InactiveCheck, InactiveCB, 0x00,
+                            0x80005, 0.0, 0.0, 0x01, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Idle01", "Inactive01", InactiveCheck, InactiveCB, 0x00,
+                            0x80006, 0.0, 0.0, 0x01, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Idle01", "Inactive02", InactiveCheck, InactiveCB, 0x00,
+                            0x80007, 0.0, 0.0, 0x01, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Idle01b", "Idle01", InactiveFinishedCheck, IdleCB, 0x00,
+                            0x00000, 0.0, 0.0, 0x00, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Idle01c", "Idle01", InactiveFinishedCheck, IdleCB, 0x00,
+                            0x00000, 0.0, 0.0, 0x00, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Idle02", "Idle01", InactiveFinishedCheck, IdleCB, 0x00,
+                            0x00000, 0.0, 0.0, 0x00, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Idle04", "Idle01", InactiveFinishedCheck, IdleCB, 0x00,
+                            0x00000, 0.0, 0.0, 0x00, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Idle05", "Idle01", InactiveFinishedCheck, IdleCB, 0x00,
+                            0x00000, 0.0, 0.0, 0x00, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Inactive01", "Idle01", NULL, IdleCB, 0x10, 0x00000, 0.0,
+                            0.0, 0x00, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Inactive02", "Idle01", NULL, IdleCB, 0x10, 0x00000, 0.0,
+                            0.0, 0x00, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Hit01", "Idle01", NULL, IdleCB, 0x10, 0x00000, 0.0, 0.0,
+                            0x00, 0, 0.15, NULL);
+
+    return animTable;
 }
 
 xAnimTable* zSpongeBobTongue_AnimTable()
 {
     xAnimTable* animTable = xAnimTableNew("SBTongue", NULL, 0);
 
-    xAnimTableNewState(animTable,"TongueSlide01",     0x10, 0, 1.0f, NULL, NULL, 0.0f, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable,"TongueStart01",     0x10, 0, 1.0f, NULL, NULL, 0.0f, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable,"TongueJump01",      0x10, 0, 1.0f, NULL, NULL, 0.0f, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable,"TongueJumpXtra01",  0x10, 0, 1.0f, NULL, NULL, 0.0f, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable,"TongueDJumpApex01", 0x10, 0, 1.0f, NULL, NULL, 0.0f, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable,"TongueFall01",      0x10, 0, 1.0f, NULL, NULL, 0.0f, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable,"TongueLand01",      0x10, 0, 1.0f, NULL, NULL, 0.0f, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "TongueSlide01", 0x10, 0, 1.0f, NULL, NULL, 0.0f, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "TongueStart01", 0x10, 0, 1.0f, NULL, NULL, 0.0f, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "TongueJump01", 0x10, 0, 1.0f, NULL, NULL, 0.0f, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "TongueJumpXtra01", 0x10, 0, 1.0f, NULL, NULL, 0.0f, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "TongueDJumpApex01", 0x10, 0, 1.0f, NULL, NULL, 0.0f, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "TongueFall01", 0x10, 0, 1.0f, NULL, NULL, 0.0f, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "TongueLand01", 0x10, 0, 1.0f, NULL, NULL, 0.0f, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
 
     return animTable;
 }
@@ -5088,486 +5335,830 @@ xAnimTable* zPatrick_AnimTable()
 {
     xAnimTable* animTable = xAnimTableNew("Patrick", NULL, 0);
 
-    xAnimTableNewState(animTable, "Idle01",               0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Idle02",               0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Idle03",               0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Idle04",               0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "SlipIdle01",           0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Inactive01",           0x20, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Inactive02",           0x20, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Inactive03",           0x20, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Inactive04",           0x20, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Inactive05",           0x20, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Inactive06",           0x20, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Inactive07",           0x20, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Walk01",               0x10, 0x0044, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Walk02",               0x10, 0x0044, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Walk03",               0x10, 0x0044, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Run01",                0x10, 0x0046, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Run02",                0x10, 0x0046, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Run03",                0x10, 0x0046, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "RunOutOfWorld01",      0x10, 0x0046, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "SlipRun01",            0x10, 0x0046, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "JumpStart01",          0x20, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Fall01",               0x10, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Land01",               0x20, 0x0000, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "BounceStart01",        0x20, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "BounceLift01",         0x10, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "BounceApex01",         0x20, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "DJumpStart01",         0x20, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "FallHigh01",           0x10, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "LandHigh01",           0x20, 0x0000, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "LedgeGrab01",          0x20, 0x0080, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "StunJump",             0x20, 0x400a, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "StunFall",             0x10, 0x400a, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "StunLand",             0x20, 0x0080, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Hit01",                0x20, 0x0080, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Hit02",                0x20, 0x0080, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Hit03",                0x20, 0x0080, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Melee01",              0x20, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Defeated01",           0x00, 0x0480, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Defeated02",           0x00, 0x0480, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "DefeatedGoo01",        0x00, 0x0480, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "DefeatedProjectile01", 0x00, 0x0480, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "ButtSlide01",          0x10, 0x1840, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Talk04",               0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Talk03",               0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Talk02",               0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Talk01",               0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Carry_Pickup",         0x20, 0x0080, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Carry_PickupFail",     0x20, 0x0080, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Carry_Idle",           0x10, 0x0000, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Carry_Walk",           0x10, 0x0004, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Carry_Throw",          0x20, 0x0000, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Carry_PickupItem",     0x10, 0x0000, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Carry_IdleItem",       0x10, 0x0000, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Carry_WalkItem",       0x10, 0x0000, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Carry_ThrowItem",      0x10, 0x0000, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "SpatulaGrab01",        0x20, 0x0080, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Idle01", 0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Idle02", 0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Idle03", 0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Idle04", 0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "SlipIdle01", 0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Inactive01", 0x20, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Inactive02", 0x20, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Inactive03", 0x20, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Inactive04", 0x20, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Inactive05", 0x20, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Inactive06", 0x20, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Inactive07", 0x20, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Walk01", 0x10, 0x0044, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Walk02", 0x10, 0x0044, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Walk03", 0x10, 0x0044, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Run01", 0x10, 0x0046, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Run02", 0x10, 0x0046, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Run03", 0x10, 0x0046, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "RunOutOfWorld01", 0x10, 0x0046, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "SlipRun01", 0x10, 0x0046, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "JumpStart01", 0x20, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Fall01", 0x10, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Land01", 0x20, 0x0000, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "BounceStart01", 0x20, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "BounceLift01", 0x10, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "BounceApex01", 0x20, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "DJumpStart01", 0x20, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "FallHigh01", 0x10, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "LandHigh01", 0x20, 0x0000, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "LedgeGrab01", 0x20, 0x0080, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "StunJump", 0x20, 0x400a, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "StunFall", 0x10, 0x400a, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "StunLand", 0x20, 0x0080, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Hit01", 0x20, 0x0080, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Hit02", 0x20, 0x0080, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Hit03", 0x20, 0x0080, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Melee01", 0x20, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Defeated01", 0x00, 0x0480, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Defeated02", 0x00, 0x0480, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "DefeatedGoo01", 0x00, 0x0480, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "DefeatedProjectile01", 0x00, 0x0480, 1.0, NULL, NULL, 0.0, NULL,
+                       NULL, xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "ButtSlide01", 0x10, 0x1840, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Talk04", 0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Talk03", 0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Talk02", 0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Talk01", 0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Carry_Pickup", 0x20, 0x0080, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Carry_PickupFail", 0x20, 0x0080, 1.0, NULL, NULL, 0.0, NULL,
+                       NULL, xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Carry_Idle", 0x10, 0x0000, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Carry_Walk", 0x10, 0x0004, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Carry_Throw", 0x20, 0x0000, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Carry_PickupItem", 0x10, 0x0000, 1.0, NULL, NULL, 0.0, NULL,
+                       NULL, xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Carry_IdleItem", 0x10, 0x0000, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Carry_WalkItem", 0x10, 0x0000, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Carry_ThrowItem", 0x10, 0x0000, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "SpatulaGrab01", 0x20, 0x0080, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
 
-    xAnimTableNewTransition(animTable, "Idle01 Idle02 Idle03 Idle04 SlipIdle01 Inactive01 Inactive02 Inactive03 Inactive04 Inactive05 Inactive06 Inactive07 Walk01 Walk02 Walk03 Run01 Run02 Run03 Land01 LandHigh01 Melee01 Carry_Idle Carry_Walk Carry_IdleItem Carry_WalkItem", "SpatulaGrab01", SpatulaGrabCheck, SpatulaGrabCB, 0, 0, 0.0, 0.0, 5, 0, 0.15, NULL);
+    xAnimTableNewTransition(
+        animTable,
+        "Idle01 Idle02 Idle03 Idle04 SlipIdle01 Inactive01 Inactive02 Inactive03 Inactive04 Inactive05 Inactive06 Inactive07 Walk01 Walk02 Walk03 Run01 Run02 Run03 Land01 LandHigh01 Melee01 Carry_Idle Carry_Walk Carry_IdleItem Carry_WalkItem",
+        "SpatulaGrab01", SpatulaGrabCheck, SpatulaGrabCB, 0, 0, 0.0, 0.0, 5, 0, 0.15, NULL);
 
-    xAnimTableNewTransition(animTable, "SpatulaGrab01",    "Idle01",             NULL, SpatulaGrabStopCB, 0x10, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Carry_Pickup",     "Carry_Idle",         NULL,              NULL, 0x10, 0, 0.0, 0.0, 0, 0, 0.10, NULL);
-    xAnimTableNewTransition(animTable, "Carry_Throw",      "Idle01",             NULL,              NULL, 0x10, 0, 0.0, 0.0, 0, 0, 0.10, NULL);
-    xAnimTableNewTransition(animTable, "Carry_PickupFail", "Idle01",             NULL,              NULL, 0x10, 0, 0.0, 0.0, 0, 0, 0.10, NULL);
-    xAnimTableNewTransition(animTable, "Carry_Idle",       "Carry_Walk", AnyMoveCheck,              NULL, 0x00, 0, 0.0, 0.0, 0, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Carry_Walk",       "Carry_Idle", AnyStopCheck,              NULL, 0x00, 0, 0.0, 0.0, 0, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "SpatulaGrab01", "Idle01", NULL, SpatulaGrabStopCB, 0x10, 0,
+                            0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Carry_Pickup", "Carry_Idle", NULL, NULL, 0x10, 0, 0.0, 0.0,
+                            0, 0, 0.10, NULL);
+    xAnimTableNewTransition(animTable, "Carry_Throw", "Idle01", NULL, NULL, 0x10, 0, 0.0, 0.0, 0, 0,
+                            0.10, NULL);
+    xAnimTableNewTransition(animTable, "Carry_PickupFail", "Idle01", NULL, NULL, 0x10, 0, 0.0, 0.0,
+                            0, 0, 0.10, NULL);
+    xAnimTableNewTransition(animTable, "Carry_Idle", "Carry_Walk", AnyMoveCheck, NULL, 0x00, 0, 0.0,
+                            0.0, 0, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Carry_Walk", "Carry_Idle", AnyStopCheck, NULL, 0x00, 0, 0.0,
+                            0.0, 0, 0, 0.15, NULL);
 
-    xAnimTableNewTransition(animTable, "Carry_Idle Carry_Walk", "Carry_Throw", PatrickGrabThrow, PatrickGrabThrowCB, 0, 0, 0.0, 0.0, 0, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Carry_Idle Carry_Walk", "Carry_Throw", PatrickGrabThrow,
+                            PatrickGrabThrowCB, 0, 0, 0.0, 0.0, 0, 0, 0.15, NULL);
 
-    xAnimTableNewTransition(animTable, "Idle01 Idle02 Idle03 Idle04 SlipIdle01 Inactive01 Inactive02 Inactive03 Inactive04 Inactive05 Inactive06 Inactive07 Walk01 Walk02 Walk03 Run01 Run02 Run03 SlipRun01", "Carry_Pickup",  PatrickGrabCheck, PatrickGrabCB, 0, 0, 0.0, 0.0, 0, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01 Idle02 Idle03 Idle04 SlipIdle01 Inactive01 Inactive02 Inactive03 Inactive04 Inactive05 Inactive06 Inactive07 Walk01 Walk02 Walk03 Run01 Run02 Run03", "Carry_PickupFail", PatrickGrabFailed, NULL, 0, 0, 0.0, 0.0, 0, 0, 0.15, NULL);
+    xAnimTableNewTransition(
+        animTable,
+        "Idle01 Idle02 Idle03 Idle04 SlipIdle01 Inactive01 Inactive02 Inactive03 Inactive04 Inactive05 Inactive06 Inactive07 Walk01 Walk02 Walk03 Run01 Run02 Run03 SlipRun01",
+        "Carry_Pickup", PatrickGrabCheck, PatrickGrabCB, 0, 0, 0.0, 0.0, 0, 0, 0.15, NULL);
+    xAnimTableNewTransition(
+        animTable,
+        "Idle01 Idle02 Idle03 Idle04 SlipIdle01 Inactive01 Inactive02 Inactive03 Inactive04 Inactive05 Inactive06 Inactive07 Walk01 Walk02 Walk03 Run01 Run02 Run03",
+        "Carry_PickupFail", PatrickGrabFailed, NULL, 0, 0, 0.0, 0.0, 0, 0, 0.15, NULL);
 
-    xAnimTableNewTransition(animTable, "Carry_Idle Carry_Walk Carry_Pickup","Idle01", PatrickGrabKill, NULL, 0, 0, 0.0, 0.0, 0, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Carry_Idle Carry_Walk Carry_Pickup", "Idle01",
+                            PatrickGrabKill, NULL, 0, 0, 0.0, 0.0, 0, 0, 0.15, NULL);
 
-    xAnimTableNewTransition(animTable, "Idle01 Idle02 Idle03 Idle04 SlipIdle01 Inactive01 Inactive02 Inactive03 Inactive04 Inactive05 Inactive06 Inactive07 Walk01 Walk02 Walk03 Run01 Run02 Run03 SlipRun01","Melee01", PatrickAttackCheck, PatrickMeleeCB, 0, 0, 0.0, 0.0, 0, 0, 0.15, NULL);
+    xAnimTableNewTransition(
+        animTable,
+        "Idle01 Idle02 Idle03 Idle04 SlipIdle01 Inactive01 Inactive02 Inactive03 Inactive04 Inactive05 Inactive06 Inactive07 Walk01 Walk02 Walk03 Run01 Run02 Run03 SlipRun01",
+        "Melee01", PatrickAttackCheck, PatrickMeleeCB, 0, 0, 0.0, 0.0, 0, 0, 0.15, NULL);
 
-    xAnimTableNewTransition(animTable, "Melee01", "SlipIdle01",           IdleSlipCheck, NULL, 0x10, 0, 0.0, 0.0, 1, 0, 0.00, NULL);
-    xAnimTableNewTransition(animTable, "Melee01", "Idle01",                   IdleCheck, NULL, 0x10, 0, 0.0, 0.0, 1, 0, 0.00, NULL);
-    xAnimTableNewTransition(animTable, "Melee01", "Walk01",              WalkStoicCheck, NULL, 0x10, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Melee01", "Walk02",            WalkVictoryCheck, NULL, 0x10, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Melee01", "Walk03",             WalkScaredCheck, NULL, 0x10, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Melee01", "Run01",                RunStoicCheck, NULL, 0x10, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Melee01", "Run02",              RunVictoryCheck, NULL, 0x10, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Melee01", "Run03",               RunScaredCheck, NULL, 0x10, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Melee01", "RunOutOfWorld01", RunOutOfWorldCheck, NULL, 0x10, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Melee01", "SlipRun01",             RunSlipCheck, NULL, 0x10, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Melee01", "SlipIdle01", IdleSlipCheck, NULL, 0x10, 0, 0.0,
+                            0.0, 1, 0, 0.00, NULL);
+    xAnimTableNewTransition(animTable, "Melee01", "Idle01", IdleCheck, NULL, 0x10, 0, 0.0, 0.0, 1,
+                            0, 0.00, NULL);
+    xAnimTableNewTransition(animTable, "Melee01", "Walk01", WalkStoicCheck, NULL, 0x10, 0, 0.0, 0.0,
+                            1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Melee01", "Walk02", WalkVictoryCheck, NULL, 0x10, 0, 0.0,
+                            0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Melee01", "Walk03", WalkScaredCheck, NULL, 0x10, 0, 0.0,
+                            0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Melee01", "Run01", RunStoicCheck, NULL, 0x10, 0, 0.0, 0.0,
+                            1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Melee01", "Run02", RunVictoryCheck, NULL, 0x10, 0, 0.0, 0.0,
+                            1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Melee01", "Run03", RunScaredCheck, NULL, 0x10, 0, 0.0, 0.0,
+                            1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Melee01", "RunOutOfWorld01", RunOutOfWorldCheck, NULL, 0x10,
+                            0, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Melee01", "SlipRun01", RunSlipCheck, NULL, 0x10, 0, 0.0,
+                            0.0, 1, 0, 0.15, NULL);
 
-    xAnimTableNewTransition(animTable, "Inactive01 Land01 LandHigh01","Idle01", NULL, NULL, 0x10, 0, 0.0, 0.0, 0, 0, 0.1, NULL);
+    xAnimTableNewTransition(animTable, "Inactive01 Land01 LandHigh01", "Idle01", NULL, NULL, 0x10,
+                            0, 0.0, 0.0, 0, 0, 0.1, NULL);
 
-    xAnimTableNewTransition(animTable, "JumpStart01",  "Fall01", NULL, NULL, 0x10, 0, 0.0, 0.0, 0, 0, 0.0, NULL);
-    xAnimTableNewTransition(animTable, "DJumpStart01", "Fall01", NULL, NULL, 0x10, 0, 0.0, 0.0, 0, 0, 0.0, NULL);
+    xAnimTableNewTransition(animTable, "JumpStart01", "Fall01", NULL, NULL, 0x10, 0, 0.0, 0.0, 0, 0,
+                            0.0, NULL);
+    xAnimTableNewTransition(animTable, "DJumpStart01", "Fall01", NULL, NULL, 0x10, 0, 0.0, 0.0, 0,
+                            0, 0.0, NULL);
 
-    xAnimTableNewTransition(animTable, "Idle01 SlipIdle01 Walk01 Walk02 Walk03 Run01 Run02 Run03 RunOutOfWorld01 SlipRun01 Land01 LandHigh01 JumpStart01 JumpApex01 DJumpStart01 Fall01 StunJump StunFall StunLand","BounceStart01", BounceCheck, BounceCB, 0, 0, 0.0, 0.0, 0x0F, 0, 0.15, NULL);
+    xAnimTableNewTransition(
+        animTable,
+        "Idle01 SlipIdle01 Walk01 Walk02 Walk03 Run01 Run02 Run03 RunOutOfWorld01 SlipRun01 Land01 LandHigh01 JumpStart01 JumpApex01 DJumpStart01 Fall01 StunJump StunFall StunLand",
+        "BounceStart01", BounceCheck, BounceCB, 0, 0, 0.0, 0.0, 0x0F, 0, 0.15, NULL);
 
-    xAnimTableNewTransition(animTable, "BounceStart01",   "BounceLift01",          NULL, NULL, 0x10, 0, 0.0, 0.0, 0, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "BounceLift01",    "BounceApex01", JumpApexCheck, NULL, 0x00, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "BounceApex01",    "Fall01",                NULL, NULL, 0x10, 0, 0.0, 0.0, 0, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "BounceStart01", "BounceLift01", NULL, NULL, 0x10, 0, 0.0,
+                            0.0, 0, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "BounceLift01", "BounceApex01", JumpApexCheck, NULL, 0x00, 0,
+                            0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "BounceApex01", "Fall01", NULL, NULL, 0x10, 0, 0.0, 0.0, 0,
+                            0, 0.15, NULL);
 
-    xAnimTableNewTransition(animTable, "Idle01 Walk01 Walk02 Walk03 Run01 Run02 Run03 RunOutOfWorld01 SlipRun01","SlipIdle01", IdleSlipCheck, NULL, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(
+        animTable, "Idle01 Walk01 Walk02 Walk03 Run01 Run02 Run03 RunOutOfWorld01 SlipRun01",
+        "SlipIdle01", IdleSlipCheck, NULL, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
 
-    xAnimTableNewTransition(animTable, "SlipIdle01 Walk01 Run01 RunOutOfWorld01 SlipRun01","Idle01", IdleCheck, NULL, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "SlipIdle01 Walk01 Run01 RunOutOfWorld01 SlipRun01",
+                            "Idle01", IdleCheck, NULL, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
 
-    xAnimTableNewTransition(animTable, "Idle01 Walk02 Run02", "Idle02", IdleVictoryCheck, IdleCB, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle02 Run02",        "Walk02", WalkVictoryCheck, IdleCB, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle02 Walk02",        "Run02",  RunVictoryCheck, IdleCB, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle02 Walk02 Run02", "Idle01",   IdleStoicCheck, IdleCB, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Walk03 Run03 Idle01", "Idle04",  IdleScaredCheck, IdleCB, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle04 Run03",        "Walk03",  WalkScaredCheck, IdleCB, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle04 Walk03",        "Run03",   RunScaredCheck, IdleCB, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle04 Walk03 Run03", "Idle01",   IdleStoicCheck, IdleCB, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Idle01 Walk02 Run02", "Idle02", IdleVictoryCheck, IdleCB, 0,
+                            0, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Idle02 Run02", "Walk02", WalkVictoryCheck, IdleCB, 0, 0,
+                            0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Idle02 Walk02", "Run02", RunVictoryCheck, IdleCB, 0, 0, 0.0,
+                            0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Idle02 Walk02 Run02", "Idle01", IdleStoicCheck, IdleCB, 0,
+                            0, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Walk03 Run03 Idle01", "Idle04", IdleScaredCheck, IdleCB, 0,
+                            0, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Idle04 Run03", "Walk03", WalkScaredCheck, IdleCB, 0, 0, 0.0,
+                            0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Idle04 Walk03", "Run03", RunScaredCheck, IdleCB, 0, 0, 0.0,
+                            0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Idle04 Walk03 Run03", "Idle01", IdleStoicCheck, IdleCB, 0,
+                            0, 0.0, 0.0, 1, 0, 0.15, NULL);
 
-    xAnimTableNewTransition(animTable, "Idle01 Idle02 Idle03 Idle04 SlipIdle01 Inactive01 Inactive02 Inactive03 Inactive04 Inactive05 Inactive06 Inactive07 Run01 Run02 Run03 RunOutOfWorld01 SlipRun01 Land01 LandHigh01","Walk01", WalkStoicCheck,   NULL, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01 Idle02 Idle03 Idle04 SlipIdle01 Inactive01 Inactive02 Inactive03 Inactive04 Inactive05 Inactive06 Inactive07 Run01 Run02 Run03 RunOutOfWorld01 SlipRun01 Land01 LandHigh01","Walk02", WalkVictoryCheck, NULL, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01 Idle02 Idle03 Idle04 SlipIdle01 Inactive01 Inactive02 Inactive03 Inactive04 Inactive05 Inactive06 Inactive07 Run01 Run02 Run03 RunOutOfWorld01 SlipRun01 Land01 LandHigh01","Walk03", WalkScaredCheck,  NULL, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(
+        animTable,
+        "Idle01 Idle02 Idle03 Idle04 SlipIdle01 Inactive01 Inactive02 Inactive03 Inactive04 Inactive05 Inactive06 Inactive07 Run01 Run02 Run03 RunOutOfWorld01 SlipRun01 Land01 LandHigh01",
+        "Walk01", WalkStoicCheck, NULL, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(
+        animTable,
+        "Idle01 Idle02 Idle03 Idle04 SlipIdle01 Inactive01 Inactive02 Inactive03 Inactive04 Inactive05 Inactive06 Inactive07 Run01 Run02 Run03 RunOutOfWorld01 SlipRun01 Land01 LandHigh01",
+        "Walk02", WalkVictoryCheck, NULL, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(
+        animTable,
+        "Idle01 Idle02 Idle03 Idle04 SlipIdle01 Inactive01 Inactive02 Inactive03 Inactive04 Inactive05 Inactive06 Inactive07 Run01 Run02 Run03 RunOutOfWorld01 SlipRun01 Land01 LandHigh01",
+        "Walk03", WalkScaredCheck, NULL, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
 
-    xAnimTableNewTransition(animTable, "Idle01 Idle02 Idle03 Idle04 SlipIdle01 Inactive01 Inactive02 Inactive03 Inactive04 Inactive05 Inactive06 Inactive07 Walk01 Walk02 Walk03 Land01 LandHigh01 Run02 Run03 RunOutOfWorld01 SlipRun01",        "Run01",                RunStoicCheck,   NULL, 0, 0, 0.0, 0.0, 0x01, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01 Idle02 Idle03 Idle04 SlipIdle01 Inactive01 Inactive02 Inactive03 Inactive04 Inactive05 Inactive06 Inactive07 Walk01 Walk02 Walk03 Land01 LandHigh01 Run01 Run03 RunOutOfWorld01 SlipRun01",        "Run02",              RunVictoryCheck,   NULL, 0, 0, 0.0, 0.0, 0x01, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01 Idle02 Idle03 Idle04 SlipIdle01 Inactive01 Inactive02 Inactive03 Inactive04 Inactive05 Inactive06 Inactive07 Walk01 Walk02 Walk03 Land01 LandHigh01 Run01 Run02 RunOutOfWorld01 SlipRun01",        "Run03",               RunScaredCheck,   NULL, 0, 0, 0.0, 0.0, 0x01, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01 Idle02 Idle03 Idle04 SlipIdle01 Inactive01 Inactive02 Inactive03 Inactive04 Inactive05 Inactive06 Inactive07 Walk01 Walk02 Walk03 Land01 LandHigh01 Run01 Run02 Run03 SlipRun01",                  "RunOutOfWorld01", RunOutOfWorldCheck,   NULL, 0, 0, 0.0, 0.0, 0x01, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01 Idle02 Idle03 Idle04 SlipIdle01 Inactive01 Inactive02 Inactive03 Inactive04 Inactive05 Inactive06 Inactive07 Walk01 Walk02 Walk03 Land01 LandHigh01 Run01 Run02 Run03 RunOutOfWorld01",            "SlipRun01",             RunSlipCheck,   NULL, 0, 0, 0.0, 0.0, 0x01, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01 Idle02 Idle03 Idle04 SlipIdle01 Inactive01 Inactive02 Inactive03 Inactive04 Inactive05 Inactive06 Inactive07 Walk01 Walk02 Walk03 Run01 Run02 Run03 RunOutOfWorld01 SlipRun01 Land01 LandHigh01",  "JumpStart01",              JumpCheck, JumpCB, 0, 0, 0.0, 0.0, 0x0A, 0, 0.15, NULL);
+    xAnimTableNewTransition(
+        animTable,
+        "Idle01 Idle02 Idle03 Idle04 SlipIdle01 Inactive01 Inactive02 Inactive03 Inactive04 Inactive05 Inactive06 Inactive07 Walk01 Walk02 Walk03 Land01 LandHigh01 Run02 Run03 RunOutOfWorld01 SlipRun01",
+        "Run01", RunStoicCheck, NULL, 0, 0, 0.0, 0.0, 0x01, 0, 0.15, NULL);
+    xAnimTableNewTransition(
+        animTable,
+        "Idle01 Idle02 Idle03 Idle04 SlipIdle01 Inactive01 Inactive02 Inactive03 Inactive04 Inactive05 Inactive06 Inactive07 Walk01 Walk02 Walk03 Land01 LandHigh01 Run01 Run03 RunOutOfWorld01 SlipRun01",
+        "Run02", RunVictoryCheck, NULL, 0, 0, 0.0, 0.0, 0x01, 0, 0.15, NULL);
+    xAnimTableNewTransition(
+        animTable,
+        "Idle01 Idle02 Idle03 Idle04 SlipIdle01 Inactive01 Inactive02 Inactive03 Inactive04 Inactive05 Inactive06 Inactive07 Walk01 Walk02 Walk03 Land01 LandHigh01 Run01 Run02 RunOutOfWorld01 SlipRun01",
+        "Run03", RunScaredCheck, NULL, 0, 0, 0.0, 0.0, 0x01, 0, 0.15, NULL);
+    xAnimTableNewTransition(
+        animTable,
+        "Idle01 Idle02 Idle03 Idle04 SlipIdle01 Inactive01 Inactive02 Inactive03 Inactive04 Inactive05 Inactive06 Inactive07 Walk01 Walk02 Walk03 Land01 LandHigh01 Run01 Run02 Run03 SlipRun01",
+        "RunOutOfWorld01", RunOutOfWorldCheck, NULL, 0, 0, 0.0, 0.0, 0x01, 0, 0.15, NULL);
+    xAnimTableNewTransition(
+        animTable,
+        "Idle01 Idle02 Idle03 Idle04 SlipIdle01 Inactive01 Inactive02 Inactive03 Inactive04 Inactive05 Inactive06 Inactive07 Walk01 Walk02 Walk03 Land01 LandHigh01 Run01 Run02 Run03 RunOutOfWorld01",
+        "SlipRun01", RunSlipCheck, NULL, 0, 0, 0.0, 0.0, 0x01, 0, 0.15, NULL);
+    xAnimTableNewTransition(
+        animTable,
+        "Idle01 Idle02 Idle03 Idle04 SlipIdle01 Inactive01 Inactive02 Inactive03 Inactive04 Inactive05 Inactive06 Inactive07 Walk01 Walk02 Walk03 Run01 Run02 Run03 RunOutOfWorld01 SlipRun01 Land01 LandHigh01",
+        "JumpStart01", JumpCheck, JumpCB, 0, 0, 0.0, 0.0, 0x0A, 0, 0.15, NULL);
 
-    xAnimTableNewTransition(animTable, "JumpStart01 Fall01 FallHigh01 BounceStart01 BounceLift01 BounceApex01","DJumpStart01", DblJumpCheck, DblJumpCB, 0, 0, 0.0, 0.0, 0x0A, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable,
+                            "JumpStart01 Fall01 FallHigh01 BounceStart01 BounceLift01 BounceApex01",
+                            "DJumpStart01", DblJumpCheck, DblJumpCB, 0, 0, 0.0, 0.0, 0x0A, 0, 0.15,
+                            NULL);
 
-    xAnimTableNewTransition(animTable, "Fall01 FallHigh01 JumpStart01 DJumpStart01","Land01",             LandCheck, NULL, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Fall01 FallHigh01 JumpStart01 DJumpStart01","SlipRun01",   LandSlipRunCheck, NULL, 0, 0, 0.0, 0.0, 2, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Fall01 FallHigh01 JumpStart01 DJumpStart01","SlipIdle01", LandSlipIdleCheck, NULL, 0, 0, 0.0, 0.0, 2, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Fall01 FallHigh01 JumpStart01 DJumpStart01", "Land01",
+                            LandCheck, NULL, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Fall01 FallHigh01 JumpStart01 DJumpStart01", "SlipRun01",
+                            LandSlipRunCheck, NULL, 0, 0, 0.0, 0.0, 2, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Fall01 FallHigh01 JumpStart01 DJumpStart01", "SlipIdle01",
+                            LandSlipIdleCheck, NULL, 0, 0, 0.0, 0.0, 2, 0, 0.15, NULL);
 
-    xAnimTableNewTransition(animTable, "Idle01 Idle02 Idle03 Idle04 SlipIdle01 Inactive01 Inactive02 Inactive03 Inactive04 Inactive05 Inactive06 Inactive07 Walk01 Walk02 Walk03 Run01 Run02 Run03 RunOutOfWorld01 SlipRun01 Land01 LandHigh01","Fall01", FallCheck, NULL, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(
+        animTable,
+        "Idle01 Idle02 Idle03 Idle04 SlipIdle01 Inactive01 Inactive02 Inactive03 Inactive04 Inactive05 Inactive06 Inactive07 Walk01 Walk02 Walk03 Run01 Run02 Run03 RunOutOfWorld01 SlipRun01 Land01 LandHigh01",
+        "Fall01", FallCheck, NULL, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
 
-    xAnimTableNewTransition(animTable, "JumpStart01 Fall01 FallHigh01 DJumpStart01 BounceStart01 BounceLift01 BounceApex01","StunJump", PatrickStunCheck, NULL, 0, 0, 0.0, 0.0, 0x0A, 0, 0.125, NULL);
+    xAnimTableNewTransition(
+        animTable,
+        "JumpStart01 Fall01 FallHigh01 DJumpStart01 BounceStart01 BounceLift01 BounceApex01",
+        "StunJump", PatrickStunCheck, NULL, 0, 0, 0.0, 0.0, 0x0A, 0, 0.125, NULL);
 
-    xAnimTableNewTransition(animTable, "StunJump", "StunFall",      NULL, StunStartFallCB, 0x10, 0, 0.0, 0.0, 0, 0, 0.0, NULL);
-    xAnimTableNewTransition(animTable, "StunFall", "StunLand", LandCheck,    StunRadiusCB, 0x00, 0, 0.0, 0.0, 1, 0, 0.1, NULL);
-    xAnimTableNewTransition(animTable, "StunLand", "Idle01",        NULL,            NULL, 0x10, 0, 0.0, 0.0, 0, 0, 0.0, NULL);
+    xAnimTableNewTransition(animTable, "StunJump", "StunFall", NULL, StunStartFallCB, 0x10, 0, 0.0,
+                            0.0, 0, 0, 0.0, NULL);
+    xAnimTableNewTransition(animTable, "StunFall", "StunLand", LandCheck, StunRadiusCB, 0x00, 0,
+                            0.0, 0.0, 1, 0, 0.1, NULL);
+    xAnimTableNewTransition(animTable, "StunLand", "Idle01", NULL, NULL, 0x10, 0, 0.0, 0.0, 0, 0,
+                            0.0, NULL);
 
-    xAnimTableNewTransition(animTable, "JumpStart01 Fall01 FallHigh01 DJumpStart01","LedgeGrab01", LedgeGrabCheck, LedgeGrabCB, 0, 0, 0.0, 0.0, 0x0B, 0, 0.1, NULL);
+    xAnimTableNewTransition(animTable, "JumpStart01 Fall01 FallHigh01 DJumpStart01", "LedgeGrab01",
+                            LedgeGrabCheck, LedgeGrabCB, 0, 0, 0.0, 0.0, 0x0B, 0, 0.1, NULL);
 
-    xAnimTableNewTransition(animTable, "LedgeGrab01","Idle01", NULL, LedgeFinishCB, 0x10, 0, 0.0, 0.0, 0, 0, 0.1, NULL);
+    xAnimTableNewTransition(animTable, "LedgeGrab01", "Idle01", NULL, LedgeFinishCB, 0x10, 0, 0.0,
+                            0.0, 0, 0, 0.1, NULL);
 
-    xAnimTableNewTransition(animTable, "Idle01 Idle02 Idle03 Idle04 SlipIdle01 Inactive01 Inactive02 Inactive03 Inactive04 Inactive05 Inactive06 Inactive07 Walk01 Walk02 Walk03 Run01 Run02 Run03 RunOutOfWorld01 SlipRun01 Fall01 FallHigh01 Land01 LandHigh01","ButtSlide01", SlideTrackCheck, SlideTrackCB, 0, 0, 0.0, 0.0, 9, 0, 0.15, NULL);
+    xAnimTableNewTransition(
+        animTable,
+        "Idle01 Idle02 Idle03 Idle04 SlipIdle01 Inactive01 Inactive02 Inactive03 Inactive04 Inactive05 Inactive06 Inactive07 Walk01 Walk02 Walk03 Run01 Run02 Run03 RunOutOfWorld01 SlipRun01 Fall01 FallHigh01 Land01 LandHigh01",
+        "ButtSlide01", SlideTrackCheck, SlideTrackCB, 0, 0, 0.0, 0.0, 9, 0, 0.15, NULL);
 
-    xAnimTableNewTransition(animTable, "Carry_PickupFail Carry_Idle Carry_Walk Carry_Throw","ButtSlide01", SlideTrackCheck, SlideTrackCB, 0, 0, 0.0, 0.0, 9, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Carry_PickupFail Carry_Idle Carry_Walk Carry_Throw",
+                            "ButtSlide01", SlideTrackCheck, SlideTrackCB, 0, 0, 0.0, 0.0, 9, 0,
+                            0.15, NULL);
 
-    xAnimTableNewTransition(animTable, "ButtSlide01", "Idle01",   NoslideTrackCheck, NoslideTrackCB, 0, 0, 0.0, 0.0, 0x09, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "ButtSlide01", "Fall01",      TrackFallCheck,    TrackFallCB, 0, 0, 0.0, 0.0, 0x09, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "ButtSlide01", "JumpStart01",      JumpCheck,         JumpCB, 0, 0, 0.0, 0.0, 0x0A, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "ButtSlide01", "Idle01", NoslideTrackCheck, NoslideTrackCB,
+                            0, 0, 0.0, 0.0, 0x09, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "ButtSlide01", "Fall01", TrackFallCheck, TrackFallCB, 0, 0,
+                            0.0, 0.0, 0x09, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "ButtSlide01", "JumpStart01", JumpCheck, JumpCB, 0, 0, 0.0,
+                            0.0, 0x0A, 0, 0.15, NULL);
 
-    xAnimTableNewTransition(animTable, "JumpStart01 Fall01 FallHigh01","JumpStart01", TrackPrefallJumpCheck, JumpCB, 0, 0, 0.0, 0.0, 0x0F, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "JumpStart01 Fall01 FallHigh01", "JumpStart01",
+                            TrackPrefallJumpCheck, JumpCB, 0, 0, 0.0, 0.0, 0x0F, 0, 0.15, NULL);
 
-    xAnimTableNewTransition(animTable, "Idle01", "Idle03",             InactiveCheck, InactiveCB, 0, 0x080000, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01", "Inactive01",         InactiveCheck, InactiveCB, 0, 0x080001, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01", "Inactive02",         InactiveCheck, InactiveCB, 0, 0x080002, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01", "Inactive03",         InactiveCheck, InactiveCB, 0, 0x080003, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01", "Inactive04",         InactiveCheck, InactiveCB, 0, 0x080004, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01", "Inactive05",         InactiveCheck, InactiveCB, 0, 0x080005, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01", "Inactive06",         InactiveCheck, InactiveCB, 0, 0x080006, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01", "Inactive07",         InactiveCheck, InactiveCB, 0, 0x080007, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle03", "Idle01",     InactiveFinishedCheck,     IdleCB, 0, 0x000000, 0.0, 0.0, 0, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Idle01", "Idle03", InactiveCheck, InactiveCB, 0, 0x080000,
+                            0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Idle01", "Inactive01", InactiveCheck, InactiveCB, 0,
+                            0x080001, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Idle01", "Inactive02", InactiveCheck, InactiveCB, 0,
+                            0x080002, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Idle01", "Inactive03", InactiveCheck, InactiveCB, 0,
+                            0x080003, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Idle01", "Inactive04", InactiveCheck, InactiveCB, 0,
+                            0x080004, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Idle01", "Inactive05", InactiveCheck, InactiveCB, 0,
+                            0x080005, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Idle01", "Inactive06", InactiveCheck, InactiveCB, 0,
+                            0x080006, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Idle01", "Inactive07", InactiveCheck, InactiveCB, 0,
+                            0x080007, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Idle03", "Idle01", InactiveFinishedCheck, IdleCB, 0,
+                            0x000000, 0.0, 0.0, 0, 0, 0.15, NULL);
 
-    xAnimTableNewTransition(animTable, "Inactive01 Inactive02 Inactive03 Inactive04 Inactive05 Inactive06 Inactive07 ","Idle01", NULL, IdleCB, 0x10, 0, 0.0, 0.0, 0, 0, 0.15, NULL);
+    xAnimTableNewTransition(
+        animTable, "Inactive01 Inactive02 Inactive03 Inactive04 Inactive05 Inactive06 Inactive07 ",
+        "Idle01", NULL, IdleCB, 0x10, 0, 0.0, 0.0, 0, 0, 0.15, NULL);
 
-    xAnimTableNewTransition(animTable, "Hit01 Hit02 Hit03 Hit04","Idle01", NULL, IdleCB, 0x10, 0, 0.0, 0.0, 0, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Hit01 Hit02 Hit03 Hit04", "Idle01", NULL, IdleCB, 0x10, 0,
+                            0.0, 0.0, 0, 0, 0.15, NULL);
 
-    xAnimTransition* pTran = xAnimTableNewTransition(animTable,"Idle01 Idle02 Idle03 Idle04 SlipIdle01 Inactive01 Inactive02 Inactive03 Inactive04 Inactive05 Inactive06 Inactive07 Walk01 Walk02 Walk03 Run01 Run02 Run03 RunOutOfWorld01 SlipRun01","Defeated01", Defeated01Check, DefeatedCB, 0,2, 0.0, 0.0, 0x0F, 0, 0.15, NULL);
+    xAnimTransition* pTran = xAnimTableNewTransition(
+        animTable,
+        "Idle01 Idle02 Idle03 Idle04 SlipIdle01 Inactive01 Inactive02 Inactive03 Inactive04 Inactive05 Inactive06 Inactive07 Walk01 Walk02 Walk03 Run01 Run02 Run03 RunOutOfWorld01 SlipRun01",
+        "Defeated01", Defeated01Check, DefeatedCB, 0, 2, 0.0, 0.0, 0x0F, 0, 0.15, NULL);
 
-    xAnimTableAddTransition(animTable, pTran, "JumpStart01 Fall01 Land01 DJumpStart01 FallHigh01 LandHigh01 LedgeGrab01 StunJump");
-    xAnimTableAddTransition(animTable, pTran, "StunFall StunLand Hit01 Hit02 Hit03 Hit04 Melee01 ButtSlide01");
-    xAnimTableAddTransition(animTable, pTran, "Carry_Pickup Carry_PickupFail Carry_Idle Carry_Walk Carry_Throw Carry_PickupItem");
+    xAnimTableAddTransition(
+        animTable, pTran,
+        "JumpStart01 Fall01 Land01 DJumpStart01 FallHigh01 LandHigh01 LedgeGrab01 StunJump");
+    xAnimTableAddTransition(animTable, pTran,
+                            "StunFall StunLand Hit01 Hit02 Hit03 Hit04 Melee01 ButtSlide01");
+    xAnimTableAddTransition(
+        animTable, pTran,
+        "Carry_Pickup Carry_PickupFail Carry_Idle Carry_Walk Carry_Throw Carry_PickupItem");
     xAnimTableAddTransition(animTable, pTran, "Carry_IdleItem Carry_WalkItem Carry_ThrowItem");
 
-    pTran = xAnimTableNewTransition(animTable, "Idle01 Idle02 Idle03 Idle04 SlipIdle01 Inactive01 Inactive02 Inactive03 Inactive04 Inactive05 Inactive06 Inactive07 Walk01 Walk02 Walk03 Run01 Run02 Run03 RunOutOfWorld01 SlipRun01","Defeated02", Defeated02Check, DefeatedCB, 0,2, 0.0, 0.0, 0x0F, 0, 0.15, NULL);
+    pTran = xAnimTableNewTransition(
+        animTable,
+        "Idle01 Idle02 Idle03 Idle04 SlipIdle01 Inactive01 Inactive02 Inactive03 Inactive04 Inactive05 Inactive06 Inactive07 Walk01 Walk02 Walk03 Run01 Run02 Run03 RunOutOfWorld01 SlipRun01",
+        "Defeated02", Defeated02Check, DefeatedCB, 0, 2, 0.0, 0.0, 0x0F, 0, 0.15, NULL);
 
-    xAnimTableAddTransition(animTable, pTran, "JumpStart01 Fall01 Land01 DJumpStart01 FallHigh01 LandHigh01 LedgeGrab01 StunJump");
-    xAnimTableAddTransition(animTable, pTran, "StunFall StunLand Hit01 Hit02 Hit03 Hit04 Melee01 ButtSlide01");
-    xAnimTableAddTransition(animTable, pTran, "Carry_Pickup Carry_PickupFail Carry_Idle Carry_Walk Carry_Throw Carry_PickupItem");
+    xAnimTableAddTransition(
+        animTable, pTran,
+        "JumpStart01 Fall01 Land01 DJumpStart01 FallHigh01 LandHigh01 LedgeGrab01 StunJump");
+    xAnimTableAddTransition(animTable, pTran,
+                            "StunFall StunLand Hit01 Hit02 Hit03 Hit04 Melee01 ButtSlide01");
+    xAnimTableAddTransition(
+        animTable, pTran,
+        "Carry_Pickup Carry_PickupFail Carry_Idle Carry_Walk Carry_Throw Carry_PickupItem");
     xAnimTableAddTransition(animTable, pTran, "Carry_IdleItem Carry_WalkItem Carry_ThrowItem");
 
-    pTran = xAnimTableNewTransition(animTable,"Idle01 Idle02 Idle03 Idle04 SlipIdle01 Inactive01 Inactive02 Inactive03 Inactive04 Inactive05 Inactive06 Inactive07 Walk01 Walk02 Walk03 Run01 Run02 Run03 RunOutOfWorld01 SlipRun01","DefeatedGoo01", GooCheck, GooDeathCB, 0, 0, 0.0, 0.0, 0x10, 0, 0.15, NULL);
+    pTran = xAnimTableNewTransition(
+        animTable,
+        "Idle01 Idle02 Idle03 Idle04 SlipIdle01 Inactive01 Inactive02 Inactive03 Inactive04 Inactive05 Inactive06 Inactive07 Walk01 Walk02 Walk03 Run01 Run02 Run03 RunOutOfWorld01 SlipRun01",
+        "DefeatedGoo01", GooCheck, GooDeathCB, 0, 0, 0.0, 0.0, 0x10, 0, 0.15, NULL);
 
-    xAnimTableAddTransition(animTable, pTran, "JumpStart01 Fall01 Land01 DJumpStart01 FallHigh01 LandHigh01 LedgeGrab01 StunJump");
-    xAnimTableAddTransition(animTable, pTran, "StunFall StunLand Hit01 Hit02 Hit03 Hit04 Melee01 ButtSlide01");
-    xAnimTableAddTransition(animTable, pTran, "Carry_Pickup Carry_PickupFail Carry_Idle Carry_Walk Carry_Throw Carry_PickupItem");
+    xAnimTableAddTransition(
+        animTable, pTran,
+        "JumpStart01 Fall01 Land01 DJumpStart01 FallHigh01 LandHigh01 LedgeGrab01 StunJump");
+    xAnimTableAddTransition(animTable, pTran,
+                            "StunFall StunLand Hit01 Hit02 Hit03 Hit04 Melee01 ButtSlide01");
+    xAnimTableAddTransition(
+        animTable, pTran,
+        "Carry_Pickup Carry_PickupFail Carry_Idle Carry_Walk Carry_Throw Carry_PickupItem");
     xAnimTableAddTransition(animTable, pTran, "Carry_IdleItem Carry_WalkItem Carry_ThrowItem");
 
-    xAnimTableNewTransition(animTable, "Idle01 Idle02 Idle03 Idle04 SlipIdle01 Inactive01 Inactive02 Inactive03 Inactive04 Inactive05 Inactive06 Inactive07 ", "Talk01", TalkCheck, NULL, 0, 0, 0.0, 0.0, 0x14, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01 Idle02 Idle03 Idle04 SlipIdle01 Inactive01 Inactive02 Inactive03 Inactive04 Inactive05 Inactive06 Inactive07 ", "Talk02", TalkCheck, NULL, 0, 1, 0.0, 0.0, 0x14, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01 Idle02 Idle03 Idle04 SlipIdle01 Inactive01 Inactive02 Inactive03 Inactive04 Inactive05 Inactive06 Inactive07 ", "Talk03", TalkCheck, NULL, 0, 2, 0.0, 0.0, 0x14, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01 Idle02 Idle03 Idle04 SlipIdle01 Inactive01 Inactive02 Inactive03 Inactive04 Inactive05 Inactive06 Inactive07 ", "Talk04", TalkCheck, NULL, 0, 3, 0.0, 0.0, 0x14, 0, 0.15, NULL);
+    xAnimTableNewTransition(
+        animTable,
+        "Idle01 Idle02 Idle03 Idle04 SlipIdle01 Inactive01 Inactive02 Inactive03 Inactive04 Inactive05 Inactive06 Inactive07 ",
+        "Talk01", TalkCheck, NULL, 0, 0, 0.0, 0.0, 0x14, 0, 0.15, NULL);
+    xAnimTableNewTransition(
+        animTable,
+        "Idle01 Idle02 Idle03 Idle04 SlipIdle01 Inactive01 Inactive02 Inactive03 Inactive04 Inactive05 Inactive06 Inactive07 ",
+        "Talk02", TalkCheck, NULL, 0, 1, 0.0, 0.0, 0x14, 0, 0.15, NULL);
+    xAnimTableNewTransition(
+        animTable,
+        "Idle01 Idle02 Idle03 Idle04 SlipIdle01 Inactive01 Inactive02 Inactive03 Inactive04 Inactive05 Inactive06 Inactive07 ",
+        "Talk03", TalkCheck, NULL, 0, 2, 0.0, 0.0, 0x14, 0, 0.15, NULL);
+    xAnimTableNewTransition(
+        animTable,
+        "Idle01 Idle02 Idle03 Idle04 SlipIdle01 Inactive01 Inactive02 Inactive03 Inactive04 Inactive05 Inactive06 Inactive07 ",
+        "Talk04", TalkCheck, NULL, 0, 3, 0.0, 0.0, 0x14, 0, 0.15, NULL);
 
-    xAnimTableNewTransition(animTable, "Talk01", "Idle01", TalkDoneCheck, IdleCB, 0, 0, 0.0, 0.0, 0x14, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Talk02", "Idle01", TalkDoneCheck, IdleCB, 0, 1, 0.0, 0.0, 0x14, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Talk03", "Idle01", TalkDoneCheck, IdleCB, 0, 2, 0.0, 0.0, 0x14, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Talk04", "Idle01", TalkDoneCheck, IdleCB, 0, 3, 0.0, 0.0, 0x14, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Talk01", "Idle01", TalkDoneCheck, IdleCB, 0, 0, 0.0, 0.0,
+                            0x14, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Talk02", "Idle01", TalkDoneCheck, IdleCB, 0, 1, 0.0, 0.0,
+                            0x14, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Talk03", "Idle01", TalkDoneCheck, IdleCB, 0, 2, 0.0, 0.0,
+                            0x14, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Talk04", "Idle01", TalkDoneCheck, IdleCB, 0, 3, 0.0, 0.0,
+                            0x14, 0, 0.15, NULL);
 
     return animTable;
 }
 
 xAnimTable* zEntPlayer_AnimTable()
 {
-    static const char* STANDARD_STATES[33] =
-    {
-        "Idle01",
-        "Walk01",
-        "Run01",
-        "Run02",
-        "Run03",
-        "RunOutOfWorld01",
-        "SlipRun01",
-        "SlipIdle01",
-        "Land01",
-        "LandHigh01",
-        "Idle02",
-        "Idle03",
-        "Idle04",
-        "Idle05",
-        "Idle06",
-        "Idle07",
-        "Idle08",
-        "Idle09",
-        "Idle10",
-        "Idle11",
-        "Idle12",
-        "Idle13",
-        "Inactive01",
-        "Inactive02",
-        "Inactive03",
-        "Inactive04",
-        "Inactive05",
-        "Inactive06",
-        "Inactive07",
-        "Inactive08",
-        "Inactive09",
-        "Inactive10",
-        NULL
+    static const char* STANDARD_STATES[33] = {
+        "Idle01",     "Walk01",     "Run01",      "Run02",      "Run03",      "RunOutOfWorld01",
+        "SlipRun01",  "SlipIdle01", "Land01",     "LandHigh01", "Idle02",     "Idle03",
+        "Idle04",     "Idle05",     "Idle06",     "Idle07",     "Idle08",     "Idle09",
+        "Idle10",     "Idle11",     "Idle12",     "Idle13",     "Inactive01", "Inactive02",
+        "Inactive03", "Inactive04", "Inactive05", "Inactive06", "Inactive07", "Inactive08",
+        "Inactive09", "Inactive10", NULL
     };
 
-    static const char* HIT_STATES[64] =
-    {
-        "Idle01",
-        "SlipIdle01",
-        "Walk01",
-        "Run01",
-        "Run02",
-        "Run03",
-        "SlipRun01",
-        "Land01",
-        "LandHigh01",
-        "LandRun01",
-        "Idle02",
-        "Idle03",
-        "Idle04",
-        "Idle05",
-        "Idle06",
-        "Idle07",
-        "Idle08",
-        "Idle09",
-        "Idle10",
-        "Idle11",
-        "Idle12",
-        "Idle13",
-        "Inactive01",
-        "Inactive02",
-        "Inactive03",
-        "Inactive04",
-        "Inactive05",
-        "Inactive06",
-        "Inactive07",
-        "Inactive08",
-        "Inactive09",
-        "Inactive10",
-        "TongueStart01",
-        "TongueSlide01",
-        "TongueJump01",
-        "TongueJumpXtra01",
-        "TongueDJumpApex01",
-        "TongueLand01",
-        "JumpStart01",
-        "JumpApex01",
-        "DJumpStart01",
-        "DJumpLift01",
-        "Fall01",
-        "Bspin01",
-        "BbashStart01",
-        "BbashAttack01",
-        "BbashStrike01",
-        "BbounceStart01",
-        "BbounceAttack01",
-        "BbounceStrike01",
-        "BounceStart01",
-        "BounceLift01",
-        "BounceApex01",
-        "Bbowl01",
-        "BbowlStart01",
-        "BbowlWindup01",
-        "BbowlToss01",
-        "BbowlRecover01",
-        "WallLaunch01",
-        "WallFlight01",
-        "WallFlight02",
-        "WallLand01",
-        "WallFall01",
-        NULL
-    };
+    static const char* HIT_STATES[64] = { "Idle01",
+                                          "SlipIdle01",
+                                          "Walk01",
+                                          "Run01",
+                                          "Run02",
+                                          "Run03",
+                                          "SlipRun01",
+                                          "Land01",
+                                          "LandHigh01",
+                                          "LandRun01",
+                                          "Idle02",
+                                          "Idle03",
+                                          "Idle04",
+                                          "Idle05",
+                                          "Idle06",
+                                          "Idle07",
+                                          "Idle08",
+                                          "Idle09",
+                                          "Idle10",
+                                          "Idle11",
+                                          "Idle12",
+                                          "Idle13",
+                                          "Inactive01",
+                                          "Inactive02",
+                                          "Inactive03",
+                                          "Inactive04",
+                                          "Inactive05",
+                                          "Inactive06",
+                                          "Inactive07",
+                                          "Inactive08",
+                                          "Inactive09",
+                                          "Inactive10",
+                                          "TongueStart01",
+                                          "TongueSlide01",
+                                          "TongueJump01",
+                                          "TongueJumpXtra01",
+                                          "TongueDJumpApex01",
+                                          "TongueLand01",
+                                          "JumpStart01",
+                                          "JumpApex01",
+                                          "DJumpStart01",
+                                          "DJumpLift01",
+                                          "Fall01",
+                                          "Bspin01",
+                                          "BbashStart01",
+                                          "BbashAttack01",
+                                          "BbashStrike01",
+                                          "BbounceStart01",
+                                          "BbounceAttack01",
+                                          "BbounceStrike01",
+                                          "BounceStart01",
+                                          "BounceLift01",
+                                          "BounceApex01",
+                                          "Bbowl01",
+                                          "BbowlStart01",
+                                          "BbowlWindup01",
+                                          "BbowlToss01",
+                                          "BbowlRecover01",
+                                          "WallLaunch01",
+                                          "WallFlight01",
+                                          "WallFlight02",
+                                          "WallLand01",
+                                          "WallFall01",
+                                          NULL };
 
     xAnimTable* animTable = xAnimTableNew("SB", NULL, 0);
 
-    xAnimTableNewState(animTable, "Idle01",            0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Idle02",            0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Idle03",            0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Idle04",            0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Idle05",            0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Idle06",            0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Idle07",            0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Idle08",            0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Idle09",            0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Idle10",            0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Idle11",            0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Idle12",            0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Idle13",            0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "SlipIdle01",        0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Inactive01",        0x20, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Inactive02",        0x20, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Inactive03",        0x20, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Inactive04",        0x20, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Inactive05",        0x20, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Inactive06",        0x20, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Inactive07",        0x20, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Inactive08",        0x20, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Inactive09",        0x20, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Inactive10",        0x20, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Walk01",            0x10, 0x0044, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Run01",             0x10, 0x0046, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Run02",             0x10, 0x0046, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Run03",             0x10, 0x0046, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "RunOutOfWorld01",   0x10, 0x0046, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "SlipRun01",         0x10, 0x0046, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "JumpStart01",       0x20, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "JumpLift01",        0x10, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "JumpApex01",        0x20, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Fall01",            0x10, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Land01",            0x20, 0x0000, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "LandRun01",         0x20, 0x0006, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "BounceStart01",     0x20, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "BounceLift01",      0x10, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "BounceApex01",      0x20, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "DJumpStart01",      0x20, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "DJumpLift01",       0x10, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "FallHigh01",        0x20, 0x0000, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "LandHigh01",        0x20, 0x0000, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Bspin01",           0x20, 0x080A, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "BbashAttack01",     0x10, 0x4000, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "BbashStart01",      0x20, 0x0000, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "BbashStrike01",     0x20, 0x4000, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "BbashMiss01",       0x20, 0x0000, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "BbounceAttack01",   0x10, 0x4000, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "BbounceStart01",    0x20, 0x0000, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "BbounceStrike01",   0x20, 0x0000, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Bbowl01",           0x20, 0x0000, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "BbowlStart01",      0x20, 0x0000, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "BbowlWindup01",     0x10, 0x0000, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "BbowlToss01",       0x20, 0x0000, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "BbowlRecover01",    0x20, 0x0080, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "LedgeGrab01",       0x20, 0x0080, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Hit01",             0x20, 0x0080, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Hit02",             0x20, 0x0080, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Hit03",             0x20, 0x0080, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Hit04",             0x20, 0x0080, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Hit05",             0x20, 0x0080, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Defeated01",        0x00, 0x0480, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Defeated02",        0x00, 0x0480, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Defeated03",        0x00, 0x0480, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Defeated04",        0x00, 0x0480, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Defeated05",        0x00, 0x0480, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "TongueSlide01",     0x10, 0x1840, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "TongueStart01",     0x20, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "TongueJump01",      0x20, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "TongueJumpXtra01",  0x20, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "TongueDJumpApex01", 0x20, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "TongueFall01",      0x10, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "TongueLand01",      0x20, 0x1800, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "TongueTumble01",    0x20, 0x1800, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Goo01",             0x10, 0x0000, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Goo02",             0x20, 0x0000, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "GooDefeated",       0x00, 0x0480, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "WallLaunch01",      0x20, 0x008A, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "WallFlight01",      0x20, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "WallFlight02",      0x10, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "WallLand01",        0x20, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "WallFall01",        0x10, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "BoulderRoll01",     0x20, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "BoulderRoll02",     0x10, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Talk04",            0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Talk03",            0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Talk02",            0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "Talk01",            0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
-    xAnimTableNewState(animTable, "SpatulaGrab01",     0x20, 0x0080, 1.0, NULL, NULL, 0.0, NULL, NULL, xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Idle01", 0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Idle02", 0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Idle03", 0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Idle04", 0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Idle05", 0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Idle06", 0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Idle07", 0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Idle08", 0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Idle09", 0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Idle10", 0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Idle11", 0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Idle12", 0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Idle13", 0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "SlipIdle01", 0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Inactive01", 0x20, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Inactive02", 0x20, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Inactive03", 0x20, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Inactive04", 0x20, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Inactive05", 0x20, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Inactive06", 0x20, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Inactive07", 0x20, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Inactive08", 0x20, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Inactive09", 0x20, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Inactive10", 0x20, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Walk01", 0x10, 0x0044, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Run01", 0x10, 0x0046, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Run02", 0x10, 0x0046, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Run03", 0x10, 0x0046, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "RunOutOfWorld01", 0x10, 0x0046, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "SlipRun01", 0x10, 0x0046, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "JumpStart01", 0x20, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "JumpLift01", 0x10, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "JumpApex01", 0x20, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Fall01", 0x10, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Land01", 0x20, 0x0000, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "LandRun01", 0x20, 0x0006, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "BounceStart01", 0x20, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "BounceLift01", 0x10, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "BounceApex01", 0x20, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "DJumpStart01", 0x20, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "DJumpLift01", 0x10, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "FallHigh01", 0x20, 0x0000, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "LandHigh01", 0x20, 0x0000, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Bspin01", 0x20, 0x080A, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "BbashAttack01", 0x10, 0x4000, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "BbashStart01", 0x20, 0x0000, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "BbashStrike01", 0x20, 0x4000, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "BbashMiss01", 0x20, 0x0000, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "BbounceAttack01", 0x10, 0x4000, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "BbounceStart01", 0x20, 0x0000, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "BbounceStrike01", 0x20, 0x0000, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Bbowl01", 0x20, 0x0000, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "BbowlStart01", 0x20, 0x0000, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "BbowlWindup01", 0x10, 0x0000, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "BbowlToss01", 0x20, 0x0000, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "BbowlRecover01", 0x20, 0x0080, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "LedgeGrab01", 0x20, 0x0080, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Hit01", 0x20, 0x0080, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Hit02", 0x20, 0x0080, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Hit03", 0x20, 0x0080, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Hit04", 0x20, 0x0080, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Hit05", 0x20, 0x0080, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Defeated01", 0x00, 0x0480, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Defeated02", 0x00, 0x0480, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Defeated03", 0x00, 0x0480, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Defeated04", 0x00, 0x0480, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Defeated05", 0x00, 0x0480, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "TongueSlide01", 0x10, 0x1840, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "TongueStart01", 0x20, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "TongueJump01", 0x20, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "TongueJumpXtra01", 0x20, 0x000A, 1.0, NULL, NULL, 0.0, NULL,
+                       NULL, xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "TongueDJumpApex01", 0x20, 0x000A, 1.0, NULL, NULL, 0.0, NULL,
+                       NULL, xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "TongueFall01", 0x10, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "TongueLand01", 0x20, 0x1800, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "TongueTumble01", 0x20, 0x1800, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Goo01", 0x10, 0x0000, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Goo02", 0x20, 0x0000, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "GooDefeated", 0x00, 0x0480, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "WallLaunch01", 0x20, 0x008A, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "WallFlight01", 0x20, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "WallFlight02", 0x10, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "WallLand01", 0x20, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "WallFall01", 0x10, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "BoulderRoll01", 0x20, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "BoulderRoll02", 0x10, 0x000A, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Talk04", 0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Talk03", 0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Talk02", 0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "Talk01", 0x10, 0x0001, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
+    xAnimTableNewState(animTable, "SpatulaGrab01", 0x20, 0x0080, 1.0, NULL, NULL, 0.0, NULL, NULL,
+                       xAnimDefaultBeforeEnter, NULL, NULL);
 
-    xAnimTableNewTransition(animTable, "Idle01 Idle02 Idle03 Idle04 Idle05 Idle06 Idle07 Idle08 Idle09 Idle10 Idle11 Idle12 Idle13 SlipIdle01 Inactive01 Inactive02 Inactive03 Inactive04 Inactive05 Inactive06 Inactive07 Inactive08 Inactive09 Inactive10 Walk01 Run01 Run02 Run03 Land01 LandRun01","SpatulaGrab01",SpatulaGrabCheck,SpatulaGrabCB, 0,0, 0.0,0.0,2, 0,0.15, NULL);
+    xAnimTableNewTransition(
+        animTable,
+        "Idle01 Idle02 Idle03 Idle04 Idle05 Idle06 Idle07 Idle08 Idle09 Idle10 Idle11 Idle12 Idle13 SlipIdle01 Inactive01 Inactive02 Inactive03 Inactive04 Inactive05 Inactive06 Inactive07 Inactive08 Inactive09 Inactive10 Walk01 Run01 Run02 Run03 Land01 LandRun01",
+        "SpatulaGrab01", SpatulaGrabCheck, SpatulaGrabCB, 0, 0, 0.0, 0.0, 2, 0, 0.15, NULL);
 
-    xAnimTableNewTransition(animTable, "SpatulaGrab01", "Idle01",                  NULL, SpatulaGrabStopCB, 0x10, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle02",        "Idle01", InactiveFinishedCheck,            IdleCB, 0x00, 0, 0.0, 0.0, 0, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle03",        "Idle01", InactiveFinishedCheck,            IdleCB, 0x00, 0, 0.0, 0.0, 0, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle04",        "Idle01", InactiveFinishedCheck,            IdleCB, 0x00, 0, 0.0, 0.0, 0, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle05",        "Idle01", InactiveFinishedCheck,            IdleCB, 0x00, 0, 0.0, 0.0, 0, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle06",        "Idle01", InactiveFinishedCheck,            IdleCB, 0x00, 0, 0.0, 0.0, 0, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle07",        "Idle01", InactiveFinishedCheck,            IdleCB, 0x00, 0, 0.0, 0.0, 0, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle08",        "Idle01", InactiveFinishedCheck,            IdleCB, 0x00, 0, 0.0, 0.0, 0, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle09",        "Idle01", InactiveFinishedCheck,            IdleCB, 0x00, 0, 0.0, 0.0, 0, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle11",        "Idle01", InactiveFinishedCheck,            IdleCB, 0x00, 0, 0.0, 0.0, 0, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle12",        "Idle01", InactiveFinishedCheck,            IdleCB, 0x00, 0, 0.0, 0.0, 0, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Inactive01",    "Idle01",                  NULL,            IdleCB, 0x10, 0, 0.0, 0.0, 0, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Inactive02",    "Idle01",                  NULL,            IdleCB, 0x10, 0, 0.0, 0.0, 0, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Inactive03",    "Idle01",                  NULL,            IdleCB, 0x10, 0, 0.0, 0.0, 0, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Inactive04",    "Idle01",                  NULL,            IdleCB, 0x10, 0, 0.0, 0.0, 0, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Inactive05",    "Idle01",                  NULL,            IdleCB, 0x10, 0, 0.0, 0.0, 0, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Inactive06",    "Idle01",                  NULL,            IdleCB, 0x10, 0, 0.0, 0.0, 0, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Inactive07",    "Idle01",                  NULL,            IdleCB, 0x10, 0, 0.0, 0.0, 0, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Inactive08",    "Idle01",                  NULL,            IdleCB, 0x10, 0, 0.0, 0.0, 0, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Inactive09",    "Idle01",                  NULL,            IdleCB, 0x10, 0, 0.0, 0.0, 0, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Inactive10",    "Idle01",                  NULL,            IdleCB, 0x10, 0, 0.0, 0.0, 0, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Land01",        "Idle01",                  NULL,            IdleCB, 0x10, 0, 0.0, 0.0, 0, 0, 0.10, NULL);
-    xAnimTableNewTransition(animTable, "LandHigh01",    "Idle01",                  NULL,            IdleCB, 0x10, 0, 0.0, 0.0, 0, 0, 0.10, NULL);
+    xAnimTableNewTransition(animTable, "SpatulaGrab01", "Idle01", NULL, SpatulaGrabStopCB, 0x10, 0,
+                            0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Idle02", "Idle01", InactiveFinishedCheck, IdleCB, 0x00, 0,
+                            0.0, 0.0, 0, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Idle03", "Idle01", InactiveFinishedCheck, IdleCB, 0x00, 0,
+                            0.0, 0.0, 0, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Idle04", "Idle01", InactiveFinishedCheck, IdleCB, 0x00, 0,
+                            0.0, 0.0, 0, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Idle05", "Idle01", InactiveFinishedCheck, IdleCB, 0x00, 0,
+                            0.0, 0.0, 0, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Idle06", "Idle01", InactiveFinishedCheck, IdleCB, 0x00, 0,
+                            0.0, 0.0, 0, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Idle07", "Idle01", InactiveFinishedCheck, IdleCB, 0x00, 0,
+                            0.0, 0.0, 0, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Idle08", "Idle01", InactiveFinishedCheck, IdleCB, 0x00, 0,
+                            0.0, 0.0, 0, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Idle09", "Idle01", InactiveFinishedCheck, IdleCB, 0x00, 0,
+                            0.0, 0.0, 0, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Idle11", "Idle01", InactiveFinishedCheck, IdleCB, 0x00, 0,
+                            0.0, 0.0, 0, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Idle12", "Idle01", InactiveFinishedCheck, IdleCB, 0x00, 0,
+                            0.0, 0.0, 0, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Inactive01", "Idle01", NULL, IdleCB, 0x10, 0, 0.0, 0.0, 0,
+                            0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Inactive02", "Idle01", NULL, IdleCB, 0x10, 0, 0.0, 0.0, 0,
+                            0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Inactive03", "Idle01", NULL, IdleCB, 0x10, 0, 0.0, 0.0, 0,
+                            0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Inactive04", "Idle01", NULL, IdleCB, 0x10, 0, 0.0, 0.0, 0,
+                            0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Inactive05", "Idle01", NULL, IdleCB, 0x10, 0, 0.0, 0.0, 0,
+                            0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Inactive06", "Idle01", NULL, IdleCB, 0x10, 0, 0.0, 0.0, 0,
+                            0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Inactive07", "Idle01", NULL, IdleCB, 0x10, 0, 0.0, 0.0, 0,
+                            0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Inactive08", "Idle01", NULL, IdleCB, 0x10, 0, 0.0, 0.0, 0,
+                            0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Inactive09", "Idle01", NULL, IdleCB, 0x10, 0, 0.0, 0.0, 0,
+                            0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Inactive10", "Idle01", NULL, IdleCB, 0x10, 0, 0.0, 0.0, 0,
+                            0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Land01", "Idle01", NULL, IdleCB, 0x10, 0, 0.0, 0.0, 0, 0,
+                            0.10, NULL);
+    xAnimTableNewTransition(animTable, "LandHigh01", "Idle01", NULL, IdleCB, 0x10, 0, 0.0, 0.0, 0,
+                            0, 0.10, NULL);
 
-    xAnimTableNewTransition(animTable, "Idle01 Walk01 Run01 Run02 Run03 RunOutOfWorld01 SlipRun01", "SlipIdle01", IdleSlipCheck, IdleCB, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Idle01 Walk01 Run01 Run02 Run03 RunOutOfWorld01 SlipRun01",
+                            "SlipIdle01", IdleSlipCheck, IdleCB, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
 
-    xAnimTableNewTransition(animTable, "LandRun01",  "SlipIdle01", IdleSlipCheck,     IdleCB, 0, 0x00000000, 0.0, 0.0, 1, 0, 0.10, NULL);
-    xAnimTableNewTransition(animTable, "SlipIdle01", "Idle01",         IdleCheck,     IdleCB, 0, 0x00000000, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Walk01",     "Idle01",         IdleCheck,     IdleCB, 0, 0x00000000, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Run01",      "Idle01",         IdleCheck,     IdleCB, 0, 0x00000000, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Run02",      "Idle10",  IdleVictoryCheck,     IdleCB, 0, 0x00000000, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Run02",      "Idle01",    IdleStoicCheck,     IdleCB, 0, 0x00000000, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle10",     "Idle01",    IdleStoicCheck,     IdleCB, 0, 0x00000000, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01",     "Idle10",  IdleVictoryCheck,     IdleCB, 0, 0x00000000, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Run03",      "Idle13",   IdleScaredCheck,     IdleCB, 0, 0x00000000, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Run03",      "Idle01",    IdleStoicCheck,     IdleCB, 0, 0x00000000, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle13",     "Idle01",    IdleStoicCheck,     IdleCB, 0, 0x00000000, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01",     "Idle13",   IdleScaredCheck,     IdleCB, 0, 0x00000000, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "LandRun01",  "Idle01",         IdleCheck,     IdleCB, 0, 0x00000000, 0.0, 0.0, 1, 0, 0.10, NULL);
-    xAnimTableNewTransition(animTable, "SlipRun01",  "Idle01",         IdleCheck,     IdleCB, 0, 0x00000000, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01",     "Idle02",     InactiveCheck, InactiveCB, 0, 0x00140000, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01",     "Idle03",     InactiveCheck, InactiveCB, 0, 0x00140001, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01",     "Idle04",     InactiveCheck, InactiveCB, 0, 0x00140002, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01",     "Idle05",     InactiveCheck, InactiveCB, 0, 0x00140003, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01",     "Idle06",     InactiveCheck, InactiveCB, 0, 0x00140004, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01",     "Idle07",     InactiveCheck, InactiveCB, 0, 0x00140005, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01",     "Idle08",     InactiveCheck, InactiveCB, 0, 0x00140006, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01",     "Idle09",     InactiveCheck, InactiveCB, 0, 0x00140007, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01",     "Idle11",     InactiveCheck, InactiveCB, 0, 0x00140008, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01",     "Idle12",     InactiveCheck, InactiveCB, 0, 0x00140009, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01",     "Inactive01", InactiveCheck, InactiveCB, 0, 0x0014000a, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01",     "Inactive02", InactiveCheck, InactiveCB, 0, 0x0014000b, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01",     "Inactive03", InactiveCheck, InactiveCB, 0, 0x0014000c, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01",     "Inactive04", InactiveCheck, InactiveCB, 0, 0x0014000d, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01",     "Inactive05", InactiveCheck, InactiveCB, 0, 0x0014000e, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01",     "Inactive06", InactiveCheck, InactiveCB, 0, 0x0014000f, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01",     "Inactive07", InactiveCheck, InactiveCB, 0, 0x00140010, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01",     "Inactive08", InactiveCheck, InactiveCB, 0, 0x00140011, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01",     "Inactive09", InactiveCheck, InactiveCB, 0, 0x00140012, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01",     "Inactive10", InactiveCheck, InactiveCB, 0, 0x00140013, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "LandRun01", "SlipIdle01", IdleSlipCheck, IdleCB, 0,
+                            0x00000000, 0.0, 0.0, 1, 0, 0.10, NULL);
+    xAnimTableNewTransition(animTable, "SlipIdle01", "Idle01", IdleCheck, IdleCB, 0, 0x00000000,
+                            0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Walk01", "Idle01", IdleCheck, IdleCB, 0, 0x00000000, 0.0,
+                            0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Run01", "Idle01", IdleCheck, IdleCB, 0, 0x00000000, 0.0,
+                            0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Run02", "Idle10", IdleVictoryCheck, IdleCB, 0, 0x00000000,
+                            0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Run02", "Idle01", IdleStoicCheck, IdleCB, 0, 0x00000000,
+                            0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Idle10", "Idle01", IdleStoicCheck, IdleCB, 0, 0x00000000,
+                            0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Idle01", "Idle10", IdleVictoryCheck, IdleCB, 0, 0x00000000,
+                            0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Run03", "Idle13", IdleScaredCheck, IdleCB, 0, 0x00000000,
+                            0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Run03", "Idle01", IdleStoicCheck, IdleCB, 0, 0x00000000,
+                            0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Idle13", "Idle01", IdleStoicCheck, IdleCB, 0, 0x00000000,
+                            0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Idle01", "Idle13", IdleScaredCheck, IdleCB, 0, 0x00000000,
+                            0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "LandRun01", "Idle01", IdleCheck, IdleCB, 0, 0x00000000, 0.0,
+                            0.0, 1, 0, 0.10, NULL);
+    xAnimTableNewTransition(animTable, "SlipRun01", "Idle01", IdleCheck, IdleCB, 0, 0x00000000, 0.0,
+                            0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Idle01", "Idle02", InactiveCheck, InactiveCB, 0, 0x00140000,
+                            0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Idle01", "Idle03", InactiveCheck, InactiveCB, 0, 0x00140001,
+                            0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Idle01", "Idle04", InactiveCheck, InactiveCB, 0, 0x00140002,
+                            0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Idle01", "Idle05", InactiveCheck, InactiveCB, 0, 0x00140003,
+                            0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Idle01", "Idle06", InactiveCheck, InactiveCB, 0, 0x00140004,
+                            0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Idle01", "Idle07", InactiveCheck, InactiveCB, 0, 0x00140005,
+                            0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Idle01", "Idle08", InactiveCheck, InactiveCB, 0, 0x00140006,
+                            0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Idle01", "Idle09", InactiveCheck, InactiveCB, 0, 0x00140007,
+                            0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Idle01", "Idle11", InactiveCheck, InactiveCB, 0, 0x00140008,
+                            0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Idle01", "Idle12", InactiveCheck, InactiveCB, 0, 0x00140009,
+                            0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Idle01", "Inactive01", InactiveCheck, InactiveCB, 0,
+                            0x0014000a, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Idle01", "Inactive02", InactiveCheck, InactiveCB, 0,
+                            0x0014000b, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Idle01", "Inactive03", InactiveCheck, InactiveCB, 0,
+                            0x0014000c, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Idle01", "Inactive04", InactiveCheck, InactiveCB, 0,
+                            0x0014000d, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Idle01", "Inactive05", InactiveCheck, InactiveCB, 0,
+                            0x0014000e, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Idle01", "Inactive06", InactiveCheck, InactiveCB, 0,
+                            0x0014000f, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Idle01", "Inactive07", InactiveCheck, InactiveCB, 0,
+                            0x00140010, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Idle01", "Inactive08", InactiveCheck, InactiveCB, 0,
+                            0x00140011, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Idle01", "Inactive09", InactiveCheck, InactiveCB, 0,
+                            0x00140012, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Idle01", "Inactive10", InactiveCheck, InactiveCB, 0,
+                            0x00140013, 0.0, 0.0, 1, 0, 0.15, NULL);
 
     xAnimTransition* tranTbl1[8];
 
-    tranTbl1[0] = xAnimTableNewTransition(animTable, STANDARD_STATES[0], "Walk01",                    WalkCheck,        NoSlipCB, 0, 0x00000000, 0.0f, 0.0f, 0x01, 0, 0.15f, NULL);
-    tranTbl1[1] = xAnimTableNewTransition(animTable, STANDARD_STATES[0], "Run01",                 RunStoicCheck,        NoSlipCB, 0, 0x00000000, 0.0f, 0.0f, 0x01, 0, 0.15f, NULL);
-    tranTbl1[2] = xAnimTableNewTransition(animTable, STANDARD_STATES[0], "Run02",               RunVictoryCheck,        NoSlipCB, 0, 0x00000000, 0.0f, 0.0f, 0x03, 0, 0.15f, NULL);
-    tranTbl1[3] = xAnimTableNewTransition(animTable, STANDARD_STATES[0], "Run03",                RunScaredCheck,        NoSlipCB, 0, 0x00000000, 0.0f, 0.0f, 0x02, 0, 0.15f, NULL);
-    tranTbl1[4] = xAnimTableNewTransition(animTable, STANDARD_STATES[0], "SlipRun01",              RunSlipCheck,       SlipRunCB, 0, 0x00000000, 0.0f, 0.0f, 0x02, 0, 0.15f, NULL);
-    tranTbl1[5] = xAnimTableNewTransition(animTable, STANDARD_STATES[0], "RunOutOfWorld01",  RunOutOfWorldCheck,        NoSlipCB, 0, 0x00200100, 0.0f, 0.0f, 0x02, 0, 0.15f, NULL);
-    tranTbl1[6] = xAnimTableNewTransition(animTable, STANDARD_STATES[0], "Fall01",                    FallCheck,        NoSlipCB, 0, 0x00000000, 0.0f, 0.0f, 0x01, 0, 0.15f, NULL);
-    tranTbl1[7] = xAnimTableNewTransition(animTable, STANDARD_STATES[0], "BbashStart01",        BubbleBashCheck,    BubbleBashCB, 0, 0x00000000, 0.0f, 0.0f, 0x0A, 0, 0.00f, NULL);
+    tranTbl1[0] =
+        xAnimTableNewTransition(animTable, STANDARD_STATES[0], "Walk01", WalkCheck, NoSlipCB, 0,
+                                0x00000000, 0.0f, 0.0f, 0x01, 0, 0.15f, NULL);
+    tranTbl1[1] =
+        xAnimTableNewTransition(animTable, STANDARD_STATES[0], "Run01", RunStoicCheck, NoSlipCB, 0,
+                                0x00000000, 0.0f, 0.0f, 0x01, 0, 0.15f, NULL);
+    tranTbl1[2] =
+        xAnimTableNewTransition(animTable, STANDARD_STATES[0], "Run02", RunVictoryCheck, NoSlipCB,
+                                0, 0x00000000, 0.0f, 0.0f, 0x03, 0, 0.15f, NULL);
+    tranTbl1[3] =
+        xAnimTableNewTransition(animTable, STANDARD_STATES[0], "Run03", RunScaredCheck, NoSlipCB, 0,
+                                0x00000000, 0.0f, 0.0f, 0x02, 0, 0.15f, NULL);
+    tranTbl1[4] =
+        xAnimTableNewTransition(animTable, STANDARD_STATES[0], "SlipRun01", RunSlipCheck, SlipRunCB,
+                                0, 0x00000000, 0.0f, 0.0f, 0x02, 0, 0.15f, NULL);
+    tranTbl1[5] = xAnimTableNewTransition(animTable, STANDARD_STATES[0], "RunOutOfWorld01",
+                                          RunOutOfWorldCheck, NoSlipCB, 0, 0x00200100, 0.0f, 0.0f,
+                                          0x02, 0, 0.15f, NULL);
+    tranTbl1[6] =
+        xAnimTableNewTransition(animTable, STANDARD_STATES[0], "Fall01", FallCheck, NoSlipCB, 0,
+                                0x00000000, 0.0f, 0.0f, 0x01, 0, 0.15f, NULL);
+    tranTbl1[7] =
+        xAnimTableNewTransition(animTable, STANDARD_STATES[0], "BbashStart01", BubbleBashCheck,
+                                BubbleBashCB, 0, 0x00000000, 0.0f, 0.0f, 0x0A, 0, 0.00f, NULL);
 
     for (int i = 1; STANDARD_STATES[i] != NULL; i++)
     {
         for (U32 a = 0; a < 8; a++)
         {
-            if
-            (
-                (strcmp(STANDARD_STATES[i], tranTbl1[a]->Dest->Name) != 0) &&
-                ((i != 5 || ((S32)a != 7)))
-            )
+            if ((strcmp(STANDARD_STATES[i], tranTbl1[a]->Dest->Name) != 0) &&
+                ((i != 5 || ((S32)a != 7))))
             {
                 xAnimTableAddTransition(animTable, tranTbl1[a], STANDARD_STATES[i]);
             }
@@ -5579,14 +6170,21 @@ xAnimTable* zEntPlayer_AnimTable()
     xAnimTableAddTransition(animTable, tranTbl1[6], "LandRun01");
     xAnimTableAddTransition(animTable, tranTbl1[7], "LandRun01");
 
-    xAnimTableNewTransition(animTable, "LandRun01", "Walk01",                   WalkCheck,      NULL, 0x10,0x00000000, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "LandRun01", "Run01",                RunStoicCheck,      NULL, 0x10,0x00000000, 0.0, 0.0, 1, 0, 0.10, NULL);
-    xAnimTableNewTransition(animTable, "LandRun01", "Run02",              RunVictoryCheck,      NULL, 0x10,0x00000000, 0.0, 0.0, 3, 0, 0.10, NULL);
-    xAnimTableNewTransition(animTable, "LandRun01", "Run03",               RunScaredCheck,      NULL, 0x10,0x00000000, 0.0, 0.0, 2, 0, 0.10, NULL);
-    xAnimTableNewTransition(animTable, "LandRun01", "RunOutOfWorld01", RunOutOfWorldCheck,      NULL, 0x10,0x00200100, 0.0, 0.0, 3, 0, 0.10, NULL);
-    xAnimTableNewTransition(animTable, "LandRun01", "SlipRun01",             RunSlipCheck, SlipRunCB, 0x10,0x00000000, 0.0, 0.0, 2, 0, 0.10, NULL);
+    xAnimTableNewTransition(animTable, "LandRun01", "Walk01", WalkCheck, NULL, 0x10, 0x00000000,
+                            0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "LandRun01", "Run01", RunStoicCheck, NULL, 0x10, 0x00000000,
+                            0.0, 0.0, 1, 0, 0.10, NULL);
+    xAnimTableNewTransition(animTable, "LandRun01", "Run02", RunVictoryCheck, NULL, 0x10,
+                            0x00000000, 0.0, 0.0, 3, 0, 0.10, NULL);
+    xAnimTableNewTransition(animTable, "LandRun01", "Run03", RunScaredCheck, NULL, 0x10, 0x00000000,
+                            0.0, 0.0, 2, 0, 0.10, NULL);
+    xAnimTableNewTransition(animTable, "LandRun01", "RunOutOfWorld01", RunOutOfWorldCheck, NULL,
+                            0x10, 0x00200100, 0.0, 0.0, 3, 0, 0.10, NULL);
+    xAnimTableNewTransition(animTable, "LandRun01", "SlipRun01", RunSlipCheck, SlipRunCB, 0x10,
+                            0x00000000, 0.0, 0.0, 2, 0, 0.10, NULL);
 
-    xAnimTransition* pTran = xAnimTableNewTransition(animTable, "Idle01", "JumpStart01", JumpCheck, JumpCB, 0, 0, 0.0, 0.0, 10, 0, 0.15, NULL);
+    xAnimTransition* pTran = xAnimTableNewTransition(animTable, "Idle01", "JumpStart01", JumpCheck,
+                                                     JumpCB, 0, 0, 0.0, 0.0, 10, 0, 0.15, NULL);
 
     xAnimTableAddTransition(animTable, pTran, "Walk01");
     xAnimTableAddTransition(animTable, pTran, "Run01");
@@ -5622,7 +6220,8 @@ xAnimTable* zEntPlayer_AnimTable()
     xAnimTableAddTransition(animTable, pTran, "Inactive10");
     xAnimTableAddTransition(animTable, pTran, "Goo01");
 
-    pTran = xAnimTableNewTransition(animTable, "Idle01", "BounceStart01", BounceCheck, BounceCB, 0, 0, 0.0, 0.0, 0x0f, 0, 0.15, NULL);
+    pTran = xAnimTableNewTransition(animTable, "Idle01", "BounceStart01", BounceCheck, BounceCB, 0,
+                                    0, 0.0, 0.0, 0x0f, 0, 0.15, NULL);
 
     xAnimTableAddTransition(animTable, pTran, "SlipIdle01");
     xAnimTableAddTransition(animTable, pTran, "Walk01");
@@ -5644,17 +6243,28 @@ xAnimTable* zEntPlayer_AnimTable()
     xAnimTableAddTransition(animTable, pTran, "BbashMiss01");
 
     xAnimTransition* tranTbl2[10];
-    tranTbl2[0]  = xAnimTableNewTransition(animTable, HIT_STATES[0], "Hit01",            Hit01Check,    Hit01CB, 0, 0, 0.0, 0.0, 0x14, 0, 0.15, NULL);
-    tranTbl2[1]  = xAnimTableNewTransition(animTable, HIT_STATES[0], "Hit02",            Hit02Check,    Hit02CB, 0, 0, 0.0, 0.0, 0x14, 0, 0.15, NULL);
-    tranTbl2[2]  = xAnimTableNewTransition(animTable, HIT_STATES[0], "Hit03",            Hit03Check,    Hit03CB, 0, 0, 0.0, 0.0, 0x14, 0, 0.15, NULL);
-    tranTbl2[3]  = xAnimTableNewTransition(animTable, HIT_STATES[0], "Hit04",            Hit04Check,    Hit04CB, 0, 0, 0.0, 0.0, 0x14, 0, 0.15, NULL);
-    tranTbl2[4]  = xAnimTableNewTransition(animTable, HIT_STATES[0], "Hit05",            Hit05Check,    Hit05CB, 0, 0, 0.0, 0.0, 0x14, 0, 0.15, NULL);
-    tranTbl2[5]  = xAnimTableNewTransition(animTable, HIT_STATES[0], "Defeated01",  Defeated01Check, DefeatedCB, 0, 5, 0.0, 0.0, 0x1e, 0, 0.15, NULL);
-    tranTbl2[6]  = xAnimTableNewTransition(animTable, HIT_STATES[0], "Defeated02",  Defeated02Check, DefeatedCB, 0, 5, 0.0, 0.0, 0x1e, 0, 0.15, NULL);
-    tranTbl2[7]  = xAnimTableNewTransition(animTable, HIT_STATES[0], "Defeated03",  Defeated03Check, DefeatedCB, 0, 5, 0.0, 0.0, 0x1e, 0, 0.15, NULL);
-    tranTbl2[8]  = xAnimTableNewTransition(animTable, HIT_STATES[0], "Defeated04",  Defeated04Check, DefeatedCB, 0, 5, 0.0, 0.0, 0x1e, 0, 0.15, NULL);
-    tranTbl2[9]  = xAnimTableNewTransition(animTable, HIT_STATES[0], "Defeated05",  Defeated05Check, DefeatedCB, 0, 5, 0.0, 0.0, 0x1e, 0, 0.15, NULL);
-    tranTbl2[10] = xAnimTableNewTransition(animTable, HIT_STATES[0], "GooDefeated",        GooCheck, GooDeathCB, 0, 0, 0.0, 0.0, 0x1e, 0, 0.15, NULL);
+    tranTbl2[0] = xAnimTableNewTransition(animTable, HIT_STATES[0], "Hit01", Hit01Check, Hit01CB, 0,
+                                          0, 0.0, 0.0, 0x14, 0, 0.15, NULL);
+    tranTbl2[1] = xAnimTableNewTransition(animTable, HIT_STATES[0], "Hit02", Hit02Check, Hit02CB, 0,
+                                          0, 0.0, 0.0, 0x14, 0, 0.15, NULL);
+    tranTbl2[2] = xAnimTableNewTransition(animTable, HIT_STATES[0], "Hit03", Hit03Check, Hit03CB, 0,
+                                          0, 0.0, 0.0, 0x14, 0, 0.15, NULL);
+    tranTbl2[3] = xAnimTableNewTransition(animTable, HIT_STATES[0], "Hit04", Hit04Check, Hit04CB, 0,
+                                          0, 0.0, 0.0, 0x14, 0, 0.15, NULL);
+    tranTbl2[4] = xAnimTableNewTransition(animTable, HIT_STATES[0], "Hit05", Hit05Check, Hit05CB, 0,
+                                          0, 0.0, 0.0, 0x14, 0, 0.15, NULL);
+    tranTbl2[5] = xAnimTableNewTransition(animTable, HIT_STATES[0], "Defeated01", Defeated01Check,
+                                          DefeatedCB, 0, 5, 0.0, 0.0, 0x1e, 0, 0.15, NULL);
+    tranTbl2[6] = xAnimTableNewTransition(animTable, HIT_STATES[0], "Defeated02", Defeated02Check,
+                                          DefeatedCB, 0, 5, 0.0, 0.0, 0x1e, 0, 0.15, NULL);
+    tranTbl2[7] = xAnimTableNewTransition(animTable, HIT_STATES[0], "Defeated03", Defeated03Check,
+                                          DefeatedCB, 0, 5, 0.0, 0.0, 0x1e, 0, 0.15, NULL);
+    tranTbl2[8] = xAnimTableNewTransition(animTable, HIT_STATES[0], "Defeated04", Defeated04Check,
+                                          DefeatedCB, 0, 5, 0.0, 0.0, 0x1e, 0, 0.15, NULL);
+    tranTbl2[9] = xAnimTableNewTransition(animTable, HIT_STATES[0], "Defeated05", Defeated05Check,
+                                          DefeatedCB, 0, 5, 0.0, 0.0, 0x1e, 0, 0.15, NULL);
+    tranTbl2[10] = xAnimTableNewTransition(animTable, HIT_STATES[0], "GooDefeated", GooCheck,
+                                           GooDeathCB, 0, 0, 0.0, 0.0, 0x1e, 0, 0.15, NULL);
 
     for (U32 i = 1; HIT_STATES[i] != NULL; i++)
     {
@@ -5664,70 +6274,150 @@ xAnimTable* zEntPlayer_AnimTable()
         }
     }
 
-    xAnimTableNewTransition(animTable, "Idle01 Idle02 Idle03 Idle04 Idle05 Idle06 Idle07 Idle08 Idle09 Idle10 Idle11 Idle12 Idle13 SlipIdle01 Inactive01 Inactive02 Inactive03 Inactive04 Inactive05 Inactive06 Inactive07 Inactive08 Inactive09 Inactive10 Walk01 Run01 Run02 Run03 RunOutOfWorld01 Land01 LandHigh01 LandRun01 SlipIdle01 SlipRun01", "TongueStart01", SlideTrackCheck, SlideTrackCB, 0, 0, 0.0, 0.0, 9, 0, 0.15, NULL);
+    xAnimTableNewTransition(
+        animTable,
+        "Idle01 Idle02 Idle03 Idle04 Idle05 Idle06 Idle07 Idle08 Idle09 Idle10 Idle11 Idle12 Idle13 SlipIdle01 Inactive01 Inactive02 Inactive03 Inactive04 Inactive05 Inactive06 Inactive07 Inactive08 Inactive09 Inactive10 Walk01 Run01 Run02 Run03 RunOutOfWorld01 Land01 LandHigh01 LandRun01 SlipIdle01 SlipRun01",
+        "TongueStart01", SlideTrackCheck, SlideTrackCB, 0, 0, 0.0, 0.0, 9, 0, 0.15, NULL);
 
-    xAnimTableNewTransition(animTable, "TongueSlide01", "Idle01",       NoslideTrackCheck,NoslideTrackCB, 0x00, 0, 0.0, 0.0, 9, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "TongueStart01", "TongueSlide01",             NULL,          NULL, 0x10, 0, 0.0, 0.0, 0, 0, 0.00, NULL);
+    xAnimTableNewTransition(animTable, "TongueSlide01", "Idle01", NoslideTrackCheck, NoslideTrackCB,
+                            0x00, 0, 0.0, 0.0, 9, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "TongueStart01", "TongueSlide01", NULL, NULL, 0x10, 0, 0.0,
+                            0.0, 0, 0, 0.00, NULL);
 
-    xAnimTableNewTransition(animTable, "TongueSlide01 TongueLand01 TongueStart01","TongueFall01", TrackFallCheck, TrackFallCB, 0, 0, 0.0, 0.0, 9, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "TongueSlide01 TongueLand01 TongueStart01", "TongueFall01",
+                            TrackFallCheck, TrackFallCB, 0, 0, 0.0, 0.0, 9, 0, 0.15, NULL);
 
-    xAnimTableNewTransition(animTable, "TongueDJumpApex01",          "TongueFall01",                     NULL,     NULL, 0x10, 0, 0.0, 0.0, 0x00, 0, 0.20, NULL);
-    xAnimTableNewTransition(animTable, "TongueJump01",               "TongueFall01",                     NULL,     NULL, 0x10, 0, 0.0, 0.0, 0x00, 0, 0.08, NULL);
-    xAnimTableNewTransition(animTable, "TongueLand01",               "TongueSlide01",                    NULL,     NULL, 0x10, 0, 0.0, 0.0, 0x00, 0, 0.08, NULL);
-    xAnimTableNewTransition(animTable, "TongueSlide01 TongueLand01", "TongueJump01",                JumpCheck,   JumpCB, 0x00, 0, 0.0, 0.0, 0x0A, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "TongueJump01 TongueFall01",  "TongueJump01",    TrackPrefallJumpCheck,   JumpCB, 0x00, 0, 0.0, 0.0, 0x0F, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "TongueDJumpApex01", "TongueFall01", NULL, NULL, 0x10, 0,
+                            0.0, 0.0, 0x00, 0, 0.20, NULL);
+    xAnimTableNewTransition(animTable, "TongueJump01", "TongueFall01", NULL, NULL, 0x10, 0, 0.0,
+                            0.0, 0x00, 0, 0.08, NULL);
+    xAnimTableNewTransition(animTable, "TongueLand01", "TongueSlide01", NULL, NULL, 0x10, 0, 0.0,
+                            0.0, 0x00, 0, 0.08, NULL);
+    xAnimTableNewTransition(animTable, "TongueSlide01 TongueLand01", "TongueJump01", JumpCheck,
+                            JumpCB, 0x00, 0, 0.0, 0.0, 0x0A, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "TongueJump01 TongueFall01", "TongueJump01",
+                            TrackPrefallJumpCheck, JumpCB, 0x00, 0, 0.0, 0.0, 0x0F, 0, 0.15, NULL);
 
-    xAnimTableNewTransition(animTable, "TongueFall01", "TongueDJumpApex01", DblJumpCheck, DblJumpCB, 0, 0, 0.0, 0.0, 0x0A, 0, 0.2, NULL);
+    xAnimTableNewTransition(animTable, "TongueFall01", "TongueDJumpApex01", DblJumpCheck, DblJumpCB,
+                            0, 0, 0.0, 0.0, 0x0A, 0, 0.2, NULL);
 
-    xAnimTableNewTransition(animTable, "TongueJump01 TongueJumpXtra01 TongueDJumpApex01 TongueFall01", "TongueLand01",           LandTrackCheck,    SlideTrackCB, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "TongueJump01 TongueJumpXtra01 TongueDJumpApex01 TongueFall01", "Land01",               LandNoTrackCheck,  NoslideTrackCB, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "TongueJump01 TongueJumpXtra01 TongueDJumpApex01 TongueFall01", "LandRun01",        LandNoTrackFastCheck,            NULL, 0, 0, 0.0, 0.0, 3, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "TongueJump01 TongueJumpXtra01 TongueDJumpApex01 TongueFall01", "Walk01",           LandNoTrackWalkCheck,            NULL, 0, 0, 0.0, 0.0, 3, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "TongueJump01 TongueJumpXtra01 TongueDJumpApex01 TongueFall01", "SlipRun01",     LandNoTrackSlipRunCheck,       SlipRunCB, 0, 0, 0.0, 0.0, 4, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "TongueJump01 TongueJumpXtra01 TongueDJumpApex01 TongueFall01", "SlipIdle01",   LandNoTrackSlipIdleCheck,            NULL, 0, 0, 0.0, 0.0, 4, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable,
+                            "TongueJump01 TongueJumpXtra01 TongueDJumpApex01 TongueFall01",
+                            "TongueLand01", LandTrackCheck, SlideTrackCB, 0, 0, 0.0, 0.0, 1, 0,
+                            0.15, NULL);
+    xAnimTableNewTransition(animTable,
+                            "TongueJump01 TongueJumpXtra01 TongueDJumpApex01 TongueFall01",
+                            "Land01", LandNoTrackCheck, NoslideTrackCB, 0, 0, 0.0, 0.0, 1, 0, 0.15,
+                            NULL);
+    xAnimTableNewTransition(animTable,
+                            "TongueJump01 TongueJumpXtra01 TongueDJumpApex01 TongueFall01",
+                            "LandRun01", LandNoTrackFastCheck, NULL, 0, 0, 0.0, 0.0, 3, 0, 0.15,
+                            NULL);
+    xAnimTableNewTransition(animTable,
+                            "TongueJump01 TongueJumpXtra01 TongueDJumpApex01 TongueFall01",
+                            "Walk01", LandNoTrackWalkCheck, NULL, 0, 0, 0.0, 0.0, 3, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable,
+                            "TongueJump01 TongueJumpXtra01 TongueDJumpApex01 TongueFall01",
+                            "SlipRun01", LandNoTrackSlipRunCheck, SlipRunCB, 0, 0, 0.0, 0.0, 4, 0,
+                            0.15, NULL);
+    xAnimTableNewTransition(animTable,
+                            "TongueJump01 TongueJumpXtra01 TongueDJumpApex01 TongueFall01",
+                            "SlipIdle01", LandNoTrackSlipIdleCheck, NULL, 0, 0, 0.0, 0.0, 4, 0,
+                            0.15, NULL);
 
-    xAnimTableNewTransition(animTable,"TongueJump01", "TongueJumpXtra01", DblJumpCheck, TongueDblJumpCB, 0x20, 0, 0.0, 0.0, 0x0A, 0, 0.00, NULL);
+    xAnimTableNewTransition(animTable, "TongueJump01", "TongueJumpXtra01", DblJumpCheck,
+                            TongueDblJumpCB, 0x20, 0, 0.0, 0.0, 0x0A, 0, 0.00, NULL);
 
-    xAnimTableNewTransition(animTable, "TongueJumpXtra01","TongueDJumpApex01", NULL, TongueDblSpinCB, 0x10, 0, 0.0, 0.0, 1, 0, 0.0, NULL);
+    xAnimTableNewTransition(animTable, "TongueJumpXtra01", "TongueDJumpApex01", NULL,
+                            TongueDblSpinCB, 0x10, 0, 0.0, 0.0, 1, 0, 0.0, NULL);
 
-    xAnimTableNewTransition(animTable, "Idle01 Idle02 Idle03 Idle04 Idle05 Idle06 Idle07 Idle08 Idle09 Idle10 Idle11 Idle12 Idle13 Inactive01 Inactive02 Inactive03 Inactive04 Inactive05 Inactive06 Inactive07 Inactive08 Inactive09 Inactive10 Walk01 Run01 Run02 Run03 RunOutOfWorld01 SlipRun01 SlipIdle01 Land01 LandRun01","BoulderRoll01",BoulderRollCheck,BoulderRollWindupCB, 0,0, 0.0,0.0, 0x0A, 0,0.5, NULL);
+    xAnimTableNewTransition(
+        animTable,
+        "Idle01 Idle02 Idle03 Idle04 Idle05 Idle06 Idle07 Idle08 Idle09 Idle10 Idle11 Idle12 Idle13 Inactive01 Inactive02 Inactive03 Inactive04 Inactive05 Inactive06 Inactive07 Inactive08 Inactive09 Inactive10 Walk01 Run01 Run02 Run03 RunOutOfWorld01 SlipRun01 SlipIdle01 Land01 LandRun01",
+        "BoulderRoll01", BoulderRollCheck, BoulderRollWindupCB, 0, 0, 0.0, 0.0, 0x0A, 0, 0.5, NULL);
 
-    xAnimTableNewTransition(animTable, "BoulderRoll01", "BoulderRoll02",                 NULL, BoulderRollCB, 0x10, 0x00000000, 0.0, 0.0, 0x00, 0, 0.00, NULL);
-    xAnimTableNewTransition(animTable, "BoulderRoll02", "SlipIdle01",           IdleSlipCheck,          NULL, 0x00, 0x00000000, 0.0, 0.0, 0x0A, 0, 0.25, NULL);
-    xAnimTableNewTransition(animTable, "BoulderRoll02", "Idle01",                   IdleCheck,          NULL, 0x00, 0x00000000, 0.0, 0.0, 0x0A, 0, 0.25, NULL);
-    xAnimTableNewTransition(animTable, "BoulderRoll02", "Walk01",                   WalkCheck,          NULL, 0x00, 0x00000000, 0.0, 0.0, 0x0A, 0, 0.25, NULL);
-    xAnimTableNewTransition(animTable, "BoulderRoll02", "Run01",                RunStoicCheck,          NULL, 0x00, 0x00000000, 0.0, 0.0, 0x0A, 0, 0.25, NULL);
-    xAnimTableNewTransition(animTable, "BoulderRoll02", "Run02",              RunVictoryCheck,          NULL, 0x00, 0x00000000, 0.0, 0.0, 0x0A, 0, 0.25, NULL);
-    xAnimTableNewTransition(animTable, "BoulderRoll02", "Run03",               RunScaredCheck,          NULL, 0x00, 0x00000000, 0.0, 0.0, 0x0A, 0, 0.25, NULL);
-    xAnimTableNewTransition(animTable, "BoulderRoll02", "RunOutOfWorld01", RunOutOfWorldCheck,          NULL, 0x00, 0x00200100, 0.0, 0.0, 0x0A, 0, 0.25, NULL);
-    xAnimTableNewTransition(animTable, "BoulderRoll02", "SlipRun01",             RunSlipCheck,     SlipRunCB, 0x00, 0x00000000, 0.0, 0.0, 0x0A, 0, 0.25, NULL);
-    xAnimTableNewTransition(animTable, "BoulderRoll02", "Fall01",                   FallCheck,          NULL, 0x00, 0x00000000, 0.0, 0.0, 0x0A, 0, 0.25, NULL);
+    xAnimTableNewTransition(animTable, "BoulderRoll01", "BoulderRoll02", NULL, BoulderRollCB, 0x10,
+                            0x00000000, 0.0, 0.0, 0x00, 0, 0.00, NULL);
+    xAnimTableNewTransition(animTable, "BoulderRoll02", "SlipIdle01", IdleSlipCheck, NULL, 0x00,
+                            0x00000000, 0.0, 0.0, 0x0A, 0, 0.25, NULL);
+    xAnimTableNewTransition(animTable, "BoulderRoll02", "Idle01", IdleCheck, NULL, 0x00, 0x00000000,
+                            0.0, 0.0, 0x0A, 0, 0.25, NULL);
+    xAnimTableNewTransition(animTable, "BoulderRoll02", "Walk01", WalkCheck, NULL, 0x00, 0x00000000,
+                            0.0, 0.0, 0x0A, 0, 0.25, NULL);
+    xAnimTableNewTransition(animTable, "BoulderRoll02", "Run01", RunStoicCheck, NULL, 0x00,
+                            0x00000000, 0.0, 0.0, 0x0A, 0, 0.25, NULL);
+    xAnimTableNewTransition(animTable, "BoulderRoll02", "Run02", RunVictoryCheck, NULL, 0x00,
+                            0x00000000, 0.0, 0.0, 0x0A, 0, 0.25, NULL);
+    xAnimTableNewTransition(animTable, "BoulderRoll02", "Run03", RunScaredCheck, NULL, 0x00,
+                            0x00000000, 0.0, 0.0, 0x0A, 0, 0.25, NULL);
+    xAnimTableNewTransition(animTable, "BoulderRoll02", "RunOutOfWorld01", RunOutOfWorldCheck, NULL,
+                            0x00, 0x00200100, 0.0, 0.0, 0x0A, 0, 0.25, NULL);
+    xAnimTableNewTransition(animTable, "BoulderRoll02", "SlipRun01", RunSlipCheck, SlipRunCB, 0x00,
+                            0x00000000, 0.0, 0.0, 0x0A, 0, 0.25, NULL);
+    xAnimTableNewTransition(animTable, "BoulderRoll02", "Fall01", FallCheck, NULL, 0x00, 0x00000000,
+                            0.0, 0.0, 0x0A, 0, 0.25, NULL);
 
-    xAnimTableNewTransition(animTable, "JumpStart01",  "JumpApex01",            NULL, NULL, 0x10, 0, 0.0, 0.0, 0, 0, 0.08, NULL);
-    xAnimTableNewTransition(animTable, "JumpApex01",   "Fall01",                NULL, NULL, 0x10, 0, 0.0, 0.0, 0, 0, 0.08, NULL);
-    xAnimTableNewTransition(animTable, "BounceStart01","BounceLift01",          NULL, NULL, 0x10, 0, 0.0, 0.0, 0, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "BounceLift01", "BounceApex01", JumpApexCheck, NULL, 0x00, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "BounceApex01", "Fall01",                NULL, NULL, 0x10, 0, 0.0, 0.0, 0, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "DJumpStart01", "DJumpLift01",           NULL, NULL, 0x10, 0, 0.0, 0.0, 0, 0, 0.00, NULL);
-    xAnimTableNewTransition(animTable, "JumpLift01",   "JumpApex01",   JumpApexCheck, NULL, 0x00, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "JumpStart01", "JumpApex01", NULL, NULL, 0x10, 0, 0.0, 0.0,
+                            0, 0, 0.08, NULL);
+    xAnimTableNewTransition(animTable, "JumpApex01", "Fall01", NULL, NULL, 0x10, 0, 0.0, 0.0, 0, 0,
+                            0.08, NULL);
+    xAnimTableNewTransition(animTable, "BounceStart01", "BounceLift01", NULL, NULL, 0x10, 0, 0.0,
+                            0.0, 0, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "BounceLift01", "BounceApex01", JumpApexCheck, NULL, 0x00, 0,
+                            0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "BounceApex01", "Fall01", NULL, NULL, 0x10, 0, 0.0, 0.0, 0,
+                            0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "DJumpStart01", "DJumpLift01", NULL, NULL, 0x10, 0, 0.0, 0.0,
+                            0, 0, 0.00, NULL);
+    xAnimTableNewTransition(animTable, "JumpLift01", "JumpApex01", JumpApexCheck, NULL, 0x00, 0,
+                            0.0, 0.0, 1, 0, 0.15, NULL);
 
-    xAnimTableNewTransition(animTable, "JumpStart01 JumpLift01 JumpApex01 BounceStart01 BounceLift01 BounceApex01 Fall01","DJumpStart01",DblJumpCheck,DblJumpCB, 0, 0, 0.0, 0.0, 0x0A, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "JumpStart01 JumpLift01 JumpApex01 Fall01 WallFlight01 WallFlight02 WallLand01 WallFall01 DJumpStart01 DJumpLift01 DJumpApex01","WallLaunch01",WallJumpLaunchCheck,WallJumpLaunchCallback, 0,0, 0.0, 0.0, 0x0A, 0, 0.15, NULL);
+    xAnimTableNewTransition(
+        animTable,
+        "JumpStart01 JumpLift01 JumpApex01 BounceStart01 BounceLift01 BounceApex01 Fall01",
+        "DJumpStart01", DblJumpCheck, DblJumpCB, 0, 0, 0.0, 0.0, 0x0A, 0, 0.15, NULL);
+    xAnimTableNewTransition(
+        animTable,
+        "JumpStart01 JumpLift01 JumpApex01 Fall01 WallFlight01 WallFlight02 WallLand01 WallFall01 DJumpStart01 DJumpLift01 DJumpApex01",
+        "WallLaunch01", WallJumpLaunchCheck, WallJumpLaunchCallback, 0, 0, 0.0, 0.0, 0x0A, 0, 0.15,
+        NULL);
 
-    xAnimTableNewTransition(animTable, "WallLaunch01","WallFlight01", NULL, WallJumpCallback, 0x10, 0, 0.0, 0.0, 0, 0, 0.0, NULL);
-    xAnimTableNewTransition(animTable, "WallFlight01","WallFlight02", NULL,             NULL, 0x10, 0, 0.0, 0.0, 0, 0, 0.0, NULL);
+    xAnimTableNewTransition(animTable, "WallLaunch01", "WallFlight01", NULL, WallJumpCallback, 0x10,
+                            0, 0.0, 0.0, 0, 0, 0.0, NULL);
+    xAnimTableNewTransition(animTable, "WallFlight01", "WallFlight02", NULL, NULL, 0x10, 0, 0.0,
+                            0.0, 0, 0, 0.0, NULL);
 
-    xAnimTableNewTransition(animTable, "WallFlight01 WallFlight02", "WallLand01",   WallJumpFlightLandCheck, WallJumpFlightLandCallback, 0x00, 0, 0.0, 0.0, 0,0, 0.08, NULL);
-    xAnimTableNewTransition(animTable, "WallLand01",                "WallFlight02", WallJumpLandFlightCheck, WallJumpLandFlightCallback, 0x00, 0, 0.0, 0.0, 0,0, 0.08, NULL);
-    xAnimTableNewTransition(animTable, "WallLand01",                "WallFall01",                      NULL,                       NULL, 0x10, 0, 0.0, 0.0, 0,0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "WallFlight01 WallFlight02", "WallLand01",
+                            WallJumpFlightLandCheck, WallJumpFlightLandCallback, 0x00, 0, 0.0, 0.0,
+                            0, 0, 0.08, NULL);
+    xAnimTableNewTransition(animTable, "WallLand01", "WallFlight02", WallJumpLandFlightCheck,
+                            WallJumpLandFlightCallback, 0x00, 0, 0.0, 0.0, 0, 0, 0.08, NULL);
+    xAnimTableNewTransition(animTable, "WallLand01", "WallFall01", NULL, NULL, 0x10, 0, 0.0, 0.0, 0,
+                            0, 0.15, NULL);
 
-    xAnimTableNewTransition(animTable, "JumpApex01 Fall01 DJumpLift01 WallFlight01 WallFlight02 WallLand01 WallFall01 BbashMiss01", "Land01",             LandCheck,        LandCallback, 0,0, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "JumpApex01 Fall01 DJumpLift01 WallFlight01 WallFlight02 WallLand01 WallFall01 BbashMiss01", "LandHigh01",     LandHighCheck,        LandCallback, 0,0, 0.0, 0.0, 2, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "JumpApex01 Fall01 DJumpLift01 WallFlight01 WallFlight02 WallLand01 WallFall01 BbashMiss01", "LandRun01",       LandRunCheck,        LandCallback, 0,0, 0.0, 0.0, 3, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "JumpApex01 Fall01 DJumpLift01 WallFlight01 WallFlight02 WallLand01 WallFall01 BbashMiss01", "SlipRun01",   LandSlipRunCheck, LandSlipRunCallback, 0,0, 0.0, 0.0, 4, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "JumpApex01 Fall01 DJumpLift01 WallFlight01 WallFlight02 WallLand01 WallFall01 BbashMiss01", "SlipIdle01", LandSlipIdleCheck,        LandCallback, 0,0, 0.0, 0.0, 4, 0, 0.15, NULL);
+    xAnimTableNewTransition(
+        animTable,
+        "JumpApex01 Fall01 DJumpLift01 WallFlight01 WallFlight02 WallLand01 WallFall01 BbashMiss01",
+        "Land01", LandCheck, LandCallback, 0, 0, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(
+        animTable,
+        "JumpApex01 Fall01 DJumpLift01 WallFlight01 WallFlight02 WallLand01 WallFall01 BbashMiss01",
+        "LandHigh01", LandHighCheck, LandCallback, 0, 0, 0.0, 0.0, 2, 0, 0.15, NULL);
+    xAnimTableNewTransition(
+        animTable,
+        "JumpApex01 Fall01 DJumpLift01 WallFlight01 WallFlight02 WallLand01 WallFall01 BbashMiss01",
+        "LandRun01", LandRunCheck, LandCallback, 0, 0, 0.0, 0.0, 3, 0, 0.15, NULL);
+    xAnimTableNewTransition(
+        animTable,
+        "JumpApex01 Fall01 DJumpLift01 WallFlight01 WallFlight02 WallLand01 WallFall01 BbashMiss01",
+        "SlipRun01", LandSlipRunCheck, LandSlipRunCallback, 0, 0, 0.0, 0.0, 4, 0, 0.15, NULL);
+    xAnimTableNewTransition(
+        animTable,
+        "JumpApex01 Fall01 DJumpLift01 WallFlight01 WallFlight02 WallLand01 WallFall01 BbashMiss01",
+        "SlipIdle01", LandSlipIdleCheck, LandCallback, 0, 0, 0.0, 0.0, 4, 0, 0.15, NULL);
 
-    pTran = xAnimTableNewTransition(animTable, "Idle01", "Bspin01", BubbleSpinCheck, BubbleSpinCB, 0, 0, 0.0, 0.0, 0x0A, 0, 0.05, NULL);
+    pTran = xAnimTableNewTransition(animTable, "Idle01", "Bspin01", BubbleSpinCheck, BubbleSpinCB,
+                                    0, 0, 0.0, 0.0, 0x0A, 0, 0.05, NULL);
 
     xAnimTableAddTransition(animTable, pTran, "Idle02");
     xAnimTableAddTransition(animTable, pTran, "Idle03");
@@ -5769,7 +6459,8 @@ xAnimTable* zEntPlayer_AnimTable()
     xAnimTableAddTransition(animTable, pTran, "DJumpLift01");
     xAnimTableAddTransition(animTable, pTran, "Fall01");
 
-    pTran = xAnimTableNewTransition(animTable,"JumpStart01","BbounceStart01", BubbleBounceCheck,BubbleBounceCB, 0,0, 0.0, 0.0, 0x0A, 0, 0.15, NULL);
+    pTran = xAnimTableNewTransition(animTable, "JumpStart01", "BbounceStart01", BubbleBounceCheck,
+                                    BubbleBounceCB, 0, 0, 0.0, 0.0, 0x0A, 0, 0.15, NULL);
 
     xAnimTableAddTransition(animTable, pTran, "JumpLift01");
     xAnimTableAddTransition(animTable, pTran, "JumpApex01");
@@ -5781,68 +6472,133 @@ xAnimTable* zEntPlayer_AnimTable()
     xAnimTableAddTransition(animTable, pTran, "Fall01");
     xAnimTableAddTransition(animTable, pTran, "BbashMiss01");
 
-    xAnimTableNewTransition(animTable, "Bspin01",         "SlipIdle01",           IdleSlipCheck,          IdleCB, 0x10, 0x00000000, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Bspin01",         "Idle01",                   IdleCheck,          IdleCB, 0x10, 0x00000000, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Bspin01",         "Walk01",                   WalkCheck,            NULL, 0x10, 0x00000000, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Bspin01",         "Run01",                RunStoicCheck,            NULL, 0x10, 0x00000000, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Bspin01",         "Run03",               RunScaredCheck,            NULL, 0x10, 0x00000000, 0.0, 0.0, 2, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Bspin01",         "Run02",              RunVictoryCheck,            NULL, 0x10, 0x00000000, 0.0, 0.0, 3, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Bspin01",         "RunOutOfWorld01", RunOutOfWorldCheck,            NULL, 0x10, 0x00200100, 0.0, 0.0, 3, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Bspin01",         "SlipRun01",             RunSlipCheck,       SlipRunCB, 0x10, 0x00000000, 0.0, 0.0, 4, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Bspin01",         "Fall01",                        NULL,            NULL, 0x10, 0x00000000, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "BbashStart01",    "BbashAttack01",                 NULL,            NULL, 0x10, 0x00000000, 0.0, 0.0, 1, 0, 0.00, NULL);
-    xAnimTableNewTransition(animTable, "BbashStart01",    "BbashStrike01",     BBashStrikeCheck,   BBashStrikeCB, 0x00, 0x00000000, 0.0, 0.0, 2, 0, 0.10, NULL);
-    xAnimTableNewTransition(animTable, "BbashAttack01",   "BbashStrike01",     BBashStrikeCheck,   BBashStrikeCB, 0x00, 0x00000000, 0.0, 0.0, 2, 0, 0.10, NULL);
-    xAnimTableNewTransition(animTable, "BbashAttack01",   "BbashMiss01",       BBashToJumpCheck,            NULL, 0x00, 0x00000000, 0.0, 0.0, 1, 0, 0.10, NULL);
-    xAnimTableNewTransition(animTable, "BbashStrike01",   "Fall01",                        NULL,            NULL, 0x10, 0x00000000, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "BbashMiss01",     "Fall01",                        NULL,            NULL, 0x10, 0x00000000, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "BbounceStart01",  "BbounceAttack01",               NULL, BBounceAttackCB, 0x10, 0x00000000, 0.0, 0.0, 1, 0, 0.10, NULL);
-    xAnimTableNewTransition(animTable, "BbounceAttack01", "BbounceStrike01", BBounceStrikeCheck, BBounceStrikeCB, 0x00, 0x00000000, 0.0, 0.0, 1, 0, 0.00, NULL);
-    xAnimTableNewTransition(animTable, "BbounceAttack01", "JumpLift01",      BBounceToJumpCheck, BBounceToJumpCB, 0x00, 0x00000000, 0.0, 0.0, 1, 0, 0.10, NULL);
-    xAnimTableNewTransition(animTable, "BbounceStrike01", "SlipIdle01",           IdleSlipCheck,          IdleCB, 0x10, 0x00000000, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "BbounceStrike01", "Idle01",                   IdleCheck,          IdleCB, 0x10, 0x00000000, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "BbounceStrike01", "Walk01",                   WalkCheck,            NULL, 0x10, 0x00000000, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "BbounceStrike01", "Run01",                RunStoicCheck,            NULL, 0x10, 0x00000000, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "BbounceStrike01", "Run03",               RunScaredCheck,            NULL, 0x10, 0x00000000, 0.0, 0.0, 2, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "BbounceStrike01", "Run02",              RunVictoryCheck,            NULL, 0x10, 0x00000000, 0.0, 0.0, 3, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "BbounceStrike01", "RunOutOfWorld01", RunOutOfWorldCheck,            NULL, 0x10, 0x00200100, 0.0, 0.0, 3, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "BbounceStrike01", "SlipRun01",             RunSlipCheck,       SlipRunCB, 0x10, 0x00000000, 0.0, 0.0, 4, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Bspin01", "SlipIdle01", IdleSlipCheck, IdleCB, 0x10,
+                            0x00000000, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Bspin01", "Idle01", IdleCheck, IdleCB, 0x10, 0x00000000,
+                            0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Bspin01", "Walk01", WalkCheck, NULL, 0x10, 0x00000000, 0.0,
+                            0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Bspin01", "Run01", RunStoicCheck, NULL, 0x10, 0x00000000,
+                            0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Bspin01", "Run03", RunScaredCheck, NULL, 0x10, 0x00000000,
+                            0.0, 0.0, 2, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Bspin01", "Run02", RunVictoryCheck, NULL, 0x10, 0x00000000,
+                            0.0, 0.0, 3, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Bspin01", "RunOutOfWorld01", RunOutOfWorldCheck, NULL, 0x10,
+                            0x00200100, 0.0, 0.0, 3, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Bspin01", "SlipRun01", RunSlipCheck, SlipRunCB, 0x10,
+                            0x00000000, 0.0, 0.0, 4, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Bspin01", "Fall01", NULL, NULL, 0x10, 0x00000000, 0.0, 0.0,
+                            1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "BbashStart01", "BbashAttack01", NULL, NULL, 0x10,
+                            0x00000000, 0.0, 0.0, 1, 0, 0.00, NULL);
+    xAnimTableNewTransition(animTable, "BbashStart01", "BbashStrike01", BBashStrikeCheck,
+                            BBashStrikeCB, 0x00, 0x00000000, 0.0, 0.0, 2, 0, 0.10, NULL);
+    xAnimTableNewTransition(animTable, "BbashAttack01", "BbashStrike01", BBashStrikeCheck,
+                            BBashStrikeCB, 0x00, 0x00000000, 0.0, 0.0, 2, 0, 0.10, NULL);
+    xAnimTableNewTransition(animTable, "BbashAttack01", "BbashMiss01", BBashToJumpCheck, NULL, 0x00,
+                            0x00000000, 0.0, 0.0, 1, 0, 0.10, NULL);
+    xAnimTableNewTransition(animTable, "BbashStrike01", "Fall01", NULL, NULL, 0x10, 0x00000000, 0.0,
+                            0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "BbashMiss01", "Fall01", NULL, NULL, 0x10, 0x00000000, 0.0,
+                            0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "BbounceStart01", "BbounceAttack01", NULL, BBounceAttackCB,
+                            0x10, 0x00000000, 0.0, 0.0, 1, 0, 0.10, NULL);
+    xAnimTableNewTransition(animTable, "BbounceAttack01", "BbounceStrike01", BBounceStrikeCheck,
+                            BBounceStrikeCB, 0x00, 0x00000000, 0.0, 0.0, 1, 0, 0.00, NULL);
+    xAnimTableNewTransition(animTable, "BbounceAttack01", "JumpLift01", BBounceToJumpCheck,
+                            BBounceToJumpCB, 0x00, 0x00000000, 0.0, 0.0, 1, 0, 0.10, NULL);
+    xAnimTableNewTransition(animTable, "BbounceStrike01", "SlipIdle01", IdleSlipCheck, IdleCB, 0x10,
+                            0x00000000, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "BbounceStrike01", "Idle01", IdleCheck, IdleCB, 0x10,
+                            0x00000000, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "BbounceStrike01", "Walk01", WalkCheck, NULL, 0x10,
+                            0x00000000, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "BbounceStrike01", "Run01", RunStoicCheck, NULL, 0x10,
+                            0x00000000, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "BbounceStrike01", "Run03", RunScaredCheck, NULL, 0x10,
+                            0x00000000, 0.0, 0.0, 2, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "BbounceStrike01", "Run02", RunVictoryCheck, NULL, 0x10,
+                            0x00000000, 0.0, 0.0, 3, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "BbounceStrike01", "RunOutOfWorld01", RunOutOfWorldCheck,
+                            NULL, 0x10, 0x00200100, 0.0, 0.0, 3, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "BbounceStrike01", "SlipRun01", RunSlipCheck, SlipRunCB,
+                            0x10, 0x00000000, 0.0, 0.0, 4, 0, 0.15, NULL);
 
-    xAnimTableNewTransition(animTable, "JumpStart01 JumpLift01 JumpApex01 Fall01 DJumpStart01 DJumpLift01", "LedgeGrab01", LedgeGrabCheck, LedgeGrabCB, 0, 0, 0.0, 0.0, 0xb, 0, 0.1, NULL);
+    xAnimTableNewTransition(animTable,
+                            "JumpStart01 JumpLift01 JumpApex01 Fall01 DJumpStart01 DJumpLift01",
+                            "LedgeGrab01", LedgeGrabCheck, LedgeGrabCB, 0, 0, 0.0, 0.0, 0xb, 0, 0.1,
+                            NULL);
 
-    xAnimTableNewTransition(animTable, "LedgeGrab01", "Idle01", NULL, LedgeFinishCB, 0x10, 0, 0.0, 0.0, 0, 0, 0.1, NULL);
+    xAnimTableNewTransition(animTable, "LedgeGrab01", "Idle01", NULL, LedgeFinishCB, 0x10, 0, 0.0,
+                            0.0, 0, 0, 0.1, NULL);
 
-    xAnimTableNewTransition(animTable, "Idle01 Idle02 Idle03 Idle04 Idle05 Idle06 Idle07 Idle08 Idle09 Idle10 Idle11 Idle12 Idle13 SlipIdle01 Inactive01 Inactive02 Inactive03 Inactive04 Inactive05 Inactive06 Inactive07 Inactive09 Inactive10 Walk01 Land01 LandRun01 Run01 Run02 Run03 SlipRun01", "BbowlStart01", BbowlCheck, BbowlCB, 0, 0, 0.0, 0.0, 0x0A, 0, 0.1, NULL);
+    xAnimTableNewTransition(
+        animTable,
+        "Idle01 Idle02 Idle03 Idle04 Idle05 Idle06 Idle07 Idle08 Idle09 Idle10 Idle11 Idle12 Idle13 SlipIdle01 Inactive01 Inactive02 Inactive03 Inactive04 Inactive05 Inactive06 Inactive07 Inactive09 Inactive10 Walk01 Land01 LandRun01 Run01 Run02 Run03 SlipRun01",
+        "BbowlStart01", BbowlCheck, BbowlCB, 0, 0, 0.0, 0.0, 0x0A, 0, 0.1, NULL);
 
-    xAnimTableNewTransition(animTable, "BbowlStart01",   "BbowlWindup01",                             NULL,           NULL, 0x10, 0x00000000, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "BbowlWindup01",  "BbowlToss01",                BbowlWindupEndCheck,           NULL, 0x00, 0x00000000, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "BbowlToss01",    "BbowlRecover01",                            NULL, BbowlTossEndCB, 0x10, 0x00000000, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "BbowlRecover01", "Walk01",                   BbowlRecoverWalkCheck,           NULL, 0x00, 0x00000000, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "BbowlRecover01", "Run01",                     BbowlRecoverRunCheck,           NULL, 0x00, 0x00000000, 0.0, 0.0, 1, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "BbowlRecover01", "Run03",               BbowlRecoverRunScaredCheck,           NULL, 0x00, 0x00000000, 0.0, 0.0, 2, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "BbowlRecover01", "Run02",              BbowlRecoverRunVictoryCheck,           NULL, 0x00, 0x00000000, 0.0, 0.0, 3, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "BbowlRecover01", "RunOutOfWorld01", BbowlRecoverRunOutOfWorldCheck,           NULL, 0x00, 0x00200100, 0.0, 0.0, 3, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "BbowlRecover01", "SlipRun01",             BbowlRecoverRunSlipCheck,      SlipRunCB, 0x00, 0x00000000, 0.0, 0.0, 4, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "BbowlRecover01", "Idle01",                                    NULL,         IdleCB, 0x10, 0x00000000, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "BbowlStart01", "BbowlWindup01", NULL, NULL, 0x10,
+                            0x00000000, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "BbowlWindup01", "BbowlToss01", BbowlWindupEndCheck, NULL,
+                            0x00, 0x00000000, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "BbowlToss01", "BbowlRecover01", NULL, BbowlTossEndCB, 0x10,
+                            0x00000000, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "BbowlRecover01", "Walk01", BbowlRecoverWalkCheck, NULL,
+                            0x00, 0x00000000, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "BbowlRecover01", "Run01", BbowlRecoverRunCheck, NULL, 0x00,
+                            0x00000000, 0.0, 0.0, 1, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "BbowlRecover01", "Run03", BbowlRecoverRunScaredCheck, NULL,
+                            0x00, 0x00000000, 0.0, 0.0, 2, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "BbowlRecover01", "Run02", BbowlRecoverRunVictoryCheck, NULL,
+                            0x00, 0x00000000, 0.0, 0.0, 3, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "BbowlRecover01", "RunOutOfWorld01",
+                            BbowlRecoverRunOutOfWorldCheck, NULL, 0x00, 0x00200100, 0.0, 0.0, 3, 0,
+                            0.15, NULL);
+    xAnimTableNewTransition(animTable, "BbowlRecover01", "SlipRun01", BbowlRecoverRunSlipCheck,
+                            SlipRunCB, 0x00, 0x00000000, 0.0, 0.0, 4, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "BbowlRecover01", "Idle01", NULL, IdleCB, 0x10, 0x00000000,
+                            0.0, 0.0, 1, 0, 0.15, NULL);
 
     bungee_state::insert_animations(*animTable);
     cruise_bubble::insert_player_animations(*animTable);
 
-    xAnimTableNewTransition(animTable, "Hit01", "Idle01", NULL, IdleCB, 0x10, 0, 0.0, 0.0, 0, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Hit02", "Idle01", NULL, IdleCB, 0x10, 0, 0.0, 0.0, 0, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Hit03", "Idle01", NULL, IdleCB, 0x10, 0, 0.0, 0.0, 0, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Hit04", "Idle01", NULL, IdleCB, 0x10, 0, 0.0, 0.0, 0, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Hit05", "Idle01", NULL, IdleCB, 0x10, 0, 0.0, 0.0, 0, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Hit01", "Idle01", NULL, IdleCB, 0x10, 0, 0.0, 0.0, 0, 0,
+                            0.15, NULL);
+    xAnimTableNewTransition(animTable, "Hit02", "Idle01", NULL, IdleCB, 0x10, 0, 0.0, 0.0, 0, 0,
+                            0.15, NULL);
+    xAnimTableNewTransition(animTable, "Hit03", "Idle01", NULL, IdleCB, 0x10, 0, 0.0, 0.0, 0, 0,
+                            0.15, NULL);
+    xAnimTableNewTransition(animTable, "Hit04", "Idle01", NULL, IdleCB, 0x10, 0, 0.0, 0.0, 0, 0,
+                            0.15, NULL);
+    xAnimTableNewTransition(animTable, "Hit05", "Idle01", NULL, IdleCB, 0x10, 0, 0.0, 0.0, 0, 0,
+                            0.15, NULL);
 
-    xAnimTableNewTransition(animTable, "Idle01 Idle02 Idle03 Idle04 Idle05 Idle06 Idle07 Idle08 Idle09 Idle10 Idle11 Idle12 Idle13 SlipIdle01 Inactive01 Inactive02 Inactive03 Inactive04 Inactive05 Inactive06 Inactive07 Inactive08 Inactive09 Inactive10 ", "Talk01", TalkCheck, NULL, 0, 0, 0.0, 0.0, 0x14, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01 Idle02 Idle03 Idle04 Idle05 Idle06 Idle07 Idle08 Idle09 Idle10 Idle11 Idle12 Idle13 SlipIdle01 Inactive01 Inactive02 Inactive03 Inactive04 Inactive05 Inactive06 Inactive07 Inactive08 Inactive09 Inactive10 ", "Talk02", TalkCheck, NULL, 0, 1, 0.0, 0.0, 0x14, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01 Idle02 Idle03 Idle04 Idle05 Idle06 Idle07 Idle08 Idle09 Idle10 Idle11 Idle12 Idle13 SlipIdle01 Inactive01 Inactive02 Inactive03 Inactive04 Inactive05 Inactive06 Inactive07 Inactive08 Inactive09 Inactive10 ", "Talk03", TalkCheck, NULL, 0, 2, 0.0, 0.0, 0x14, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Idle01 Idle02 Idle03 Idle04 Idle05 Idle06 Idle07 Idle08 Idle09 Idle10 Idle11 Idle12 Idle13 SlipIdle01 Inactive01 Inactive02 Inactive03 Inactive04 Inactive05 Inactive06 Inactive07 Inactive08 Inactive09 Inactive10 ", "Talk04", TalkCheck, NULL, 0, 3, 0.0, 0.0, 0x14, 0, 0.15, NULL);
+    xAnimTableNewTransition(
+        animTable,
+        "Idle01 Idle02 Idle03 Idle04 Idle05 Idle06 Idle07 Idle08 Idle09 Idle10 Idle11 Idle12 Idle13 SlipIdle01 Inactive01 Inactive02 Inactive03 Inactive04 Inactive05 Inactive06 Inactive07 Inactive08 Inactive09 Inactive10 ",
+        "Talk01", TalkCheck, NULL, 0, 0, 0.0, 0.0, 0x14, 0, 0.15, NULL);
+    xAnimTableNewTransition(
+        animTable,
+        "Idle01 Idle02 Idle03 Idle04 Idle05 Idle06 Idle07 Idle08 Idle09 Idle10 Idle11 Idle12 Idle13 SlipIdle01 Inactive01 Inactive02 Inactive03 Inactive04 Inactive05 Inactive06 Inactive07 Inactive08 Inactive09 Inactive10 ",
+        "Talk02", TalkCheck, NULL, 0, 1, 0.0, 0.0, 0x14, 0, 0.15, NULL);
+    xAnimTableNewTransition(
+        animTable,
+        "Idle01 Idle02 Idle03 Idle04 Idle05 Idle06 Idle07 Idle08 Idle09 Idle10 Idle11 Idle12 Idle13 SlipIdle01 Inactive01 Inactive02 Inactive03 Inactive04 Inactive05 Inactive06 Inactive07 Inactive08 Inactive09 Inactive10 ",
+        "Talk03", TalkCheck, NULL, 0, 2, 0.0, 0.0, 0x14, 0, 0.15, NULL);
+    xAnimTableNewTransition(
+        animTable,
+        "Idle01 Idle02 Idle03 Idle04 Idle05 Idle06 Idle07 Idle08 Idle09 Idle10 Idle11 Idle12 Idle13 SlipIdle01 Inactive01 Inactive02 Inactive03 Inactive04 Inactive05 Inactive06 Inactive07 Inactive08 Inactive09 Inactive10 ",
+        "Talk04", TalkCheck, NULL, 0, 3, 0.0, 0.0, 0x14, 0, 0.15, NULL);
 
-    xAnimTableNewTransition(animTable, "Talk01", "Idle01", TalkDoneCheck, NULL, 0, 0, 0.0, 0.0, 0x14, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Talk02", "Idle01", TalkDoneCheck, NULL, 0, 1, 0.0, 0.0, 0x14, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Talk03", "Idle01", TalkDoneCheck, NULL, 0, 2, 0.0, 0.0, 0x14, 0, 0.15, NULL);
-    xAnimTableNewTransition(animTable, "Talk04", "Idle01", TalkDoneCheck, NULL, 0, 3, 0.0, 0.0, 0x14, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Talk01", "Idle01", TalkDoneCheck, NULL, 0, 0, 0.0, 0.0,
+                            0x14, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Talk02", "Idle01", TalkDoneCheck, NULL, 0, 1, 0.0, 0.0,
+                            0x14, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Talk03", "Idle01", TalkDoneCheck, NULL, 0, 2, 0.0, 0.0,
+                            0x14, 0, 0.15, NULL);
+    xAnimTableNewTransition(animTable, "Talk04", "Idle01", TalkDoneCheck, NULL, 0, 3, 0.0, 0.0,
+                            0x14, 0, 0.15, NULL);
 
     return animTable;
 }

--- a/src/SB/Game/zEntTeleportBox.cpp
+++ b/src/SB/Game/zEntTeleportBox.cpp
@@ -154,9 +154,6 @@ static U32 CtoOCheck(xAnimTransition*, xAnimSingle*, void* object)
     return (SQR(dx__) + SQR(dy__) + SQR(dz__) < _853_3);
 }
 
-#ifndef NON_MATCHING
-static U32 CtoOCB(xAnimTransition*, xAnimSingle*, void* object);
-#else
 static U32 CtoOCB(xAnimTransition*, xAnimSingle*, void* object)
 {
     // non-matching: floats
@@ -172,7 +169,6 @@ static U32 CtoOCB(xAnimTransition*, xAnimSingle*, void* object)
 
     return 0;
 }
-#endif
 
 static U32 JumpInEffectPlrInvisibleCB(U32, xAnimActiveEffect*, xAnimSingle*, void* object)
 {
@@ -248,9 +244,6 @@ void zEntTeleportBox_InitAll()
 
 void zEntTeleportBox_Setup(_zEntTeleportBox* ent);
 
-#if 1 // wip
-void zEntTeleportBox_Update(xEnt* rawent, xScene* sc, F32 dt);
-#else
 void zEntTeleportBox_Update(xEnt* rawent, xScene* sc, F32 dt)
 {
     _zEntTeleportBox* ent = (_zEntTeleportBox*)rawent;
@@ -415,7 +408,6 @@ void zEntTeleportBox_Update(xEnt* rawent, xScene* sc, F32 dt)
         }
     }
 }
-#endif
 
 void zEntTeleportBox_Save(_zEntTeleportBox* ent, xSerial* s)
 {

--- a/src/SB/Game/zGame.cpp
+++ b/src/SB/Game/zGame.cpp
@@ -193,7 +193,6 @@ char* str149 = "eGameWhere_SetupPlayerInit";
 char* str150 = "eGameWhere_SetupPlayerCamera";
 char* str151 = "eGameWhere_SetupPlayerEnd";
 
-#ifdef NON_MATCHING
 // Scheduling, I guess
 void zGameInit(U32 theSceneID)
 {
@@ -224,9 +223,7 @@ void zGameInit(U32 theSceneID)
     zhud::init();
     gGameWhereAmI = eGameWhere_InitEnd;
 }
-#endif
 
-#ifdef NON_MATCHING
 // Scheduling, I guess
 void zGameExit()
 {
@@ -253,9 +250,7 @@ void zGameExit()
     }
     gGameWhereAmI = eGameWhere_ExitEnd;
 }
-#endif
 
-#ifdef NON_MATCHING
 void zGameSetup()
 {
     gGameWhereAmI = eGameWhere_SetupScene;
@@ -297,7 +292,6 @@ void zGameSetup()
     zGameExtras_SceneInit();
     gGameWhereAmI = eGameWhere_SetupEnd;
 }
-#endif
 
 S32 zGameIsPaused()
 {
@@ -404,7 +398,6 @@ void zGameTakeSnapShot(RwCamera*)
 {
 }
 
-#ifdef NON_MATCHING
 // Float memes
 void zGameUpdateTransitionBubbles()
 {
@@ -415,9 +408,7 @@ void zGameUpdateTransitionBubbles()
     zParPTankUpdate(lbl_803CDA28 > sTimeElapsed ? sTimeElapsed : NULL);
     zParPTankRender();
 }
-#endif
 
-#ifdef NON_MATCHING
 // Tons of extra instructions for some reason
 void zGameScreenTransitionBegin()
 {
@@ -443,7 +434,6 @@ void zGameScreenTransitionBegin()
         }
     }
 }
-#endif
 
 //
 void zGameScreenTransitionUpdate(F32 percentComplete, char* msg)

--- a/src/SB/Game/zGoo.cpp
+++ b/src/SB/Game/zGoo.cpp
@@ -94,7 +94,6 @@ S32 zGooIs(xEnt* obj, F32& depth, U32 playerCheck)
     return ret;
 }
 
-#ifdef NON_MATCHING
 void zGooCollsBegin()
 {
     S32 i;
@@ -120,7 +119,6 @@ void zGooCollsBegin()
         }
     }
 }
-#endif
 
 void zGooCollsEnd()
 {

--- a/src/SB/Game/zLOD.cpp
+++ b/src/SB/Game/zLOD.cpp
@@ -16,7 +16,6 @@ extern F32 lbl_803CDC40; // 1.0
 extern F32 lbl_803CDC48; // 4.0
 extern F32 lbl_803CDC4C; // 10.0
 
-#ifdef NON_MATCHING
 // Float memes
 void AddToLODList(xModelInstance* model)
 {
@@ -43,8 +42,8 @@ void AddToLODList(xModelInstance* model)
             if (sManagerCount < 2048)
             {
                 F32 distscale = ((model->Mat->right).x * (model->Mat->right).x +
-                                     (model->Mat->right).y * (model->Mat->right).y +
-                                     (model->Mat->right).z * (model->Mat->right).z);
+                                 (model->Mat->right).y * (model->Mat->right).y +
+                                 (model->Mat->right).z * (model->Mat->right).z);
                 minst = model;
                 if (distscale < lbl_803CDC44)
                 {
@@ -69,7 +68,6 @@ void AddToLODList(xModelInstance* model)
         }
     };
 }
-#endif
 
 xEnt* AddToLODList(xEnt* ent, xScene* scene, void* v)
 {

--- a/src/SB/Game/zLight.cpp
+++ b/src/SB/Game/zLight.cpp
@@ -34,8 +34,6 @@ void zLightEffectSet(_zLight* zlight, S32 idx)
     }
 }
 
-#ifdef NON_MATCHING
-
 void zLightResetAll(xEnv* env)
 {
     memset(sLight, 0, sizeof(sLight));
@@ -51,9 +49,6 @@ void zLightResetAll(xEnv* env)
     }
     xPartitionDump(&sLightPart, zLight_strings);
 }
-#endif
-
-
 
 void zLightInit(void* b, void* tasset)
 {
@@ -210,7 +205,6 @@ S32 zLightEventCB(xBase* param_1, xBase* to, U32 toEvent, const float* param_4, 
     return 1;
 }
 
-#ifdef NON_MATCHING
 // Float issue
 void zLightUpdate(xBase* to, xScene* param_2, F32 dt)
 {
@@ -229,9 +223,7 @@ void zLightUpdate(xBase* to, xScene* param_2, F32 dt)
         sEffectFuncs[t->effect_idx](t, dt);
     }
 }
-#endif
 
-#if 0
 // Something is wrong with gNumTemporaryLights
 void zLightAddLocalEnv()
 {
@@ -252,9 +244,7 @@ void zLightAddLocalEnv()
         }
     }
 }
-#endif
 
-#ifdef NON_MATCHING
 // Float issue
 void zLightAddLocal(xEnt* ent)
 {
@@ -269,7 +259,6 @@ void zLightAddLocal(xEnt* ent)
     }
     xShadowSetLight(&ent->entShadow->pos, &ent->entShadow->vec, zLight_float);
 }
-#endif
 
 void zLightRemoveLocalEnv()
 {

--- a/src/SB/Game/zMovePoint.cpp
+++ b/src/SB/Game/zMovePoint.cpp
@@ -10,7 +10,6 @@ extern S32 g_mvpt_cnt;
 extern F32 lbl_803CDD40;
 extern F32 lbl_803CDD44;
 
-#if 0
 // Random load word at the end of the function for some reason.
 zMovePoint* zMovePoint_GetMemPool(S32 cnt)
 {
@@ -30,16 +29,14 @@ zMovePoint* zMovePoint_GetMemPool(S32 cnt)
     return g_mvpt_list;
 }
 
-#endif
-
 void zMovePointInit(zMovePoint* m, xMovePointAsset* asset)
 {
     xMovePointInit((xMovePoint*)m, asset);
     m->eventFunc = zMovePointEventCB;
     if (m->linkCount)
     {
-        m->link = (xLinkAsset*)(((U32*)asset + sizeof(xMovePointAsset) / 4) +
-                                (U32)asset->numPoints);
+        m->link =
+            (xLinkAsset*)(((U32*)asset + sizeof(xMovePointAsset) / 4) + (U32)asset->numPoints);
     }
     else
     {
@@ -122,7 +119,7 @@ S32 zMovePointEventCB(xBase* from, xBase* to, U32 toEvent, const F32* toParam, x
 }
 
 F32 zMovePointGetNext(const zMovePoint* current, const zMovePoint* prev, zMovePoint** next,
-                          xVec3* hdng)
+                      xVec3* hdng)
 {
     return xMovePointGetNext((xMovePoint*)current, (xMovePoint*)prev, (xMovePoint**)next, hdng);
 }

--- a/src/SB/Game/zMusic.cpp
+++ b/src/SB/Game/zMusic.cpp
@@ -24,7 +24,6 @@ extern const char zMusic_strings[];
 
 static const F32 minDelay = 0.001f;
 
-#ifdef NON_MATCHING
 void volume_reset()
 {
     volume.cur = 0.0f;
@@ -32,7 +31,6 @@ void volume_reset()
     volume.inc = 0.5f;
     memset(volume.adjusted, 0, sizeof(volume.adjusted));
 }
-#endif
 
 // Reset both music tracks to their default volume.
 void zMusicRefreshVolume()
@@ -179,7 +177,6 @@ static S32 getCurrLevelMusicEnum()
     return snd_enum;
 }
 
-#if 0
 // Probably floating point memes idk
 void zMusicNotify(S32 situation)
 {
@@ -209,7 +206,6 @@ void zMusicNotify(S32 situation)
     sMusicTimer[s->track] = s->punchDelay;
     sMusicQueueData[s->track]->game_state = gGameMode == eGameMode_Game;
 }
-#endif
 
 // Stop all tracks and set them to null.
 void zMusicKill()
@@ -268,26 +264,12 @@ void zMusicUnpause(S32 kill)
             S32 flags = i * 0x800;
             flags |= ((track->loop != 0) ? 0x8000 : 0) | 0x10000;
             flags |= 0x20000;
-            track->snd_id = xSndPlay(track->assetID, track->lastVol, 0.0f, 0xff, flags, 0, SND_CAT_MUSIC, 0.0f);
+            track->snd_id =
+                xSndPlay(track->assetID, track->lastVol, 0.0f, 0xff, flags, 0, SND_CAT_MUSIC, 0.0f);
         }
     }
 
     sMusicPaused = 0;
-}
-
-// WIP.
-#if 0
-// Not sure what's wrong with this one. Doesn't match in the slightest.
-void zMusicSetVolume(F32 vol, F32 delay)
-{
-    if (delay <= minDelay)
-    {
-        volume.end = vol;
-        volume.inc = vol - volume.cur;
-        return;
-    }
-    volume.end = vol;
-    volume.inc = (vol - volume.cur) / delay;
 }
 
 // This version of it matches 33%. It's also functionally incorrect.
@@ -296,12 +278,12 @@ void zMusicSetVolume(float vol, float delay)
     volume.cur = vol; // This makes it introduce the "frsp" instruction.
     volume.inc = vol - volume.cur;
 
-    if (delay > minDelay) // Doing the if statement likes this makes it generate the "blelr" instruction
+    if (delay >
+        minDelay) // Doing the if statement likes this makes it generate the "blelr" instruction
     {
         volume.inc = vol / delay;
     }
 }
-#endif
 
 void zMusicReset()
 {

--- a/src/SB/Game/zNPCHazard.cpp
+++ b/src/SB/Game/zNPCHazard.cpp
@@ -32,7 +32,6 @@ void zNPCHazard_Shutdown()
 {
 }
 
-#if 0
 // WIP.
 void zNPCHazard_ScenePrepare()
 {
@@ -55,8 +54,6 @@ void zNPCHazard_ScenePrepare()
         g_hazard_rawModel[i] = NULL;
     }
 }
-
-#endif
 
 void zNPCHazard_SceneReset()
 {
@@ -101,7 +98,6 @@ S32 HAZ_ord_sorttest(void* vkey, void* vitem)
     }
 }
 
-#if 0
 // Close, kind of.
 NPCHazard* HAZ_Acquire()
 {
@@ -119,8 +115,6 @@ NPCHazard* HAZ_Acquire()
     }
     return NULL;
 }
-
-#endif
 
 S32 HAZ_AvailablePool()
 {
@@ -140,7 +134,6 @@ void NPCHazard::WipeIt()
     memset(&this->custdata, 0, sizeof(this->custdata));
 }
 
-#if 0
 // WIP.
 S32 NPCHazard::ConfigHelper(en_npchaz haztype)
 {
@@ -164,8 +157,6 @@ S32 NPCHazard::ConfigHelper(en_npchaz haztype)
     }
     return result;
 }
-
-#endif
 
 void NPCHazard::Reconfigure(en_npchaz haztype)
 {
@@ -274,7 +265,6 @@ void UVAModelInfo::Hemorrage()
     uv = 0;
 }
 
-#if 0
 // Need to figure out what is wrong with the final return statement, and the b and blr swaps.
 S32 UVAModelInfo::GetUV(RwTexCoords*& coords, S32& numVertices, RpAtomic* model)
 {
@@ -293,8 +283,6 @@ S32 UVAModelInfo::GetUV(RwTexCoords*& coords, S32& numVertices, RpAtomic* model)
     coords = geom->texCoords[0];
     return (-(S32)coords->u | (U32)coords->u) >> 0x1f;
 }
-
-#endif
 
 RwV3d* NPCHazard::At() const
 {
@@ -330,9 +318,9 @@ void UVAModelInfo::SetColor(iColor_tag color)
     RpGeometry* geo = model->geometry;
 
     RwRGBA col;
-    col.red   = color.r;
+    col.red = color.r;
     col.green = color.g;
-    col.blue  = color.b;
+    col.blue = color.b;
     col.alpha = color.a;
 
     int numMats = model->geometry->matList.numMaterials;

--- a/src/SB/Game/zNPCSpawner.cpp
+++ b/src/SB/Game/zNPCSpawner.cpp
@@ -21,8 +21,9 @@ void zNPCSpawner_ScenePrepare()
     XOrdInit(&depot->spawners, sizeof(g_smdepot), 0);
     for (S32 i = 0; i < 0x10; i++)
     {
-        zNPCSpawner* sm = (zNPCSpawner*)RyzMemData::operator new(sizeof(zNPCSpawner), 'SPWN', NULL);
-        XOrdAppend(&depot->spawners, sm);
+        // FIXME: operator new call
+        // zNPCSpawner* sm = RyzMemData::operator new((size_t)sizeof(zNPCSpawner), 'SPWN', NULL);
+        // XOrdAppend(&depot->spawners, sm);
     }
 }
 
@@ -36,7 +37,6 @@ void zNPCSpawner_SceneFinish()
     XOrdDone(&depot->spawners, 0);
 }
 
-#if 0
 // Something weird with the conditions here.
 zNPCSpawner* zNPCSpawner_GetInstance()
 {
@@ -61,8 +61,6 @@ zNPCSpawner* zNPCSpawner_GetInstance()
         return NULL;
     }
 }
-
-#endif
 
 void zNPCSpawner::Subscribe(zNPCCommon* owner)
 {
@@ -98,7 +96,6 @@ S32 zNPCSpawner::AddSpawnPoint(zMovePoint* sp)
     return ack;
 }
 
-#if 0
 S32 zNPCSpawner::AddSpawnNPC(zNPCCommon* npc)
 {
     S32 ack = 0;
@@ -119,8 +116,6 @@ S32 zNPCSpawner::AddSpawnNPC(zNPCCommon* npc)
     return ack;
 }
 
-#endif
-
 void zNPCSpawner::Reset()
 {
     this->cnt_spawn = 0;
@@ -133,7 +128,6 @@ void zNPCSpawner::Reset()
     this->MapPreferred();
 }
 
-#if 0
 void zNPCSpawner::MapPreferred()
 {
     for (S32 i = 0; i < 0x10; i++)
@@ -141,16 +135,15 @@ void zNPCSpawner::MapPreferred()
         SMNPCStatus* npc_stat = &this->npcpool[i];
         if (npc_stat->npc != NULL)
         {
-            zMovePoint* sp = (zMovePoint*)npc_stat->npc->FirstAssigned();
-            if (sp != NULL && /*TODO*/)
-            {
-                npc_stat->sp_prefer = sp;
-            }
+            // FIXME
+            // zMovePoint* sp = (zMovePoint*)npc_stat->npc->FirstAssigned();
+            // if (sp != NULL&& /*TODO*/)
+            // {
+            //     npc_stat->sp_prefer = sp;
+            // }
         }
     }
 }
-
-#endif
 
 void zNPCSpawner::SetNPCStatus(zNPCCommon* npc, en_SM_NPC_STATUS status)
 {

--- a/src/SB/Game/zNPCSupplement.cpp
+++ b/src/SB/Game/zNPCSupplement.cpp
@@ -68,14 +68,12 @@ void NPCSupplement_Timestep(float dt)
     NPAR_Timestep(dt);
 }
 
-#if 0
-U32 NPCC_StreakCreate(en_npcstreak styp)
+S32 NPCC_StreakCreate(en_npcstreak styp)
 {
     StreakInfo info = info_950;
     NPCC_MakeStreakInfo(styp, &info);
     xFXStreakStart(&styp);
 }
-#endif
 
 void NPAR_ScenePrepare()
 {
@@ -111,7 +109,6 @@ void NPAR_CheckSpecials()
     g_isSpecialDay = g_gameExtrasFlags & 0b111110111;
 }
 
-#if 0
 // WIP
 void NPAR_Timestep(F32 dt)
 {
@@ -130,7 +127,6 @@ void NPAR_Timestep(F32 dt)
         }
     }
 }
-#endif
 
 NPARMgmt* NPAR_PartySetup(en_nparptyp parType, void** userData, NPARXtraData* xtraData)
 {
@@ -188,7 +184,6 @@ void NPAR_CopyNPARToPTPool(NPARData* param_1, ptank_pool__pos_color_size_uv2* pa
     param_2->uv[1].y = param_1->uv_br[1];
 }
 
-#ifdef NON_MATCHING
 // Matches, it just defines new data that won't match until that stuff can be redefined.
 // It also loads a bunch of byte stuff at the end for some reason
 // For the record it also matches when using the static colors. Externing zanyArray does not work.
@@ -362,7 +357,6 @@ void NPAR_TubeSpiralMagic(RwRGBA* color, int unused, F32 pam)
         return;
     }
 }
-#endif
 
 F32 ARCH3(F32 param_1)
 {

--- a/src/SB/Game/zNPCSupplement.h
+++ b/src/SB/Game/zNPCSupplement.h
@@ -3,7 +3,7 @@
 
 #include "iColor.h"
 
-#include "xMAth2.h"
+#include "xMath2.h"
 #include "xPtankPool.h"
 #include "xVec3.h"
 

--- a/src/SB/Game/zNPCTypeAmbient.cpp
+++ b/src/SB/Game/zNPCTypeAmbient.cpp
@@ -39,7 +39,7 @@ char* str10 = "Dance01";
 char* str11 = "Pray01";
 char* str12 = "Attack01";
 char* str13 = "zNPCAmbient";
-char* str14 = "zNPCJelly";  
+char* str14 = "zNPCJelly";
 char* str15 = "zNPCNeptune";
 
 void ZNPC_Ambient_Startup()
@@ -57,6 +57,7 @@ void ZNPC_Ambient_Shutdown()
 {
 }
 
+// FIXME: new calls aren't working
 xFactoryInst* ZNPC_Create_Ambient(S32 who, RyzMemGrow* grow, void*)
 {
     zNPCAmbient* inst = NULL;
@@ -65,28 +66,28 @@ xFactoryInst* ZNPC_Create_Ambient(S32 who, RyzMemGrow* grow, void*)
     {
     case NPC_TYPE_AMBIENT:
     {
-        inst = new (who, grow) zNPCAmbient(who);
+        // inst = new (who, grow) zNPCAmbient(who);
         break;
     }
     case NPC_TYPE_JELLYPINK:
     case NPC_TYPE_JELLYBLUE:
     {
-        inst = new (who, grow) zNPCJelly(who);
+        // inst = new (who, grow) zNPCJelly(who);
         break;
     }
     case NPC_TYPE_KINGNEPTUNE:
     {
-        inst = new (who, grow) zNPCNeptune(who);
+        // inst = new (who, grow) zNPCNeptune(who);
         break;
     }
     case NPC_TYPE_MIMEFISH:
     {
-        inst = new (who, grow) zNPCMimeFish(who);
+        // inst = new (who, grow) zNPCMimeFish(who);
         break;
     }
     case NPC_TYPE_COW:
     {
-        inst = new (who, grow) zNPCMimeFish(who);
+        // inst = new (who, grow) zNPCMimeFish(who);
         break;
     }
     }
@@ -390,7 +391,7 @@ void zNPCJelly::BUpdate(xVec3*)
     zGridUpdateEnt(this);
 }
 
-/* This should be 100% matching but it causes a vtable duplication error for some reason
+/* FIXME: This should be 100% matching but it causes a vtable duplication error for some reason */
 void zNPCNeptune::ParseINI()
 {
     zNPCAmbient::ParseINI();
@@ -398,23 +399,18 @@ void zNPCNeptune::ParseINI()
     cfg_npc->snd_trax = &g_sndTrax_Neptune;
     NPCS_SndTablePrepare(&g_sndTrax_Neptune);
 }
-*/
 
-#ifdef NON_MATCHING
 void zNPCNeptune::Reset()
 {
     zNPCAmbient::Reset();
     flags |= 0x40;
 }
-#endif
 
-/* This should be 100% matching but it causes a vtable duplication error for some reason
 void zNPCMimeFish::Reset()
 {
     zNPCAmbient::Reset();
     flg_move = 1;
 }
-*/
 
 void zNPCJelly::Process(xScene* xscn, F32 dt)
 {

--- a/src/SB/Game/zNPCTypeAmbient.h
+++ b/src/SB/Game/zNPCTypeAmbient.h
@@ -57,7 +57,9 @@ struct zNPCNeptune : zNPCAmbient
 {
     zNPCNeptune(S32 myType);
 
+    void ParseINI();
     void SelfSetup();
+    void Reset();
 
     U8 ColChkFlags() const;
     U8 ColPenFlags() const;

--- a/src/SB/Game/zNPCTypeBoss.cpp
+++ b/src/SB/Game/zNPCTypeBoss.cpp
@@ -181,7 +181,6 @@ void ZNPC_Destroy_Boss(xFactoryInst* inst)
     delete inst;
 }
 
-#ifdef NON_MATCHING
 xAnimTable* ZNPC_AnimTable_BossSBobbyArm()
 {
     xAnimTable* table;
@@ -191,7 +190,6 @@ xAnimTable* ZNPC_AnimTable_BossSBobbyArm()
     // Nearly identical, save for a redundant r5 load being skipped.
     table = xAnimTableNew("zNPCBBobbyArm", NULL, ourAnims[0]);
 
-
     xAnimTableNewState(table, g_strz_bossanim[1], 0x10, 0, _920_2, NULL, NULL, _921_2, NULL, NULL,
                        xAnimDefaultBeforeEnter, NULL, NULL);
 
@@ -199,7 +197,6 @@ xAnimTable* ZNPC_AnimTable_BossSBobbyArm()
 
     return table;
 }
-#endif
 
 void BOSS_InitEffects();
 
@@ -214,14 +211,12 @@ void zNPCBoss::Setup()
     }
 }
 
-#ifdef NON_MATCHING
 void BOSS_InitEffects()
 {
     // non-matching: scheduling
     g_pemit_holder = zParEmitterFind("PAREMIT_CLOUD");
     g_parf_holder.custom_flags = 0x100;
 }
-#endif
 
 zNPCBoss::zNPCBoss(S32 myType) : zNPCCommon(myType)
 {

--- a/src/SB/Game/zNPCTypeBossSandy.cpp
+++ b/src/SB/Game/zNPCTypeBossSandy.cpp
@@ -149,7 +149,6 @@ U32 HeadNotShocked(xAnimTransition*, xAnimSingle*, void*)
     return !(sSandyPtr->bossFlags & 0x100);
 }
 
-#if 0
 #define str_SandyBossHead (bossSandyStrings + 0xff)
 #define str_Idle01 (bossSandyStrings + 0x10d)
 #define str_Carried01 (bossSandyStrings + 0x114)
@@ -169,17 +168,16 @@ xAnimTable* ZNPC_AnimTable_BossSandyHead()
                        xAnimDefaultBeforeEnter, NULL, NULL);
 
     xAnimTableNewTransition(table, str_Idle01, str_Carried01, HeadIsCarried, NULL, 0, 0, __830,
-                            __830, 0, 0, __864, NULL);
+                            __830, 0, 0, _864, NULL);
     xAnimTableNewTransition(table, str_Carried01, str_Idle01, HeadNotCarried, NULL, 0, 0, __830,
-                            __830, 0, 0, __864, NULL);
+                            __830, 0, 0, _864, NULL);
     xAnimTableNewTransition(table, str_Idle01, str_Shocked01, HeadIsShocked, NULL, 0, 0, __830,
-                            __830, 0, 0, __864, NULL);
+                            __830, 0, 0, _864, NULL);
     xAnimTableNewTransition(table, str_Shocked01, str_Idle01, HeadNotShocked, NULL, 0, 0, __830,
-                            __830, 0, 0, __864, NULL);
+                            __830, 0, 0, _864, NULL);
 
     return table;
 }
-#endif
 
 void zNPCBSandy::ParseINI()
 {

--- a/src/SB/Game/zNPCTypeCommon.cpp
+++ b/src/SB/Game/zNPCTypeCommon.cpp
@@ -406,9 +406,6 @@ F32 zNPCCommon::GenShadCacheRad()
     return lbl_803CE4C0;
 }
 
-#if 0
-
-#else
 // xNPCBasic vtable at: 0x2949F4
 // vtable reference is stored immidately _after_ object fields in an xNPCBasic
 // instance. That is, sizeof(xNPCBasic) = sizeof(visible fields) + an extra 4
@@ -438,7 +435,6 @@ xNPCBasic::xNPCBasic(S32 value)
 {
     myNPCType = value;
 }
-#endif
 
 void xNPCBasic::Setup()
 {
@@ -449,7 +445,7 @@ void xNPCBasic::Move(xScene* xscn, F32 dt, xEntFrame* frm)
 }
 
 S32 xNPCBasic::SysEvent(xBase* from, xBase* to, U32 toEvent, const F32* toParam,
-                          xBase* toParamWidget, S32* handled)
+                        xBase* toParamWidget, S32* handled)
 {
     return 1;
 }

--- a/src/SB/Game/zNPCTypeDuplotron.cpp
+++ b/src/SB/Game/zNPCTypeDuplotron.cpp
@@ -86,7 +86,6 @@ void zNPCDuplotron::SelfSetup()
     psy->SetSafety(0x4E474430);
 }
 
-#if 0
 // non-matching: scheduling?
 void DUPO_InitEffects()
 {
@@ -105,7 +104,6 @@ void DUPO_InitEffects()
     xVec3Copy(&g_parf_overheat.pos, &g_O3);
     xVec3Copy(&g_parf_overheat.vel, &g_Y3);
 }
-#endif
 
 void DUPO_KillEffects()
 {

--- a/src/SB/Game/zNPCTypeRobot.cpp
+++ b/src/SB/Game/zNPCTypeRobot.cpp
@@ -1442,16 +1442,6 @@ xAnimTable* ZNPC_AnimTable_Slick()
     return pxVar1;
 }
 
-#if 0
-// Would work if IsDying() returned bool.
-// Some code relies on IsDying() returning S32, though.
-// e.g. zNPCRobot::NewTime
-bool zNPCTubelet::IsDying()
-{
-    return tubestat == TUBE_STAT_DEAD;
-}
-#endif
-
 void zNPCTubelet::Reset()
 {
     tubestat = TUBE_STAT_BORN;

--- a/src/SB/Game/zNPCTypeSubBoss.cpp
+++ b/src/SB/Game/zNPCTypeSubBoss.cpp
@@ -117,14 +117,12 @@ void zNPCSubBoss::Setup()
     }
 }
 
-#ifdef NON_MATCHING
 void SUBB_InitEffects()
 {
     // non-matching: scheduling
     g_pemit_holder = zParEmitterFind("PAREMIT_CLOUD");
     g_parf_holder.custom_flags = 0x100;
 }
-#endif
 
 zNPCSubBoss::zNPCSubBoss(S32 myType) : zNPCCommon(myType)
 {

--- a/src/SB/Game/zPlatform.cpp
+++ b/src/SB/Game/zPlatform.cpp
@@ -24,7 +24,7 @@ char* str8 = "skatepark_bumper";
 char* str9 = "skatepark_flipper";
 char* str10 = "Check1";
 
-void genericPlatRender(xEnt* ent)
+static void genericPlatRender(xEnt* ent)
 {
     if (!ent->model || !xEntIsVisible(ent))
     {
@@ -37,6 +37,11 @@ void genericPlatRender(xEnt* ent)
 void zPlatform_Init(void* plat, void* asset)
 {
     zPlatform_Init((zPlatform*)plat, (xEntAsset*)asset);
+}
+
+void zPlatform_Init(zPlatform* plat, xEntAsset* asset)
+{
+    zEntInit(plat, asset, 'PLAT');
 }
 
 void zPlatform_Save(zPlatform* ent, xSerial* s)
@@ -74,20 +79,19 @@ void zPlatform_Mount(zPlatform* ent)
 
                 // Needs to be used or the comparison's operands will be swapped.
                 F32 restingSpeed = 0.0f;
-                if ( ent->passet->fr.fspeed != restingSpeed )
+                if (ent->passet->fr.fspeed != restingSpeed)
                 {
                     zPlatform_Tremble(ent, 0.06f, DEG2RAD(720), ent->passet->fr.fspeed + 1.0f);
                 }
             }
-
         }
     }
 }
 
 void zPlatform_Setup(zPlatform* ent, xScene* sc)
 {
-    zEntSetup((zEnt *)ent);
-    sEmitTremble   = zParEmitterFind("PAREMIT_PLAT_TREMBLE");
+    zEntSetup((zEnt*)ent);
+    sEmitTremble = zParEmitterFind("PAREMIT_PLAT_TREMBLE");
     sEmitBreakaway = zParEmitterFind("PAREMIT_PLAT_BREAKAWAY");
     if (ent->subType == ZPLATFORM_SUBTYPE_PADDLE)
     {
@@ -108,7 +112,7 @@ void zPlatform_Dismount(zPlatform* ent)
 void zPlatformTranslate(xEnt* xent, xVec3* dpos, xMat4x3* dmat)
 {
     zPlatform* plat = (zPlatform*)xent;
-    xEntDefaultTranslate(xent,dpos,dmat);
+    xEntDefaultTranslate(xent, dpos, dmat);
     xEntMotionTranslate(&plat->motion, dpos, dmat);
 }
 

--- a/src/SB/Game/zPlatform.h
+++ b/src/SB/Game/zPlatform.h
@@ -161,7 +161,6 @@ struct zPlatform : zEnt
 #define ZPLATFORM_SUBTYPE_PADDLE 12
 #define ZPLATFORM_SUBTYPE_FM 13
 
-void genericPlatRender(xEnt* ent);
 void zPlatform_Init(void* plat, void* asset);
 void zPlatform_Init(zPlatform* plat, xEntAsset* asset);
 void zPlatform_Setup(zPlatform* plat, xScene* sc);

--- a/src/SB/Game/zScene.cpp
+++ b/src/SB/Game/zScene.cpp
@@ -741,12 +741,7 @@ static void PipeAddStuffCB(RpAtomic* data, U32 pipeFlags, U32)
     }
 }
 
-#ifndef NON_MATCHING
-static void PipeForAllSceneModels(void (*pipeCB)(RpAtomic* data, U32 pipeFlags,
-                                                 U32 subObjects));
-#else
-static void PipeForAllSceneModels(void (*pipeCB)(RpAtomic* data, U32 pipeFlags,
-                                                 U32 subObjects))
+static void PipeForAllSceneModels(void (*pipeCB)(RpAtomic* data, U32 pipeFlags, U32 subObjects))
 {
     // non-matching: wrong registers
 
@@ -809,7 +804,6 @@ static void PipeForAllSceneModels(void (*pipeCB)(RpAtomic* data, U32 pipeFlags,
         continue;
     }
 }
-#endif
 
 void zSceneInitEnvironmentalSoundEffect()
 {
@@ -862,7 +856,6 @@ static U32 BaseTypeNeedsUpdate(U8 baseType)
 
 void add_scene_tweaks();
 
-#ifdef NON_MATCHING
 void zSceneInit(U32 theSceneID, S32 reloadInProgress)
 {
     F32 pdone;
@@ -1175,13 +1168,11 @@ void zSceneInit(U32 theSceneID, S32 reloadInProgress)
     zGame_HackGalleryInit();
     iSndSuspendCD(0);
 }
-#endif
 
 void add_scene_tweaks()
 {
 }
 
-#ifdef NON_MATCHING
 void zSceneExit(S32 beginReload)
 {
     zScene* s = globals.sceneCur;
@@ -1285,7 +1276,6 @@ void zSceneExit(S32 beginReload)
 
     xSceneExit(s);
 }
-#endif
 
 void zSceneUpdateSFXWidgets()
 {
@@ -1294,9 +1284,6 @@ void zSceneUpdateSFXWidgets()
                                         s->baseCount[eBaseTypeSFX]);
 }
 
-#ifndef NON_MATCHING
-static void HackSwapIt(char* buf, S32 size);
-#else
 static void HackSwapIt(char* buf, S32 size)
 {
     // non-matching: r3 and r4 swapped
@@ -1313,9 +1300,7 @@ static void HackSwapIt(char* buf, S32 size)
         end--;
     }
 }
-#endif
 
-#ifdef NON_MATCHING
 void zSceneSwitch(_zPortal* p, S32 forceSameScene)
 {
     globals.sceneCur->pendingPortal = p;
@@ -1330,9 +1315,8 @@ void zSceneSwitch(_zPortal* p, S32 forceSameScene)
         HackSwapIt(id, 4);
     }
 
-    U32 nextSceneID = (((char*)&passet->sceneID)[0] << 24) |
-                         (((char*)&passet->sceneID)[1] << 16) |
-                         (((char*)&passet->sceneID)[2] << 8) | ((char*)&passet->sceneID)[3];
+    U32 nextSceneID = (((char*)&passet->sceneID)[0] << 24) | (((char*)&passet->sceneID)[1] << 16) |
+                      (((char*)&passet->sceneID)[2] << 8) | ((char*)&passet->sceneID)[3];
 
     if (!forceSameScene && nextSceneID == globals.sceneCur->sceneID)
     {
@@ -1392,7 +1376,6 @@ void zSceneSwitch(_zPortal* p, S32 forceSameScene)
         globals.sceneCur->pendingPortal = NULL;
     }
 }
-#endif
 
 void zSceneSave(zScene* ent, xSerial* s)
 {
@@ -2111,7 +2094,6 @@ static U32 _2098_0[] =
 };
 // clang-format on
 
-#ifdef NON_MATCHING
 void zSceneSetup()
 {
     zScene* s = globals.sceneCur;
@@ -2459,9 +2441,9 @@ void zSceneSetup()
     xEnt** entList =
         s->act_ents + s->baseCount[eBaseTypeTrigger] + s->baseCount[eBaseTypePickup]; // r28
     U32 entCount = s->baseCount[eBaseTypeStatic] + s->baseCount[eBaseTypePlatform] +
-                      s->baseCount[eBaseTypePendulum] + s->baseCount[eBaseTypeHangable] +
-                      s->baseCount[eBaseTypeDestructObj] + s->baseCount[eBaseTypeBoulder] +
-                      s->baseCount[eBaseTypeNPC] + s->baseCount[eBaseTypeButton]; // r27
+                   s->baseCount[eBaseTypePendulum] + s->baseCount[eBaseTypeHangable] +
+                   s->baseCount[eBaseTypeDestructObj] + s->baseCount[eBaseTypeBoulder] +
+                   s->baseCount[eBaseTypeNPC] + s->baseCount[eBaseTypeButton]; // r27
 
     U32 i, j, k;
     U32 numPrimeMovers = 0; // r24
@@ -2558,7 +2540,7 @@ void zSceneSetup()
     if (numDriven)
     {
         U32 allocsize = numDriven * sizeof(xGroup) + numDriven * sizeof(xGroupAsset) +
-                           (numDriven + numPrimeMovers) * sizeof(xBase*);
+                        (numDriven + numPrimeMovers) * sizeof(xBase*);
 
         driveGroupList = (xGroup*)RwMalloc(allocsize);
 
@@ -2720,7 +2702,6 @@ void zSceneSetup()
 
     xScrFxFade(&black, &clear, _1374, NULL, 0);
 }
-#endif
 
 S32 zSceneSetup_serialTraverseCB(U32 clientID, xSerial* xser)
 {
@@ -3231,7 +3212,6 @@ void zSceneRender()
     zSceneRenderPostFX();
 }
 
-#ifdef NON_MATCHING
 static void zSceneObjHashtableInit(S32 count)
 {
     scobj_idbps = (IDBasePair*)xMemAllocSize(count * sizeof(IDBasePair));
@@ -3241,16 +3221,13 @@ static void zSceneObjHashtableInit(S32 count)
     scobj_size = count;
     nidbps = 0;
 }
-#endif
 
-#ifdef NON_MATCHING
 static void zSceneObjHashtableExit()
 {
     scobj_idbps = NULL;
     scobj_size = -1;
     nidbps = -1;
 }
-#endif
 
 static S32 zSceneObjHashtableUsage()
 {
@@ -3417,7 +3394,6 @@ void zSceneMemLvlChkCB()
 {
 }
 
-#ifdef NON_MATCHING
 U32 zSceneLeavingLevel()
 {
     // non-matching: instruction order
@@ -3431,7 +3407,6 @@ U32 zSceneLeavingLevel()
 
     return (curScene[0] != nextScene[3]);
 }
-#endif
 
 const char* zSceneGetLevelName(U32 sceneID)
 {
@@ -3535,13 +3510,11 @@ void zSceneEnableScreenAdj(U32 enable)
     enableScreenAdj = enable;
 }
 
-#ifdef NON_MATCHING
 void zSceneSetOldScreenAdj()
 {
     oldOffsetx = offsetx;
     oldOffsety = offsety;
 }
-#endif
 
 U32 zScene_ScreenAdjustMode()
 {

--- a/src/SB/Game/zSurface.cpp
+++ b/src/SB/Game/zSurface.cpp
@@ -54,41 +54,6 @@ void zSurfaceResetSurface(xSurface* surf)
     surf->friction = ((zSurfaceProps*)(surf->moprops))->asset->friction;
 }
 
-#if 0
-xSurface* zSurfaceGetSurface(U32 mat_id)
-{
-    S32 map;
-    zMaterialMapAsset* mapper;
-    zMaterialMapEntry* entry;
-    U16 nsurfs;
-    xSurface* surf;
-
-    for (int i = 0; i < sMapperCount; i++)
-    {
-        mapper = sMapper[i];
-        if (mapper != NULL)
-        {
-            for (int j = 0; j < mapper->count; j++)
-            {
-                if (mapper->id == mat_id)
-                {
-                    nsurfs = xSurfaceGetNumSurfaces();
-                    for (int k = 0; k < nsurfs; k++)
-                    {
-                        surf = xSurfaceGetByIdx(k);
-                        if (surf->id == mapper->id)
-                        {
-                            return surf;
-                        }
-                    }
-                }
-            }
-        }
-    }
-    return &sDef_surf;
-}
-#endif
-
 xSurface* zSurfaceGetSurface(const xCollis* coll)
 {
     xSurface* surf = NULL;

--- a/src/SB/Game/zTaskBox.cpp
+++ b/src/SB/Game/zTaskBox.cpp
@@ -11,16 +11,18 @@
 
 extern ztaskbox* shared;
 
-#if 0
 void ztaskbox::load(const ztaskbox::asset_type& a)
 {
     xBaseInit((xBase*)this, &(xBaseAsset)a);
     this->baseType = eBaseTypeEnv;
-    this->asset = &a;
-    this->eventFunc = cb_dispatch;
+    // FIXME: can't force const to non-const?
+    // this->asset = &a;
+
+    // FIXME: Define cb_dispatch
+    // this->eventFunc = cb_dispatch;
     if (this->linkCount != 0)
     {
-        this->link = (xLinkAsset*)(a + 1);
+        this->link = (xLinkAsset*)(&a + 1);
     }
     bool enabled = a.enable;
     this->state = STATE_INVALID;
@@ -32,16 +34,14 @@ void ztaskbox::load(const ztaskbox::asset_type& a)
     else
     {
         this->flag.enabled = true;
-        set_state(this, STATE_BEGIN);
+        this->set_state(STATE_BEGIN);
         this->current = this;
     }
-    if (a->persistent)
+    if (a.persistent)
     {
         this->baseFlags |= 2;
     }
 }
-
-#endif
 
 void ztaskbox::read(xSerial& s)
 {
@@ -56,7 +56,6 @@ void ztaskbox::write(xSerial& s)
     s.Write((U8)this->state);
 }
 
-#if 0
 // WIP.
 void ztaskbox::start_talk(zNPCCommon* npc)
 {
@@ -65,7 +64,7 @@ void ztaskbox::start_talk(zNPCCommon* npc)
     {
         if (curr == this)
         {
-            if (this->flag.enabled && this->state != STATE_INVLAID)
+            if (this->flag.enabled && this->state != STATE_INVALID)
             {
                 //TODO!!!
             }
@@ -77,8 +76,6 @@ void ztaskbox::start_talk(zNPCCommon* npc)
         }
     }
 }
-
-#endif
 
 void ztaskbox::talk_callback::reset(ztaskbox& task)
 {
@@ -194,15 +191,12 @@ void ztaskbox::set_callback(callback* cb)
     this->cb = cb;
 }
 
-#if 0
 // WIP.
 void ztaskbox::init()
 {
     shared = NULL;
     // STUFF.
 }
-
-#endif
 
 ztaskbox::talk_callback::talk_callback()
 {

--- a/src/SB/Game/zTextBox.cpp
+++ b/src/SB/Game/zTextBox.cpp
@@ -37,8 +37,7 @@ namespace
     xtextbox::tag_type new_tags[] = { SUBSTR("blahblah"), parse_tag_blahblah, NULL, NULL };
     U32 new_tags_size = sizeof(new_tags) / sizeof(new_tags[0]);
 
-    void set_vert(RwIm2DVertex& vert, F32 x, F32 y, F32 u, F32 v, iColor_tag c,
-                  F32 nsz, F32 rcz);
+    void set_vert(RwIm2DVertex& vert, F32 x, F32 y, F32 u, F32 v, iColor_tag c, F32 nsz, F32 rcz);
 
     void render_bk_fill(const ztextbox& e)
     {
@@ -47,7 +46,6 @@ namespace
         render_fill_rect(e.tb.font.clip, convert(a.backdrop.color));
     }
 
-#ifdef NON_MATCHING
     void render_bk_tex_scale(const ztextbox& e)
     {
         // non-matching: float instruction order
@@ -75,10 +73,8 @@ namespace
 
         xfont::restore_render_state();
     }
-#endif
 
-    void set_vert(RwIm2DVertex& vert, F32 x, F32 y, F32 u, F32 v, iColor_tag c,
-                  F32 nsz, F32 rcz)
+    void set_vert(RwIm2DVertex& vert, F32 x, F32 y, F32 u, F32 v, iColor_tag c, F32 nsz, F32 rcz)
     {
         RwIm2DVertexSetScreenX(&vert, x);
         RwIm2DVertexSetScreenY(&vert, y);

--- a/src/SB/Game/zThrown.cpp
+++ b/src/SB/Game/zThrown.cpp
@@ -96,7 +96,6 @@ void zThrownCollide_Tiki(zThrownStruct* thrown, xEntCollis* collis, F32* bounce,
     zEntEvent(thrown->ent, eEventDestroy);
 }
 
-#if 0
 // WIP.
 S32 zThrown_IsFruit(xEnt* ent, F32* stackHeight)
 {
@@ -116,8 +115,6 @@ S32 zThrown_IsFruit(xEnt* ent, F32* stackHeight)
     }
     return 0;
 }
-
-#endif
 
 void checkAgainstButtons(xEnt* ent)
 {

--- a/src/SB/Game/zUIFont.cpp
+++ b/src/SB/Game/zUIFont.cpp
@@ -226,8 +226,7 @@ void zUIFont_Update(zUIFont* ent, xScene*, F32)
     }
 }
 
-S32 zUIFontEventCB(xBase* from, xBase* to, U32 toEvent, const F32* toParam,
-                     xBase* toParamWidget)
+S32 zUIFontEventCB(xBase* from, xBase* to, U32 toEvent, const F32* toParam, xBase* toParamWidget)
 {
     S32 rval = 1;
     zUIFont* s = (zUIFont*)to;
@@ -326,7 +325,6 @@ S32 zUIFontEventCB(xBase* from, xBase* to, U32 toEvent, const F32* toParam,
     return rval;
 }
 
-#ifdef NON_MATCHING
 void zUIFont_Render(xEnt* e)
 {
     zUIFont* ent = (zUIFont*)e;
@@ -375,7 +373,7 @@ void zUIFont_Render(xEnt* e)
         {
             iColor_tag c = xColorFromRGBA(a.bcolor[0], a.bcolor[1], a.bcolor[2], a.bcolor[3]);
             basic_rect<F32> r = { NSCREENX(a.pos.x), NSCREENY(a.pos.y), NSCREENX(a.dim[0]),
-                                      NSCREENY(a.dim[1]) };
+                                  NSCREENY(a.dim[1]) };
 
             render_fill_rect(r, c);
         }
@@ -440,7 +438,6 @@ void zUIFont_Render(xEnt* e)
         tb.render(true);
     }
 }
-#endif
 
 F32 xtextbox::yextent(F32 max, S32& size, bool cache) const
 {

--- a/src/SB/Game/zVar.cpp
+++ b/src/SB/Game/zVar.cpp
@@ -160,7 +160,6 @@ namespace
         return zVar_printf_buffer4;
     }
 
-#ifdef NON_MATCHING
     // Indexing into zVar_strings didn't get pulled out of the loop in the original
     // code for some reason.
     char* var_text_CorruptFileName()
@@ -175,7 +174,6 @@ namespace
         }
         return zVar_printf_buffer5;
     }
-#endif
 
     const char* var_text_CurrentArea()
     {
@@ -219,12 +217,7 @@ namespace
 
 // Note: zVarGameSlotInfo should be in the anonymous namespace, need the
 // anomymous namespace symbol formatting fix from Seil to move it in though.
-#if 1
-// Needed for the following functions to call, but not to be exposed in the
-// header file.
-char* zVarGameSlotInfo(S32 i, char* buffer, size_t something);
 
-#else
 // I don't understand this function. The behavior perfectly matches... but
 // it never ends up doing anything with the buffer it makes up?? It just returns
 // the same buffer it takes in, throwing away all the work it just did.
@@ -287,7 +280,6 @@ char* zVarGameSlotInfo(S32 i, char* buffer, size_t something)
 
     return buffer;
 }
-#endif
 
 namespace
 {
@@ -503,8 +495,6 @@ namespace
         return NULL;
     }
 
-// Note: This function is actually in the anonymous namespace
-#if 0
     // Not close, don't know enough about the data structures to know if things are
     // looking correct or not.
     void parse_tag_var(xtextbox::jot& r31, const xtextbox& r4, const xtextbox& r5,
@@ -524,14 +514,13 @@ namespace
             {
                 r31.context_size = 0xFC00;
                 // Maybe not the correct flags, something is up with the struct
-                r31.flag.upper.dynamic = 1;
+                r31.flag.dynamic = 1;
                 // No clue what this line is:
                 // r31.flag.upper. something = something??
-                r31.flag.upper.insert = 1;
+                r31.flag.insert = 1;
             }
         }
     }
-#endif
 
 } // namespace
 

--- a/src/SB/Game/zVolume.cpp
+++ b/src/SB/Game/zVolume.cpp
@@ -27,7 +27,6 @@ static void zVolumeInit(zVolume* vol, xVolumeAsset* asset)
     vol->eventFunc = zVolumeEventCB;
 }
 
-#ifdef NON_MATCHING
 void zVolumeInit()
 {
     U16 i;
@@ -52,7 +51,6 @@ void zVolumeInit()
         vols = NULL;
     }
 }
-#endif
 
 void zVolumeSetup()
 {
@@ -69,7 +67,6 @@ zVolume* zVolumeGetVolume(U16 n)
     return &vols[n];
 }
 
-#ifdef NON_MATCHING
 void zVolume_OccludePrecalc(xVec3* camPos)
 {
     S32 i;
@@ -187,9 +184,7 @@ void zVolume_OccludePrecalc(xVec3* camPos)
         }
     }
 }
-#endif
 
-#ifdef NON_MATCHING
 S32 zVolumeEventCB(xBase*, xBase* to, U32 toEvent, const F32*, xBase*)
 {
     zVolume* vol = (zVolume*)to;
@@ -241,4 +236,3 @@ S32 zVolumeEventCB(xBase*, xBase* to, U32 toEvent, const F32*, xBase*)
 
     return 1;
 }
-#endif


### PR DESCRIPTION
This PR restores many functions that were macro'd away as a result of lack of support from the project's former tooling to support building with partial matches. This is not a concern in the modern era, so I've restored all of these functions so that the project's progress tracker and objdiff comparisons are up-to-date with real progress.

Also includes a few minor float data substitutions and some other very small fixes.

Confirmed all files build using `ninja all_source`.