### PR TITLE
zTalkBox Updates

### DIFF
--- a/src/SB/Game/zTalkBox.cpp
+++ b/src/SB/Game/zTalkBox.cpp
@@ -1,6 +1,7 @@
 #include "xstransvc.h"
 #include "zTalkBox.h"
-
+#include "xDebug.h"
+#include "zEntPlayer.h"
 #include <types.h>
 
 namespace
@@ -102,10 +103,6 @@ namespace
     }
 
     void flush_triggered()
-    {
-    }
-
-    void reset_auto_wait()
     {
     }
 
@@ -366,21 +363,115 @@ void ztalkbox::permit(U32 add_flags, U32 remove_flags)
     shared.permit |= add_flags;
 }
 
-void ztalkbox::load(xBase& data, xDynAsset& asset, unsigned long)
+void ztalkbox::load(xBase& data, xDynAsset& asset, size_t)
 {
     ((ztalkbox&)data).load((const ztalkbox::asset_type&)asset);
 }
 
+void ztalkbox::load_settings(xIniFile& ini) //TODO
+{
+    shared.volume = xIniGetFloat(&ini, "talk_box.volume", 2.0f);
+    xDebugAddTweak("Talk Box|\u{1}Globals|volume", &shared.volume, 0.1f, 10.0f, NULL, NULL, 0);
+}
+
 namespace
 {
+    static U8 read_bool(const substr& s, bool def) //TODO 99%
+    {
+        extern const substr negative[6];
+        extern const substr positive[6];
+        if (def)
+        {
+            for (U32 i = 0; i < 6; ++i)
+            {
+                if (icompare(s, negative[i]) == 0)
+                    return 0;
+            }
+            return 1;
+        }
+        else
+            for (U32 i = 0; i < 6; ++i)
+            {
+                if (icompare(s, positive[i]) == 0)
+                    return 1;
+            }
+        return 0;
+    }
     static void parse_tag_pause(xtextbox::jot&, const xtextbox&, const xtextbox&,
                                 const xtextbox::split_tag&)
     {
     }
 
-    static void reset_tag_pause(xtextbox::jot&, const xtextbox&, const xtextbox&,
-                                const xtextbox::split_tag&)
+    static void parse_tag_trap(xtextbox::jot& j, const xtextbox&, const xtextbox&,
+                               const xtextbox::split_tag& ti) //TODO 99%
     {
+        U8 c = 0;
+
+        if (ti.action.size == 1 && ti.action.text[0] == '=')
+        {
+            if (read_bool(ti.value, 1) != 0)
+            {
+                c = 1;
+            }
+        }
+
+        *(U8*)&j.context = c;
+    }
+
+    static void reset_tag_pause(xtextbox::jot&, const xtextbox&, const xtextbox&,
+                                const xtextbox::split_tag&) //DONE
+    {
+    }
+    static void reset_tag_sound(xtextbox::jot& j, const xtextbox&, const xtextbox& tb,
+                                const xtextbox::split_tag&) //DONE
+    {
+        if (!shared.active)
+        {
+            return;
+        }
+
+        if (&shared.active->dialog_box->tb != &tb)
+        {
+            return;
+        }
+
+        sound_context& c = *(sound_context*)j.context;
+
+        j.context_size = 24;
+
+        c.id = 0;
+        c.action = sound_context::ACTION_SET;
+    }
+    static void reset_tag_trap(xtextbox::jot& j, const xtextbox&, const xtextbox& ctb,
+                               const xtextbox::split_tag&) //DONE
+    {
+        if (!shared.active)
+        {
+            return;
+        }
+
+        if (&shared.active->dialog_box->tb != &ctb)
+        {
+            return;
+        }
+
+        *(bool*)&j.context = (shared.active->asset->trap != 0);
+    }
+
+    static void reset_tag_allow_quit(xtextbox::jot& j, const xtextbox&, const xtextbox& ctb,
+                                     const xtextbox::split_tag&) //DONE
+    {
+        if (!shared.active)
+        {
+            return;
+        }
+
+        if (&shared.active->dialog_box->tb != &ctb)
+        {
+            return;
+        }
+
+        *(bool*)&j.context = (shared.active->asset->allow_quit != 0);
     }
 
     U8 trigger_pause(const xtextbox::jot&)
@@ -388,9 +479,85 @@ namespace
         return 1;
     }
 
