### PR TITLE
Update the objdiff-cli version that gets auto-downloaded by ninja

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -159,7 +159,7 @@ if not config.non_matching:
 config.binutils_tag = "2.42-1"
 config.compilers_tag = "20250812"
 config.dtk_tag = "v1.7.0"
-config.objdiff_tag = "v3.4.1"
+config.objdiff_tag = "v3.7.1"
 config.sjiswrap_tag = "v1.2.2"
 config.wibo_tag = "1.0.0-beta.5"
 


### PR DESCRIPTION
3.4.1 is a little outdated, specifically in that it only has interactive output mode and no one-shot mode. 3.7.1 is latest