### PR TITLE
Improve zScene matchingness

### DIFF
--- a/src/SB/Game/zScene.cpp
+++ b/src/SB/Game/zScene.cpp
@@ -110,8 +110,8 @@ static S32 neededFiles;
 static F32 offsetx;
 static F32 offsety;
 static U32 enableScreenAdj;
-static F32 oldOffsetx;
-static F32 oldOffsety;
+volatile static F32 oldOffsetx;
+volatile static F32 oldOffsety;
 static S32 sMemDepthSceneStart = -1;
 static S32 sMemDepthJustHIPStart = -1;
 _zEnv* gCurEnv;
@@ -270,21 +270,7 @@ namespace
         { "hud:text", eBaseTypeHUD_text, sizeof(xBase) + sizeof(xhud::text_widget), false, xhud::text_widget::load },
         { "game_object:bungee_hook", eBaseTypeBungeeHook, sizeof(bungee_state::hook_type), false, bungee_state::load },
         { "game_object:Flythrough", eBaseTypeCameraFly, sizeof(zCameraFly), false, zCameraFly_Init },
-#if 1 // include the rest of the strings here until their parent functions are decomped
-        { "game_object:Camera_Tweak\0"
-          "... scene preload ...\n\0"
-          "... scene loading ...\n\0"
-          "... scene asset queue ...\n\0"
-          "...initializing scene - sound\n\0"
-          "...initializing scene - base types\n\0"
-          "PAREMIT_FIREWORKS_TRAIL\0"
-          "PAREMIT_FIREWORKS1\0"
-          "PAREMIT_FIREWORKS2\0"
-          "Fireworks_explode\0"
-          "Fireworks_trail", eBaseTypeCameraTweak, sizeof(zCameraTweak), false, zCameraTweak_Init }
-#else
         { "game_object:Camera_Tweak", eBaseTypeCameraTweak, sizeof(zCameraTweak), false, zCameraTweak_Init }
-#endif
     };
     // clang-format on
 


### PR DESCRIPTION
These string definitions aren't needed anymore. Removing them allows several functions to 100% from correct stringBase offsets. Also get zSceneSetOldScreenAdj match with hack.