+    U8 trigger_allow_quit(const xtextbox::jot& j) //DONE
+    {
+        shared.allow_quit = (j.context != NULL);
+
+        return 1;
+    }
+    U8 trigger_auto_wait(const xtextbox::jot& j) //DONE
+    {
+        shared.auto_wait = *(const wait_context*)j.context;
+
+        return 1;
+    }
     state_type::state_type(state_enum t)
     {
         type = t;
+    }
+
+    wait_context& wait_context::operator=(const wait_context& rhs) //FIXME
+    {
+        type = rhs.type;
+        need = rhs.need;
+        delay = rhs.delay;
+        event_mask = rhs.event_mask;
+        query = rhs.query;
+        return *this;
+    }
+
+    void stop_audio_effect() //TODO
+    {
+        if (!shared.active)
+        {
+            return;
+        }
+
+        if (shared.active->asset == 0)
+        {
+            return;
+        }
+    }
+    static void reset_auto_wait() //DONE
+    {
+        const ztalkbox::asset_type* a = shared.active->asset;
+
+        shared.auto_wait.type.time = a->auto_wait.type.time;
+        shared.auto_wait.type.prompt = a->auto_wait.type.prompt;
+        shared.auto_wait.type.sound = a->auto_wait.type.sound;
+        shared.auto_wait.type.event = a->auto_wait.type.event;
+
+        shared.auto_wait.delay = a->auto_wait.delay;
+
+        shared.auto_wait.need = 0;
+
+        if (a->auto_wait.which_event <= 0 || a->auto_wait.which_event >= 32)
+        {
+            shared.auto_wait.event_mask = -1;
+        }
+        else
+        {
+            shared.auto_wait.event_mask = 1u << a->auto_wait.which_event;
+        }
+
+        shared.auto_wait.query = Q_SKIP;
+    }
+    static void reset_tag_auto_wait(xtextbox::jot& j, const xtextbox&, const xtextbox& ctb,
+                                    const xtextbox::split_tag&) //DONE
+    {
+        if (!shared.active)
+        {
+            return;
+        }
+        if (&shared.active->dialog_box->tb != &ctb)
+        {
+            return;
+        }
+
+        wait_context& c = *(wait_context*)j.context;
+        j.context_size = sizeof(wait_context);
+        reset_auto_wait();
+        c = shared.auto_wait;
     }
 
 } // namespace
@@ -424,4 +591,17 @@ S8 stop_state_type::update(xScene& scn, F32 dt)
 void wait_context::reset_type()
 {
     *(U16*)&this->type = 0;
+}
+
+static U8 trigger_trap(const xtextbox::jot& j) //DONE
+{
+    if (j.context != 0)
+    {
+        zEntPlayerControlOff(CONTROL_OWNER_TALK_BOX);
+    }
+    else
+    {
+        zEntPlayerControlOn(CONTROL_OWNER_TALK_BOX);
+    }
+    return 1;
 }

--- a/src/SB/Game/zTalkBox.cpp
+++ b/src/SB/Game/zTalkBox.cpp
@@ -373,18 +373,17 @@ void ztalkbox::load(xBase& data, xDynAsset& asset, unsigned long)
 
 namespace
 {
-
-    static void parse_tag_pause(xtextbox::jot&, const xtextbox&, const xtextbox&, const xtextbox::split_tag&)
+    static void parse_tag_pause(xtextbox::jot&, const xtextbox&, const xtextbox&,
+                                const xtextbox::split_tag&)
     {
-
     }
 
-    static void reset_tag_pause(xtextbox::jot&, const xtextbox&, const xtextbox&, const xtextbox::split_tag&)
+    static void reset_tag_pause(xtextbox::jot&, const xtextbox&, const xtextbox&,
+                                const xtextbox::split_tag&)
     {
-
     }
 
-    static unsigned char trigger_pause(const xtextbox::jot&)
+    U8 trigger_pause(const xtextbox::jot&)
     {
         return 1;
     }
@@ -394,40 +393,35 @@ namespace
         type = t;
     }
 
