### PR TITLE
clangd: include -std=c++98 in compile_commands.json

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -312,7 +312,7 @@ cflags_rel = [
 # Game-specific flags
 cflags_bfbb = [
     *cflags_base,
-    "-lang=C++",
+    "-lang=c++",
     "-common on",
     "-char unsigned",
     "-str reuse,pool,readonly",


### PR DESCRIPTION
DTK parses the gc compiler c flags to convert them to equivalent clang flags for the purposes of generating a compile_commands.json file. However, it only recognized language flags if they're lowercase.

https://github.com/bfbbdecomp/bfbb/blob/7ea69ef350a29a03c576ad7c8ae27552bbfcec3b/tools/project.py#L1628-L1636

This lowercases our -lang=c++ flag so that clangd will use the correct c++ version while analyzing the codebase.