### PR TITLE
Replace pull_request_trigger

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build
 
 on:
   push:
-  pull_request_target:
+  pull_request:
 
 jobs:
   build:
@@ -28,7 +28,7 @@ jobs:
 
       # Checkout the repository (PR from forked repo)
       - name: Checkout
-        if: ${{ github.event_name == 'pull_request_target'}}
+        if: ${{ github.event_name == 'pull_request'}}
         uses: actions/checkout@v4
         with:
           submodules: recursive
@@ -92,7 +92,7 @@ jobs:
 
       # Checkout the repository (PR from forked repo)
       - name: Checkout
-        if: ${{ github.event_name == 'pull_request_target'}}
+        if: ${{ github.event_name == 'pull_request'}}
         uses: actions/checkout@v4
         with:
           submodules: recursive
@@ -151,7 +151,7 @@ jobs:
 
       # Checkout the commit to generate CI progress report for PR comment report
       - name: Checkout previous report repo state
-        if: ${{ github.event_name == 'pull_request_target' }}
+        if: ${{ github.event_name == 'pull_request' }}
         run: |
           git checkout main
 
@@ -176,7 +176,7 @@ jobs:
     needs:
       - build
       - build-previous
-    if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && github.event_name != 'pull_request_target'
+    if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
     steps:
       - name: Checkout website code
         uses: actions/checkout@v4
@@ -234,7 +234,7 @@ jobs:
     needs:
       - build
       - build-previous
-    if: github.event_name == 'pull_request_target'
+    if: github.event_name == 'pull_request'
     permissions:
       pull-requests: write
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,6 +134,7 @@ jobs:
         with:
           fetch-depth: 2
           submodules: recursive
+          ref: main
 
       # Set Git config
       - name: Git config
@@ -143,17 +144,12 @@ jobs:
       - name: Prepare
         run: cp -R /orig .
 
-      # Checkout the commit to generate OK bot report used for website build
+      # If we pushed to main, we need to go back one commit
+      # to generate OK bot report used for website build
       - name: Checkout previous report repo state
         if: ${{ github.event_name == 'push' }}
         run: |
           git checkout HEAD^
-
-      # Checkout the commit to generate CI progress report for PR comment report
-      - name: Checkout previous report repo state
-        if: ${{ github.event_name == 'pull_request' }}
-        run: |
-          git checkout main
 
       # Generate report for previous repo state
       - name: Generate previous report


### PR DESCRIPTION
Prevent pwn request

Looks like `pull_request_target` was used before because build-previous would fail with `pull_request`. Root cause was actually because build-previous wants to checkout main but it isn't fetched for pull requests when using the `pull_request` trigger. Fix is to force the checkout action to always checkout main.