-}
+} // namespace
 
 void start_state_type::stop()
 {
 }
 
-signed char start_state_type::update(xScene&, float)
+S8 start_state_type::update(xScene& scn, F32 dt)
 {
     return 2;
 }
 
 void next_state_type::stop()
 {
-
 }
 
 void stop_state_type::start()
 {
-
 }
 
 void stop_state_type::stop()
 {
-
 }
 
-signed char stop_state_type::update(xScene&, float)
+S8 stop_state_type::update(xScene& scn, F32 dt)
 {
     return -1;
 }
 
 void wait_context::reset_type()
 {
-
     *(U16*)&this->type = 0;
-
 }

--- a/src/SB/Game/zTalkBox.cpp
+++ b/src/SB/Game/zTalkBox.cpp
@@ -365,3 +365,58 @@ void ztalkbox::permit(U32 add_flags, U32 remove_flags)
     shared.permit &= ~remove_flags;
     shared.permit |= add_flags;
 }
+
+namespace
+{
+
+    static void parse_tag_pause(xtextbox::jot&, const xtextbox&, const xtextbox&, const xtextbox::split_tag&)
+    {
+
+    }
+
+    static void reset_tag_pause(xtextbox::jot&, const xtextbox&, const xtextbox&, const xtextbox::split_tag&)
+    {
+
+    }
+
+    static unsigned char trigger_pause(const xtextbox::jot&)
+    {
+        return 1;
+    }
+}
+
+void start_state_type::stop()
+{
+}
+
+signed char start_state_type::update(xScene&, float)
+{
+    return 2;
+}
+
+void next_state_type::stop()
+{
+
+}
+
+void stop_state_type::start()
+{
+
+}
+
+void stop_state_type::stop()
+{
+
+}
+
+signed char stop_state_type::update(xScene&, float)
+{
+    return -1;
+}
+
+void wait_context::reset_type()
+{
+
+    *(U16*)&this->type = 0;
+
+}

--- a/src/SB/Game/zTalkBox.cpp
+++ b/src/SB/Game/zTalkBox.cpp
@@ -366,6 +366,11 @@ void ztalkbox::permit(U32 add_flags, U32 remove_flags)
     shared.permit |= add_flags;
 }
 
+void ztalkbox::load(xBase& data, xDynAsset& asset, unsigned long)
+{
+    ((ztalkbox&)data).load((const ztalkbox::asset_type&)asset);
+}
+
 namespace
 {
 
@@ -383,6 +388,12 @@ namespace
     {
         return 1;
     }
+
+    state_type::state_type(state_enum t)
+    {
+        type = t;
+    }
+
 }
 
 void start_state_type::stop()

