### PR TITLE
MSL_C: build the library optimized (Clanker Warning)

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -856,7 +856,7 @@ config.libs = [
     ),
     mslLib(
         "MSL_C.PPCEABI.H",
-        ["-str pool", "-opt level=0, peephole, schedule, nospace", "-inline off", "-sym on"],
+        ["-str pool", "-opt level=4, peephole, schedule, nospace", "-inline auto,deferred", "-sym on"],
         [
             Object(NonMatching, "MSL_C/PPC_EABI/abort_exit.c"),
             Object(NonMatching, "MSL_C/MSL_Common/alloc.c"),
@@ -880,7 +880,7 @@ config.libs = [
             Object(NonMatching, "MSL_C/MSL_Common/qsort.c"),
             Object(NonMatching, "MSL_C/MSL_Common/rand.c"),
             Object(NonMatching, "MSL_C/MSL_Common/scanf.c"),
-            Object(NonMatching, "MSL_C/MSL_Common/signal.c"),
+            Object(Matching, "MSL_C/MSL_Common/signal.c"),
             Object(NonMatching, "MSL_C/MSL_Common/string.c"),
             Object(NonMatching, "MSL_C/MSL_Common/strtold.c"),
             Object(NonMatching, "MSL_C/MSL_Common/strtoul.c"),

--- a/src/PowerPC_EABI_Support/src/MSL_C/PPC_EABI/critical_regions.gamecube.c
+++ b/src/PowerPC_EABI_Support/src/MSL_C/PPC_EABI/critical_regions.gamecube.c
@@ -1,7 +1,7 @@
 #include "types.h"
 #include "PowerPC_EABI_Support/MSL_C/MSL_Common/critical_regions.h"
 
-void __end_critical_region(int region)
+void __kill_critical_regions(void)
 {
     return;
 }
@@ -11,7 +11,7 @@ void __begin_critical_region(int region)
     return;
 }
 
-void __kill_critical_regions(void)
+void __end_critical_region(int region)
 {
     return;
 }


### PR DESCRIPTION
## Summary

`MSL_C.PPCEABI.H` is configured with `-opt level=0, peephole, schedule, nospace` and `-inline off`, but the original library was built optimized. At level 0 CodeWarrior spills user locals to callee-saved registers and emits a stack frame for functions the target objects implement as leaves, so almost nothing in the library could match.

Changing the library flags to `-opt level=4, peephole, schedule, nospace` and `-inline auto,deferred` matches **54 additional functions with no source changes**:

| | before | after |
|---|---|---|
| msl functions matched | 138 | **192** |
| msl code matched | 31.38% | **49.29%** |
| DOL functions matched | 6394 | **6448** |

`abort_exit`, `arith`, `mem`, `mem_funcs`, `rand`, `signal`, `wchar_io`, `FILE_POS` and `math_ppc` go to fully matching functions; `string` goes from 0/10 to 8/10 and `printf` from 0/14 to 7/14.

## How the flags were chosen

I swept the plausible variants across every MSL_C unit and picked by total exact-matching functions rather than by any single file:

| flags | exact functions |
|---|---|
| `-opt level=0 -inline off` (current) | 27/84 |
| `-opt level=4 -inline off` | 22/84 |
| `-opt level=4 -inline auto` / `-inline on` | 34/84 |
| `-opt level=4 -inline auto,deferred` | **39/84** |
| `-opt level=4,...,space` | 22/84 |
| `-opt nopeephole` | 5/84 |
| `-opt noschedule` | 4/84 |

Measured end to end with the project's own progress metric, `deferred` is worth **41.92% -> 49.29%** of msl code on top of `level=4` alone. It is only +3 functions but roughly 8KB more matched code, landing large bodies in `printf` and `ansi_fp` — which is why it is included rather than dropped.

`-sym on` and `-str pool` were left as they are; neither changed any output in the sweep.

## Why critical_regions.gamecube.c is reordered

`deferred` inlining makes CodeWarrior emit function bodies in reverse source order. The project already models this — `tools/project.py` sets `reverse_fn_order` from exactly this flag value.

`critical_regions.gamecube.c` is a `Matching` object, so it is linked into the DOL and its emission order has to stay correct. Its three stub functions are reordered so the object still emits `__end_critical_region`, `__begin_critical_region`, `__kill_critical_regions`, matching the target. Verified with `readelf` against `build/GQPE78/obj/`. No other linked object changed order.

`signal.c` now matches byte-for-byte and is marked `Matching`.

## Verification

`ninja` is clean and the DOL sha1 check passes, so every `Matching` object still produces identical linked output.

I checked the other libraries for the same class of misconfiguration while I was here; `cflags_bfbb` and `cflags_dolphin` are already correct and no variant improved them.
