### PR TITLE
xScrFx: Fix xScrFxLetterBoxSetAlpha declaration

### DIFF
--- a/src/SB/Core/x/xScrFx.h
+++ b/src/SB/Core/x/xScrFx.h
@@ -8,7 +8,7 @@
 
 void xScrFxInit ();
 void xScrFxLetterBoxSetSize(F32);
-void xScrFxLetterBoxSetAlpha(F32);
+void xScrFxLetterBoxSetAlpha(U8);
 void xScrFxUpdate(RwCamera* cam, F32 dt);
 void xScrFxRender(RwCamera*);
 void xScrFxDrawScreenSizeRectangle();


### PR DESCRIPTION
It takes in a U8, not an F32. Bumps zMainParseINIGlobals up by a smidge.