--- a/src/SB/Game/zTalkBox.cpp
+++ b/src/SB/Game/zTalkBox.cpp
@@ -378,8 +378,8 @@ namespace
 {
     static U8 read_bool(const substr& s, bool def)
     {
-        const substr negative[6] = {};
-        const substr positive[6] = {};
+        extern const substr negative[6];
+        extern const substr positive[6];
         if (def)
         {
             for (U32 i = 0; i < 6; ++i)

--- a/src/SB/Game/zTalkBox.cpp
+++ b/src/SB/Game/zTalkBox.cpp
@@ -363,23 +363,23 @@ void ztalkbox::permit(U32 add_flags, U32 remove_flags)
     shared.permit |= add_flags;
 }
 
-void ztalkbox::load(xBase& data, xDynAsset& asset, size_t)
+void ztalkbox::load(xBase& data, xDynAsset& asset, u32)
 {
     ((ztalkbox&)data).load((const ztalkbox::asset_type&)asset);
 }
 
-void ztalkbox::load_settings(xIniFile& ini) //TODO
+void ztalkbox::load_settings(xIniFile& ini)
 {
     shared.volume = xIniGetFloat(&ini, "talk_box.volume", 2.0f);
-    xDebugAddTweak("Talk Box|\u{1}Globals|volume", &shared.volume, 0.1f, 10.0f, NULL, NULL, 0);
+    xDebugAddTweak("Talk Box|\01GlobalsGlobals|volume", &shared.volume, 0.1f, 10.0f, NULL, NULL, 0);
 }
 
 namespace
 {
-    static U8 read_bool(const substr& s, bool def) //TODO 99%
+    static U8 read_bool(const substr& s, bool def)
     {
-        extern const substr negative[6];
-        extern const substr positive[6];
+        const substr negative[6] = {};
+        const substr positive[6] = {};
         if (def)
         {
             for (U32 i = 0; i < 6; ++i)
@@ -390,11 +390,13 @@ namespace
             return 1;
         }
         else
+        {
             for (U32 i = 0; i < 6; ++i)
             {
                 if (icompare(s, positive[i]) == 0)
                     return 1;
             }
+        }
         return 0;
     }
     static void parse_tag_pause(xtextbox::jot&, const xtextbox&, const xtextbox&,
@@ -403,9 +405,9 @@ namespace
     }
 
     static void parse_tag_trap(xtextbox::jot& j, const xtextbox&, const xtextbox&,
-                               const xtextbox::split_tag& ti) //TODO 99%
+                               const xtextbox::split_tag& ti)
     {
-        U8 c = 0;
+        bool c = 0;
 
         if (ti.action.size == 1 && ti.action.text[0] == '=')
         {
@@ -415,15 +417,15 @@ namespace
             }
         }
 
-        *(U8*)&j.context = c;
+        *(bool*)&j.context = c;
     }
 
     static void reset_tag_pause(xtextbox::jot&, const xtextbox&, const xtextbox&,
-                                const xtextbox::split_tag&) //DONE
+                                const xtextbox::split_tag&)
     {
     }
     static void reset_tag_sound(xtextbox::jot& j, const xtextbox&, const xtextbox& tb,
-                                const xtextbox::split_tag&) //DONE
+                                const xtextbox::split_tag&)
     {
         if (!shared.active)
         {
@@ -443,7 +445,7 @@ namespace
         c.action = sound_context::ACTION_SET;
     }
     static void reset_tag_trap(xtextbox::jot& j, const xtextbox&, const xtextbox& ctb,
-                               const xtextbox::split_tag&) //DONE
+                               const xtextbox::split_tag&)
     {
         if (!shared.active)
         {
@@ -459,7 +461,7 @@ namespace
     }
 
     static void reset_tag_allow_quit(xtextbox::jot& j, const xtextbox&, const xtextbox& ctb,
-                                     const xtextbox::split_tag&) //DONE
+                                     const xtextbox::split_tag&)
     {
         if (!shared.active)
         {
@@ -479,13 +481,13 @@ namespace
         return 1;
     }
 
-    U8 trigger_allow_quit(const xtextbox::jot& j) //DONE
+    U8 trigger_allow_quit(const xtextbox::jot& j)
     {
         shared.allow_quit = (j.context != NULL);
 
         return 1;
     }
-    U8 trigger_auto_wait(const xtextbox::jot& j) //DONE
+    U8 trigger_auto_wait(const xtextbox::jot& j)
     {
         shared.auto_wait = *(const wait_context*)j.context;
 
@@ -506,7 +508,7 @@ namespace
         return *this;
     }
 
-    void stop_audio_effect() //TODO
+    void stop_audio_effect()
     {
         if (!shared.active)
         {
@@ -518,7 +520,7 @@ namespace
             return;
         }
     }
-    static void reset_auto_wait() //DONE
+    static void reset_auto_wait()
     {
         const ztalkbox::asset_type* a = shared.active->asset;
 
@@ -543,7 +545,7 @@ namespace
         shared.auto_wait.query = Q_SKIP;
     }
     static void reset_tag_auto_wait(xtextbox::jot& j, const xtextbox&, const xtextbox& ctb,
-                                    const xtextbox::split_tag&) //DONE
+                                    const xtextbox::split_tag&)
     {
         if (!shared.active)
         {
@@ -593,7 +595,7 @@ void wait_context::reset_type()
     *(U16*)&this->type = 0;
 }
 
-static U8 trigger_trap(const xtextbox::jot& j) //DONE
+static U8 trigger_trap(const xtextbox::jot& j)
 {
     if (j.context != 0)
     {

--- a/src/SB/Game/zTalkBox.h
+++ b/src/SB/Game/zTalkBox.h
@@ -150,9 +150,10 @@ namespace
     struct state_type
     {
         state_enum type;
-
-        void start();
-        void stop();
+        
+        state_type(state_enum t);
+        virtual void start();
+        virtual void stop();
     };
 
     struct next_state_type

--- a/src/SB/Game/zTalkBox.h
+++ b/src/SB/Game/zTalkBox.h
@@ -34,8 +34,8 @@ struct ztalkbox : xBase
                 bool sound : 8;
                 bool event : 8;
             } type;
-            F32 delay;
-            S32 which_event;
+            F32 delay; //Offset 8d3c
+            S32 which_event; //Offset 0x8d40
         } auto_wait;
         struct
         {
@@ -85,9 +85,9 @@ struct ztalkbox : xBase
         bool visible : 1;
     } flag;
     const asset_type* asset;
-    ztextbox* dialog_box;
-    ztextbox* prompt_box;
-    ztextbox* quit_box;
+    ztextbox* dialog_box; //Offset 0x18
+    ztextbox* prompt_box; //Offset 0x1c
+    ztextbox* quit_box; //Offset 0x20
     struct
     {
         const char* skip;
@@ -145,7 +145,7 @@ namespace
     struct state_type
     {
         state_enum type;
-        
+
         state_type(state_enum t);
         virtual void start();
         virtual void stop();
@@ -262,11 +262,12 @@ namespace
             U8 event : 1;
             U16 pad : 12;
         } type;
-        U8 need;
+        U8 need; //Offset 08d3a
         F32 delay;
-        U32 event_mask;
-        query_enum query;
+        U32 event_mask; //Offset 08d40
+        query_enum query; //Offset 08d44
         void reset_type();
+        wait_context& operator=(const wait_context& rhs);
     };
 
     struct trigger_pair
@@ -277,7 +278,7 @@ namespace
 
     struct shared_type
     {
-        S32 flags;  
+        S32 flags;
         U32 permit;
         ztalkbox* active; // 0x8
         state_type* state; // 0xC
@@ -304,6 +305,43 @@ namespace
         F32 volume; // 0x8690
         zNPCCommon* speak_npc; // 0x8694
         U32 speak_player; // 0x8698
+    };
+
+    struct sound_context
+    {
+        // total size: 0x18
+        U32 id; // offset 0x0, size 0x4
+        enum
+        {
+            ACTION_SET = 0,
+            ACTION_PUSH = 1,
+            ACTION_POP = 2,
+        } action : 8; // offset 0x4, size 0x4
+        enum
+        {
+            TYPE_INVALID = 0,
+            TYPE_VOLUME = 1,
+            TYPE_TARGET = 2,
+            TYPE_ORIGIN = 3,
+        } type : 8; // offset 0x4, size 0x4
+        enum
+        {
+            SOURCE_MEMORY = 0,
+            SOURCE_STREAM = 1,
+        } source : 8; // offset 0x4, size 0x4
+        U8 anim; // offset 0x7, size 0x1
+        union
+        { // inferred
+            struct
+            {
+                // total size: 0x8
+                float left; // offset 0x0, size 0x4
+                float right; // offset 0x4, size 0x4
+            } volume; // offset 0x8, size 0x8
+            unsigned int target; // offset 0x8, size 0x4
+            class xVec3 origin; // offset 0x8, size 0xC
+        };
+        U32 speaker; // offset 0x14, size 0x4
     };
 } // namespace
 

