### PR TITLE
Match MetroTRK notify stack layout

### DIFF
--- a/src/runtime_libs/debugger/embedded/MetroTRK/Portable/notify.c
+++ b/src/runtime_libs/debugger/embedded/MetroTRK/Portable/notify.c
@@ -16,11 +16,8 @@ DSError TRKDoNotifyStopped(u8 cmd)
 {
     DSError err;
     int reqIdx;
-    TRKBuffer* msg;
     int bufIdx;
-
-    // &msg
-    // &bufIdx
+    TRKBuffer* msg;
 
     err = TRKGetFreeBuffer(&bufIdx, &msg);
     if (err == DS_NoError)


### PR DESCRIPTION
## Summary
- isolate the MetroTRK notify cleanup from pr/bfbb-swag
- remove stale stack-layout comments and keep the local declarations in the matched order
- limit the PR to src/runtime_libs/debugger/embedded/MetroTRK/Portable/notify.c

## Testing
- 
inja
