### PR TITLE
xMovePoint equivalent match

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -229,11 +229,11 @@ cflags_runtime = [
 # dolphin library flags
 cflags_dolphin = [
     *cflags_base,
-    "-lang=c", 
+    "-lang=c",
     "-fp fmadd",
     "-fp_contract off",
     "-char signed",
-    "-str reuse", 
+    "-str reuse",
     "-common off",
     "-O4,p",
     #"-requireprotos"
@@ -242,11 +242,11 @@ cflags_dolphin = [
 # Renderware library flags
 cflags_renderware = [
     *cflags_base,
-    "-lang=c", 
+    "-lang=c",
     "-fp fmadd",
     "-fp_contract off",
     "-char signed",
-    "-str reuse", 
+    "-str reuse",
     "-common off",
     "-O4,p",
     #"-requireprotos"
@@ -394,7 +394,7 @@ config.libs = [
             Object(NonMatching, "SB/Core/x/xMemMgr.cpp"),
             Object(NonMatching, "SB/Core/x/xModel.cpp"),
             Object(NonMatching, "SB/Core/x/xMorph.cpp"),
-            Object(NonMatching, "SB/Core/x/xMovePoint.cpp"),
+            Object(Equivalent, "SB/Core/x/xMovePoint.cpp"),
             Object(NonMatching, "SB/Core/x/xordarray.cpp"),
             Object(NonMatching, "SB/Core/x/xPad.cpp"),
             Object(NonMatching, "SB/Core/x/xPar.cpp"),
@@ -625,7 +625,7 @@ config.libs = [
         [
             Object(Matching, "dolphin/src/ar/ar.c"),
             Object(Matching, "dolphin/src/ar/arq.c")
-        ]        
+        ]
     ),
     DolphinLib(
         "ax",
@@ -646,7 +646,7 @@ config.libs = [
         "base",
         [
             Object(Matching, "dolphin/src/base/PPCArch.c")
-        ]        
+        ]
     ),
     DolphinLib(
         "card",
@@ -681,7 +681,7 @@ config.libs = [
             Object(NonMatching, "dolphin/src/dsp/dsp.c"),
             Object(Matching, "dolphin/src/dsp/dsp_debug.c"),
             Object(NonMatching, "dolphin/src/dsp/dsp_task.c")
-        ]        
+        ]
     ),
     DolphinLib(
         "dvd",
@@ -837,14 +837,14 @@ config.libs = [
             Object(NonMatching, "MSL_C/MSL_Common/strtold.c"),
             Object(NonMatching, "MSL_C/MSL_Common/strtoul.c"),
             Object(NonMatching, "MSL_C/MSL_Common/float.c"),
-            Object(NonMatching, "MSL_C/MSL_Common/char_io.c"),  
-            Object(NonMatching, "MSL_C/MSL_Common/wchar_io.c"),  
+            Object(NonMatching, "MSL_C/MSL_Common/char_io.c"),
+            Object(NonMatching, "MSL_C/MSL_Common/wchar_io.c"),
             Object(NonMatching, "MSL_C/MSL_Common_Embedded/uart_console_io_gcn.c")
         ]
     ),
     mslLib(
         "fdlibm.PPCEABI.H",
-        [],          
+        [],
         [
             Object(NonMatching, "MSL_C/MSL_Common_Embedded/Math/Double_precision/e_acos.c"),
             Object(NonMatching, "MSL_C/MSL_Common_Embedded/Math/Double_precision/e_asin.c"),
@@ -901,7 +901,7 @@ config.libs = [
             Object(NonMatching, "debugger/embedded/MetroTRK/Processor/ppc/Generic/targimpl.c"),
             #Object(NonMatching, "debugger/embedded/MetroTRK/Processor/ppc/Export/targsupp.s"),
             Object(Matching, "debugger/embedded/MetroTRK/Processor/ppc/Generic/mpc_7xx_603e.c"),
-            Object(NonMatching, "debugger/embedded/MetroTRK/Os/dolphin/dolphin_trk.c"),   
+            Object(NonMatching, "debugger/embedded/MetroTRK/Os/dolphin/dolphin_trk.c"),
             Object(NonMatching, "debugger/embedded/MetroTRK/Os/dolphin/usr_put.c"),
             Object(NonMatching, "debugger/embedded/MetroTRK/Os/dolphin/dolphin_trk_glue.c"),
             Object(Matching, "debugger/embedded/MetroTRK/Os/dolphin/targcont.c"),

--- a/src/SB/Core/x/xMovePoint.cpp
+++ b/src/SB/Core/x/xMovePoint.cpp
@@ -107,7 +107,6 @@ void xMovePointSplineSetup(xMovePoint* m)
     xSpline3_ArcInit(m->spl, 20);
 }
 
-// Scratch: https://decomp.me/scratch/JFBBX
 F32 xMovePointGetNext(const xMovePoint* m, const xMovePoint* prev, xMovePoint** next, xVec3* hdng)
 {
     if (m->asset->numPoints < 1)

--- a/src/SB/Core/x/xVec3.h
+++ b/src/SB/Core/x/xVec3.h
@@ -63,7 +63,8 @@ struct xVec3
 
     xVec3 cross(const xVec3& c) const
     {
-        xVec3 v = {};
+        // Initializing this causes data to leak into other files
+        xVec3 v;
 
         v.x = y * c.y - c.y * z;
         v.y = z * c.x - c.z * x;


### PR DESCRIPTION
As discussed in voice chat, `xVec3::cross` had an initialized `xVec3 v` which caused data to leak into other files that included it, so this will cause a regression necessary for matching the xMovePoint file, which will have to be solved some other way.

Dolphin test seems fine, and the only reason it's not 100% is a regswap in the remaining function.