--- a/src/SB/Game/zTalkBox.h
+++ b/src/SB/Game/zTalkBox.h
@@ -313,21 +313,21 @@ namespace
         U32 id; // offset 0x0, size 0x4
         enum
         {
-            ACTION_SET = 0,
-            ACTION_PUSH = 1,
-            ACTION_POP = 2,
+            ACTION_SET,
+            ACTION_PUSH,
+            ACTION_POP,
         } action : 8; // offset 0x4, size 0x4
         enum
         {
-            TYPE_INVALID = 0,
-            TYPE_VOLUME = 1,
-            TYPE_TARGET = 2,
-            TYPE_ORIGIN = 3,
+            TYPE_INVALID,
+            TYPE_VOLUME,
+            TYPE_TARGET,
+            TYPE_ORIGIN,
         } type : 8; // offset 0x4, size 0x4
         enum
         {
-            SOURCE_MEMORY = 0,
-            SOURCE_STREAM = 1,
+            SOURCE_MEMORY,
+            SOURCE_STREAM,
         } source : 8; // offset 0x4, size 0x4
         U8 anim; // offset 0x7, size 0x1
         union

--- a/src/SB/Game/zTalkBox.h
+++ b/src/SB/Game/zTalkBox.h
@@ -155,6 +155,24 @@ namespace
         void stop();
     };
 
