### PR TITLE
Fix MetroTRK dispatch table entry

### DIFF
--- a/src/runtime_libs/debugger/embedded/MetroTRK/Portable/dispatch.c
+++ b/src/runtime_libs/debugger/embedded/MetroTRK/Portable/dispatch.c
@@ -11,39 +11,11 @@ struct DispatchEntry gTRKDispatchTable[33] = {
 	{ &TRKDoSupportMask }, { &TRKDoCPUType },     { &TRKDoUnsupported }, { &TRKDoUnsupported },   { &TRKDoUnsupported },
 	{ &TRKDoUnsupported }, { &TRKDoUnsupported }, { &TRKDoUnsupported }, { &TRKDoUnsupported },   { &TRKDoUnsupported },
 	{ &TRKDoUnsupported }, { &TRKDoReadMemory },  { &TRKDoWriteMemory }, { &TRKDoReadRegisters }, { &TRKDoWriteRegisters },
-	{ &TRKDoUnsupported }, { &TRKDoUnsupported }, { &TRKDoFlushCache },  { &TRKDoUnsupported },   { &TRKDoContinue },
+	{ &TRKDoUnsupported }, { &TRKDoUnsupported }, { &TRKDoFlushCache },  { &TRKDoSetOption },     { &TRKDoContinue },
 	{ &TRKDoStep },        { &TRKDoStop },        { &TRKDoUnsupported }, { &TRKDoUnsupported },   { &TRKDoUnsupported },
 	{ &TRKDoUnsupported }, { &TRKDoUnsupported },
 };
 
-/*
- * --INFO--
- * Address:	8021CEE0
- * Size:	000014
- */
-DSError TRKInitializeDispatcher()
-{
-	gTRKDispatchTableSize = 32;
-	return DS_NoError;
-}
-
-/*
- * --INFO--
- * Address:	........
- * Size:	0000A0
- */
-DSError TRKOverrideDispatch(TRKBuffer* buffer)
-{
-	return DS_NoError;
-
-	// UNUSED FUNCTION
-}
-
-/*
- * --INFO--
- * Address:	8021CEF4
- * Size:	000084
- */
 DSError TRKDispatchMessage(TRKBuffer* buffer)
 {
 	DSError error;
@@ -57,4 +29,16 @@ DSError TRKDispatchMessage(TRKBuffer* buffer)
 		error = gTRKDispatchTable[command].fn(buffer);
 	}
 	return error;
+}
+
+DSError TRKInitializeDispatcher()
+{
+	gTRKDispatchTableSize = 32;
+	return DS_NoError;
+}
+
+static DSError TRKOverrideDispatch(TRKBuffer* buffer)
+{
+	(void)buffer;
+	return DS_NoError;
 }

--- a/src/runtime_libs/debugger/embedded/MetroTRK/Portable/dispatch.c
+++ b/src/runtime_libs/debugger/embedded/MetroTRK/Portable/dispatch.c
@@ -16,6 +16,34 @@ struct DispatchEntry gTRKDispatchTable[33] = {
 	{ &TRKDoUnsupported }, { &TRKDoUnsupported },
 };
 
+/*
+ * --INFO--
+ * Address:	8021CEE0
+ * Size:	000014
+ */
+DSError TRKInitializeDispatcher()
+{
+	gTRKDispatchTableSize = 32;
+	return DS_NoError;
+}
+
+/*
+ * --INFO--
+ * Address:	........
+ * Size:	0000A0
+ */
+DSError TRKOverrideDispatch(TRKBuffer* buffer)
+{
+	return DS_NoError;
+
+	// UNUSED FUNCTION
+}
+
+/*
+ * --INFO--
+ * Address:	8021CEF4
+ * Size:	000084
+ */
 DSError TRKDispatchMessage(TRKBuffer* buffer)
 {
 	DSError error;
@@ -29,16 +57,4 @@ DSError TRKDispatchMessage(TRKBuffer* buffer)
 		error = gTRKDispatchTable[command].fn(buffer);
 	}
 	return error;
-}
-
-DSError TRKInitializeDispatcher()
-{
-	gTRKDispatchTableSize = 32;
-	return DS_NoError;
-}
-
-static DSError TRKOverrideDispatch(TRKBuffer* buffer)
-{
-	(void)buffer;
-	return DS_NoError;
 }


### PR DESCRIPTION
## Summary
- isolate the MetroTRK dispatch fix from pr/bfbb-swag
- correct the dispatch table entry for TRKDoSetOption
- keep the dispatcher helper layout localized to src/runtime_libs/debugger/embedded/MetroTRK/Portable/dispatch.c

## Testing
- 
inja
