### PR TITLE
ci: factor PR comment into it's own workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -275,9 +275,10 @@ jobs:
             echo "file_empty=true" >> $GITHUB_OUTPUT
           fi
 
-      - name: PR comment with file
-        if: ${{ steps.comment_file_check.outputs.file_empty == 'false' }}
-        uses: thollander/actions-comment-pull-request@v3
+      # This workflow doesn't have permissions to post a comment.
+      # Upload the comment and it will be picked up by the pr-comment.yml workflow
+      - name: Upload comment
+        uses: actions/upload-artifact@v4
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          file-path: pr.txt
+          name: pr.txt
+          path: pr.txt

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -1,0 +1,28 @@
+name: PR Comment
+
+on:
+  workflow_run:
+    workflows: ["Build"]
+    types:
+      - completed
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request'
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Download PR comment
+        uses: actions/download-artifact@v4
+        with:
+          name: pr.txt
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: PR comment with file
+        if: ${{ steps.comment_file_check.outputs.file_empty == 'false' }}
+        uses: thollander/actions-comment-pull-request@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          file-path: pr.txt


### PR DESCRIPTION
This should allow just the PR Comment logic to run with the advanced permissions required to post comments (avoids pull_request_target trigger in main workflow)