+    struct next_state_type
+    {
+        void stop();
+    };
+
+    struct start_state_type
+    {
+        void stop();
+        signed char update(xScene&, float);
+    };
+
+    struct stop_state_type
+    {
+        void start();
+        void stop();
+        signed char update(xScene&, float);
+    };
+
     struct jot;
     struct callback
     {
@@ -252,6 +270,7 @@ namespace
         F32 delay;
         U32 event_mask;
         query_enum query;
+        void reset_type();
     };
 
     struct trigger_pair

--- a/src/SB/Game/zTalkBox.h
+++ b/src/SB/Game/zTalkBox.h
@@ -61,27 +61,22 @@ struct ztalkbox : xBase
     {
         callback()
         {
-
         }
 
         virtual void on_signal(U32)
         {
-
         }
 
         virtual void on_start()
         {
-
         }
 
         virtual void on_stop()
         {
-
         }
 
         virtual void on_answer(answer_enum answer)
         {
-
         }
     };
 
@@ -164,14 +159,14 @@ namespace
     struct start_state_type
     {
         void stop();
-        signed char update(xScene&, float);
+        S8 update(xScene& scn, F32 dt);
     };
 
     struct stop_state_type
     {
         void start();
         void stop();
-        signed char update(xScene&, float);
+        S8 update(xScene& scn, F32 dt);
     };
 
     struct jot;
@@ -310,6 +305,6 @@ namespace
         zNPCCommon* speak_npc; // 0x8694
         U32 speak_player; // 0x8698
     };
-}
+} // namespace
 
 #endif


### PR DESCRIPTION
- Made small cosmetic changes for empty space and neatness
- 
- Moved reset_auto_wait to lower down the file
- 
- Changed "unsigned long" to "size_t" for ztalkbox::load
- 
- ztalkbox::load_settings(xIniFile& ini) at 95%, seems to be missing a string but could not solve in scratch
- 
- read_bool to 99%, not sure how to fix the issue with the negative and positive arrays
- 
- parse_tag_trap to 99%, I could get to 100% when the if statements are triple nested and goto is used. Might be a better way. 
- 
- reset_tag_sound, reset_tag_trap, reset_tag_allow_quit, trigger_allow_quit, trigger_auto_wait all done at 100%
- 
- wait_context& wait_context::operator=(const wait_context& rhs)... yeah....
- 
- stop_audio_effect to 32%, still working on this
- 
- reset_auto_wait, reset_tag_auto_wait, and trigger_trap at 100%
- 
- Added various offsets in zTalkBox.h
- 
- Added struct sound_context in zTalkBox.h