### PR TITLE
zNPCTypeAmbient: make zNPCAmbient::PhysicsFlags const

### DIFF
--- a/src/SB/Game/zNPCTypeAmbient.cpp
+++ b/src/SB/Game/zNPCTypeAmbient.cpp
@@ -649,7 +649,7 @@ U8 zNPCAmbient::ColPenByFlags() const
     return 0x18;
 }
 
-U8 zNPCAmbient::PhysicsFlags()
+U8 zNPCAmbient::PhysicsFlags() const
 {
     return 3;
 }

--- a/src/SB/Game/zNPCTypeAmbient.h
+++ b/src/SB/Game/zNPCTypeAmbient.h
@@ -20,7 +20,7 @@ struct zNPCAmbient : zNPCCommon
     virtual U8 ColPenFlags() const;
     virtual U8 ColChkByFlags() const;
     virtual U8 ColPenByFlags() const;
-    virtual U8 PhysicsFlags();
+    virtual U8 PhysicsFlags() const;
     S32 AmbiHandleMail(NPCMsg*);
 };
 


### PR DESCRIPTION
The mangled name of this function is `PhysicsFlags__11zNPCAmbientCFv`. Dropping the `const` makes it mangle as `PhysicsFlags__11zNPCAmbientFv` which does not match. Adding `const` to the `PhysicsFlags` signatures properly makes it match.

Found via an LLM scan of the repo.