### PR TITLE
Matched 10 small functions

### DIFF
--- a/src/SB/Game/zTalkBox.cpp
+++ b/src/SB/Game/zTalkBox.cpp
@@ -373,18 +373,17 @@ void ztalkbox::load(xBase& data, xDynAsset& asset, unsigned long)
 
 namespace
 {
-
-    static void parse_tag_pause(xtextbox::jot&, const xtextbox&, const xtextbox&, const xtextbox::split_tag&)
+    static void parse_tag_pause(xtextbox::jot&, const xtextbox&, const xtextbox&,
+                                const xtextbox::split_tag&)
     {
-
     }
 
-    static void reset_tag_pause(xtextbox::jot&, const xtextbox&, const xtextbox&, const xtextbox::split_tag&)
+    static void reset_tag_pause(xtextbox::jot&, const xtextbox&, const xtextbox&,
+                                const xtextbox::split_tag&)
     {
-
     }
 
-    static unsigned char trigger_pause(const xtextbox::jot&)
+    U8 trigger_pause(const xtextbox::jot&)
     {
         return 1;
     }
@@ -394,40 +393,35 @@ namespace
         type = t;
     }
 
-}
+} // namespace
 
 void start_state_type::stop()
 {
 }
 
-signed char start_state_type::update(xScene&, float)
+S8 start_state_type::update(xScene& scn, F32 dt)
 {
     return 2;
 }
 
 void next_state_type::stop()
 {
-
 }
 
 void stop_state_type::start()
 {
-
 }
 
 void stop_state_type::stop()
 {
-
 }
 
-signed char stop_state_type::update(xScene&, float)
+S8 stop_state_type::update(xScene& scn, F32 dt)
 {
     return -1;
 }
 
 void wait_context::reset_type()
 {
-
     *(U16*)&this->type = 0;
-
 }

--- a/src/SB/Game/zTalkBox.cpp
+++ b/src/SB/Game/zTalkBox.cpp
@@ -365,3 +365,58 @@ void ztalkbox::permit(U32 add_flags, U32 remove_flags)
     shared.permit &= ~remove_flags;
     shared.permit |= add_flags;
 }
+
+namespace
+{
+
+    static void parse_tag_pause(xtextbox::jot&, const xtextbox&, const xtextbox&, const xtextbox::split_tag&)
+    {
+
+    }
+
+    static void reset_tag_pause(xtextbox::jot&, const xtextbox&, const xtextbox&, const xtextbox::split_tag&)
+    {
+
+    }
+
+    static unsigned char trigger_pause(const xtextbox::jot&)
+    {
+        return 1;
+    }
+}
+
+void start_state_type::stop()
+{
+}
+
+signed char start_state_type::update(xScene&, float)
+{
+    return 2;
+}
+
+void next_state_type::stop()
+{
+
+}
+
+void stop_state_type::start()
+{
+
+}
+
+void stop_state_type::stop()
+{
+
+}
+
+signed char stop_state_type::update(xScene&, float)
+{
+    return -1;
+}
+
+void wait_context::reset_type()
+{
+
+    *(U16*)&this->type = 0;
+
+}

--- a/src/SB/Game/zTalkBox.cpp
+++ b/src/SB/Game/zTalkBox.cpp
@@ -366,6 +366,11 @@ void ztalkbox::permit(U32 add_flags, U32 remove_flags)
     shared.permit |= add_flags;
 }
 
+void ztalkbox::load(xBase& data, xDynAsset& asset, unsigned long)
+{
+    ((ztalkbox&)data).load((const ztalkbox::asset_type&)asset);
+}
+
 namespace
 {
 
@@ -383,6 +388,12 @@ namespace
     {
         return 1;
     }
+
+    state_type::state_type(state_enum t)
+    {
+        type = t;
+    }
+
 }
 
 void start_state_type::stop()

--- a/src/SB/Game/zTalkBox.h
+++ b/src/SB/Game/zTalkBox.h
@@ -150,9 +150,10 @@ namespace
     struct state_type
     {
         state_enum type;
-
-        void start();
-        void stop();
+        
+        state_type(state_enum t);
+        virtual void start();
+        virtual void stop();
     };
 
     struct next_state_type

--- a/src/SB/Game/zTalkBox.h
+++ b/src/SB/Game/zTalkBox.h
@@ -155,6 +155,24 @@ namespace
         void stop();
     };
 
+    struct next_state_type
+    {
+        void stop();
+    };
+
+    struct start_state_type
+    {
+        void stop();
+        signed char update(xScene&, float);
+    };
+
+    struct stop_state_type
+    {
+        void start();
+        void stop();
+        signed char update(xScene&, float);
+    };
+
     struct jot;
     struct callback
     {
@@ -252,6 +270,7 @@ namespace
         F32 delay;
         U32 event_mask;
         query_enum query;
+        void reset_type();
     };
 
     struct trigger_pair

--- a/src/SB/Game/zTalkBox.h
+++ b/src/SB/Game/zTalkBox.h
@@ -61,27 +61,22 @@ struct ztalkbox : xBase
     {
         callback()
         {
-
         }
 
         virtual void on_signal(U32)
         {
-
         }
 
         virtual void on_start()
         {
-
         }
 
         virtual void on_stop()
         {
-
         }
 
         virtual void on_answer(answer_enum answer)
         {
-
         }
     };
 
@@ -164,14 +159,14 @@ namespace
     struct start_state_type
     {
         void stop();
-        signed char update(xScene&, float);
+        S8 update(xScene& scn, F32 dt);
     };
 
     struct stop_state_type
     {
         void start();
         void stop();
-        signed char update(xScene&, float);
+        S8 update(xScene& scn, F32 dt);
     };
 
     struct jot;
@@ -310,6 +305,6 @@ namespace
         zNPCCommon* speak_npc; // 0x8694
         U32 speak_player; // 0x8698
     };
-}
+} // namespace
 
 #endif


### PR DESCRIPTION
Created namespace for parse_tag_pause, reset_tag_pause, and trigger_pause and matched them all

Also matched start_state_type::stop, start_state_type::update, next_state_type::stop, stop_state_type::start, stop_state_type::stop, stop_state_type::update, wait_context::reset_type

Defined the following structs

next_state_type
start_state_type
stop_state_type

Add variable reset_type to wait_context struct 